### PR TITLE
only use host_key if it is not None

### DIFF
--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -2,6 +2,7 @@ import base64
 import paramiko
 from ..config import config
 
+
 def split_user(user_at_host):
     try:
         user, host = user_at_host.rsplit('@', 1)
@@ -11,6 +12,7 @@ def split_user(user_at_host):
         "Bad input to split_user: {user_at_host!r}".format(user_at_host=user_at_host)
     return user, host
 
+
 def create_key(keytype, key):
     if keytype == 'ssh-rsa':
         return paramiko.rsakey.RSAKey(data=base64.decodestring(key))
@@ -19,19 +21,22 @@ def create_key(keytype, key):
     else:
         raise ValueError('keytype must be ssh-rsa or ssh-dsa')
 
+
 def connect(user_at_host, host_key=None, keep_alive=False,
             _SSHClient=None, _create_key=None):
     user, host = split_user(user_at_host)
     if _SSHClient is None:
         _SSHClient = paramiko.SSHClient
     ssh = _SSHClient()
-    if host_key is None:
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
     if _create_key is None:
         _create_key = create_key
 
-    if host_key is None and config.verify_host_keys is True:
-        ssh.load_system_host_keys()
+    if host_key is None:
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        if config.verify_host_keys is True:
+            ssh.load_system_host_keys()
+
     else:
         keytype, key = host_key.split(' ', 1)
         ssh.get_host_keys().add(


### PR DESCRIPTION
Really make sure we are not using anything related to `host_keys` unless it is not None.

Moved the logic so that this happens correctly.
