### PR TITLE
Safer dict.get in queues.py

### DIFF
--- a/teuthology/queue.py
+++ b/teuthology/queue.py
@@ -86,7 +86,7 @@ describe. One job is run at a time.
         teuth_path = os.path.join(os.getenv("HOME"), 'teuthology-' + teuthology_branch, 'virtualenv', 'bin')
         if not os.path.isdir(teuth_path):
             raise Exception('Teuthology branch ' + teuthology_branch + ' not found at ' + teuth_path)
-        if job_config.get('last_in_suite', False):
+        if job_config.get('last_in_suite'):
             log.debug('Generating coverage for %s', job_config['name'])
             args = [
                 os.path.join(teuth_path, 'teuthology-results'),


### PR DESCRIPTION
This fixes a potential problem when doing a double `get` on a dictionary because `dict()` objects fallback to `None` when a key look up fails, so a `.get` on `None` would raise an exception and the rest of the `.get()` would not work.

It also removes an unnecessary fallback to `False` as `None` in Python will evaluate the same for that logical condition.
