### PR TITLE
nuke: add missing import os

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import yaml
 import textwrap
 from argparse import RawTextHelpFormatter


### PR DESCRIPTION
$ teuthology-nuke  -a . -r -u Traceback (most recent call last):
 File "/home/ubuntu/bin/teuthology-nuke", line 9, in <module>
   load_entry_point('teuthology==0.0.1', 'console_scripts',
'teuthology-nuke')()
 File "/home/ubuntu/teuthology/teuthology/nuke.py", line 343, in main
   ifn = os.path.join(ctx.archive, 'info.yaml') UnboundLocalError: local
variable 'os' referenced before assignment

Signed-off-by: Sage Weil sage@inktank.com
