### PR TITLE
Adding in erroneously removed args

### DIFF
--- a/teuthology/task/radosgw-agent.py
+++ b/teuthology/task/radosgw-agent.py
@@ -75,6 +75,7 @@ def run_radosgw_agent(ctx, config):
         daemon_name = '{host}.{port}.syncdaemon'.format(host=remote.name, port=port)
         in_args=[
 		        'daemon-helper',
+		        'kill',
 		        '{tdir}/radosgw-agent.{client}/radosgw-agent'.format(tdir=testdir,
 		                                                             client=client),
 		        '-v',

--- a/teuthology/task/watch_notify_stress.py
+++ b/teuthology/task/watch_notify_stress.py
@@ -45,6 +45,7 @@ def task(ctx, config):
         args =['CEPH_CLIENT_ID={id_}'.format(id_=id_),
                'CEPH_ARGS="{flags}"'.format(flags=config.get('flags', '')),
                'daemon-helper',
+               'kill',
                'multi_stress_watch foo foo'
                ]
 


### PR DESCRIPTION
The 'kill' argument was accidentially removed
as part of patch
53b8e27da996f2efdcc4eb687f3bda0791a8d947

Signed-off-by: Joe Buck jbbuck@gmail.com
