### PR TITLE
Revert "Be polite and restore /etc/sudoers when done"

### DIFF
--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -322,33 +322,22 @@ def archive(ctx, config):
                 ),
             )
 
-
 @contextlib.contextmanager
 def sudo(ctx, config):
     log.info('Configuring sudo...')
     sudoers_file = '/etc/sudoers'
-    backup_ext = '.orig'
     tty_expr = 's/requiretty/!requiretty/'
     pw_expr = 's/!visiblepw/visiblepw/'
 
     run.wait(
         ctx.cluster.run(
-            args="sudo sed -i{ext} -e '{tty}' -e '{pw}' {path}".format(
-                ext=backup_ext, tty=tty_expr, pw=pw_expr,
-                path=sudoers_file
+            args="sudo sed -i -e '{tty_expr}' -e '{pw_expr}' {path}".format(
+                tty_expr=tty_expr, pw_expr=pw_expr, path=sudoers_file
             ),
             wait=False,
         )
     )
-    try:
-        yield
-    finally:
-        log.info('Restoring {}...'.format(sudoers_file))
-        ctx.cluster.run(
-            args="sudo mv -f {path}{ext} {path}".format(
-                path=sudoers_file, ext=backup_ext
-            )
-        )
+    yield
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This reverts commit f0eabc970f3c3ee70ec860943e469f9274a27f40.

We can't remove ubuntu for now because things like nuke rely on it being 
there to mop up afterwards.

Maybe we should make a separate 'clean' activity that removes all traces that
does this sort of cleanup...
