### PR TITLE
schedule: strip out targets

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -354,6 +354,11 @@ def schedule():
                 job.delete()
         return
 
+    # strip out targets; the worker will allocate new ones when we run
+    # the job with --lock.
+    if ctx.config.get('targets'):
+        del ctx.config['targets']
+
     job_config = dict(
             config=ctx.config,
             name=ctx.name,


### PR DESCRIPTION
If the user feeds in a yaml with targets, the worker will launch the job but
fail with

2013-09-03T11:18:34.333 CRITICAL:root:AssertionError: You cannot specify
targets in a config file when using the --lock option

Just strip them out before scheduling.  This eases my personal workflow where
I have a test I'm running manually against some prelocked machines but also
want to schedule it.

Signed-off-by: Sage Weil sage@inktank.com
