### PR TITLE
nuke: clean up stray firmware.git locks

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -467,6 +467,11 @@ def nuke_helper(ctx, log):
         need_reboot = ctx.cluster.remotes.keys()
     synch_clocks(need_reboot, log)
 
+    log.info('Making sure firmware.git is not locked...')
+    ctx.cluster.run(args=[
+            'sudo', 'rm', '-f', '/lib/firmware/updates/.git/index.lock',
+            ])
+
     log.info('Reseting syslog output locations...')
     reset_syslog_dir(ctx, log)
     log.info('Clearing filesystem of test data...')


### PR DESCRIPTION
These get lost occasionally and cause all firmware.git updates to fail when
the kernel task runs.

Signed-off-by: Sage Weil sage@inktank.com
