### PR TITLE
suite: do not calculate product on an empty list

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -180,18 +180,19 @@ combination, and will override anything in the suite.
                     args=arg,
                     )
 
-    arg = copy.deepcopy(base_arg)
-    arg.append('--last-in-suite')
-    if args.email:
-        arg.extend(['--email', args.email])
-    if args.timeout:
-        arg.extend(['--timeout', args.timeout])
-    if args.dry_run:
-        log.info('dry-run: %s' % ' '.join(arg))
-    else:
-        subprocess.check_call(
-            args=arg,
-            )
+    if num_jobs:
+        arg = copy.deepcopy(base_arg)
+        arg.append('--last-in-suite')
+        if args.email:
+            arg.extend(['--email', args.email])
+        if args.timeout:
+            arg.extend(['--timeout', args.timeout])
+        if args.dry_run:
+            log.info('dry-run: %s' % ' '.join(arg))
+        else:
+            subprocess.check_call(
+                args=arg,
+                )
 
 
 def combine_path(left, right):


### PR DESCRIPTION
This fixes a bug where a directory with just % generates a bogus job item
with no actual content.  (e.g.,

$ find basic basic basic/%
$ teuthology-suite --dry-run --base . --collections basic --name foo 
INFO:teuthology.suite:Collection basic in ./basic 
INFO:teuthology.suite:configs [('basic/{}', [])]

...which then blows up because the job yaml is empty.  With the fix, there
are no generated jobs:

$ teuthology-suite --dry-run --base . --collections basic --name foo 
INFO:teuthology.suite:Collection basic in ./basic 
INFO:teuthology.suite:configs []

(The configs print was temporarily added for debugging purposes.)

Signed-off-by: Sage Weil sage@inktank.com
