### PR TITLE
lock: Fix import cycle breakage

### DIFF
--- a/teuthology/lockstatus.py
+++ b/teuthology/lockstatus.py
@@ -1,0 +1,25 @@
+import json
+import httplib2
+import logging
+
+log = logging.getLogger(__name__)
+
+def _lock_url(ctx):
+    return ctx.teuthology_config['lock_server']
+
+def send_request(method, url, body=None, headers=None):
+    http = httplib2.Http()
+    resp, content = http.request(url, method=method, body=body, headers=headers)
+    if resp.status == 200:
+        return (True, content, resp.status)
+    log.info("%s request to '%s' with body '%s' failed with response code %d",
+             method, url, body, resp.status)
+    return (False, None, resp.status)
+
+def get_status(ctx, name):
+    success, content, _ = send_request('GET', _lock_url(ctx) + '/' + name)
+    if success:
+        return json.loads(content)
+    return None
+
+

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -13,7 +13,7 @@ import yaml
 import json
 
 from teuthology import safepath
-from teuthology import lock
+from teuthology import lockstatus
 from .orchestra import run
 
 log = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ def get_testdir(ctx):
     if not checked_jobid:
         jobids = {}
         for machine in ctx.config['targets'].iterkeys():
-            status = lock.get_status(ctx, machine)
+            status = lockstatus.get_status(ctx, machine)
             jid = status['description'].split('/')[-1]
             jobids[jid] = 1
             if len(jobids) > 1:

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -8,6 +8,7 @@ import yaml
 import re
 import subprocess
 
+from teuthology import lockstatus
 from teuthology import lock
 from teuthology import misc as teuthology
 from teuthology.parallel import parallel
@@ -124,7 +125,7 @@ def check_lock(ctx, config):
         return
     log.info('Checking locks...')
     for machine in ctx.config['targets'].iterkeys():
-        status = lock.get_status(ctx, machine)
+        status = lockstatus.get_status(ctx, machine)
         log.debug('machine status is %s', repr(status))
         assert status is not None, \
             'could not read lock status for {name}'.format(name=machine)


### PR DESCRIPTION
fa2049f caused an import cycle between lock.py and misc.py.  Move the
needed functions from lock.py to lockstatus.py so that we can avoid the
import cycle.

Signed-off-by: Sam Lang sam.lang@inktank.com
