### PR TITLE
Allow a user to define a ceph-deploy branch to use (instead of master)

### DIFF
--- a/teuthology/task/ceph-deploy.py
+++ b/teuthology/task/ceph-deploy.py
@@ -26,7 +26,7 @@ def download_ceph_deploy(ctx, config):
     default_cd_branch = {'ceph-deploy-branch': 'master'}
     ceph_deploy_branch = ctx.get(
         'ceph-deploy',
-        default_cd_branch).get('ceph-deploy-branch', 'master')
+        default_cd_branch).get('ceph-deploy-branch')
 
     ctx.cluster.only(ceph_admin).run(
         args=[


### PR DESCRIPTION
As described in ticket http://tracker.ceph.com/issues/5887 - for ceph-deploy's new features, we need to be able to specify what branch of ceph-deploy we want to use so that we avoid breaking tests before they hit the master branch.
