### PR TITLE
ceph: fix daemon-helper typo

### DIFF
--- a/teuthology/task/ceph.py
+++ b/teuthology/task/ceph.py
@@ -882,7 +882,7 @@ def run_daemon(ctx, config, type_):
                 'adjust-ulimits',
                 'ceph-coverage',
                 coverage_dir,
-                '	'.format(tdir=testdir),
+                'daemon-helper',
                 daemon_signal,
                 ]
             run_cmd_tail = [


### PR DESCRIPTION
Broken in edc5ef8860b2917c14ee648f15ac7751535d411a

Signed-off-by: Sage Weil sage@inktank.com
