### PR TITLE
remove basedir/testdir distinction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,23 +312,12 @@ this issue.
 Test Sandbox Directory
 ======================
 
-Teuthology currently places most test files and mount points in a sandbox
-directory, defaulting to ``/home/$USER/cephtest/{rundir}``.  The ``{rundir}``
-is the name of the run (as given by ``--name``) or if no name is specified,
-``user@host-timestamp`` is used.  To change the location of the sandbox
-directory, the following options can be specified in
-``$HOME/.teuthology.yaml``::
-
-    base_test_dir: <directory>
-
-The ``base_test_dir`` option will set the base directory to use for the
-individual run directories.
+Teuthology currently places most test files and mount points in a
+sandbox directory, defaulting to ``/home/$USER/cephtest``.  To change
+the location of the sandbox directory, the following option can be
+specified in ``$HOME/.teuthology.yaml``::
 
     test_path: <directory>
-
-The ``test_path`` option will set the complete path to use for the test
-directory.  This allows for the old behavior, where ``/tmp/cephtest`` was used
-as the sandbox directory.
 
 
 VIRTUAL MACHINE SUPPORT

--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -263,13 +263,13 @@ def remove_installed_packages(ctx, log):
     install_task.purge_data(ctx)
 
 def remove_testing_tree(ctx, log):
-    from teuthology.misc import get_testdir_base
+    from teuthology.misc import get_testdir
     from .orchestra import run
     nodes = {}
     for remote in ctx.cluster.remotes.iterkeys():
         proc = remote.run(
             args=[
-                'sudo', 'rm', '-rf', get_testdir_base(ctx),
+                'sudo', 'rm', '-rf', get_testdir(ctx),
                 # just for old time's sake
                 run.Raw('&&'),
                 'sudo', 'rm', '-rf', '/tmp/cephtest',


### PR DESCRIPTION
We should never run with a conflicting testdir in the basedir, and the code
to do this is confusing and buggy.  Go back to a single testdir and simple
checks.

Signed-off-by: Sage Weil sage@inktank.com
