### PR TITLE
drop obsolete PYTHONPATH settings

### DIFF
--- a/teuthology/task/cram.py
+++ b/teuthology/task/cram.py
@@ -112,7 +112,6 @@ def _run_tests(ctx, role):
         args=[
             run.Raw('CEPH_REF={ref}'.format(ref=ceph_ref)),
             run.Raw('CEPH_ID="{id}"'.format(id=id_)),
-            run.Raw('PYTHONPATH="$PYTHONPATH:{tdir}/binary/usr/local/lib/python2.7/dist-packages:{tdir}/binary/usr/local/lib/python2.6/dist-packages"'.format(tdir=testdir)),
             '{tdir}/adjust-ulimits'.format(tdir=testdir),
             'ceph-coverage',
             '{tdir}/archive/coverage'.format(tdir=testdir),

--- a/teuthology/task/restart.py
+++ b/teuthology/task/restart.py
@@ -103,7 +103,6 @@ def task(ctx, config):
                 log.info('Running restart script %s...', c)
                 args = [
                     run.Raw('TESTDIR="{tdir}"'.format(tdir=testdir)),
-                    run.Raw('PYTHONPATH="$PYTHONPATH:{tdir}/binary/usr/local/lib/python2.7/dist-packages:{tdir}/binary/usr/local/lib/python2.6/dist-packages"'.format(tdir=testdir)),
                     ]
                 env = config.get('env')
                 if env is not None:

--- a/teuthology/task/workunit.py
+++ b/teuthology/task/workunit.py
@@ -280,7 +280,6 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None):
                     run.Raw('CEPH_REF={ref}'.format(ref=refspec)),
                     run.Raw('TESTDIR="{tdir}"'.format(tdir=testdir)),
                     run.Raw('CEPH_ID="{id}"'.format(id=id_)),
-                    run.Raw('PYTHONPATH="$PYTHONPATH:{tdir}/binary/usr/local/lib/python2.7/dist-packages:{tdir}/binary/usr/local/lib/python2.6/dist-packages"'.format(tdir=testdir)),
                     ]
                 if env is not None:
                     for var, val in env.iteritems():


### PR DESCRIPTION
These are left over from when we were extracting a tarball in the test dir.

Signed-off-by: Sage Weil sage@inktank.com
