### PR TITLE
fix double requirements issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ bunch >=1.0.0
 argparse >=1.2.1
 httplib2
 beanstalkc >=0.2.0
-nose >=1.0.0
-fudge >=1.0.3
 boto >=2.0b4
 pexpect
 requests ==0.14.0


### PR DESCRIPTION
I introduced this problem on the last merge attempting to clean up.

Some development requirements got required twice, this fixes that problem
