### PR TITLE
nuke: refix import os

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import yaml
 import textwrap
 from argparse import RawTextHelpFormatter
@@ -340,6 +339,7 @@ def main():
 
     info = {}
     if ctx.archive:
+        import os
         ctx.config = config_file(ctx.archive + '/config.yaml')
         ifn = os.path.join(ctx.archive, 'info.yaml')
         if os.path.exists(ifn):


### PR DESCRIPTION
Why does this work and the top-level import does not?

Signed-off-by: Sage Weil sage@inktank.com
