### PR TITLE
nuke: make half-hearted attempt to sync before reboot

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -197,12 +197,17 @@ def remove_osd_tmpfs(ctx, log):
         )
 
 def reboot(ctx, remotes, log):
+    from .orchestra import run
     import time
     nodes = {}
     for remote in remotes:
         log.info('rebooting %s', remote.name)
         proc = remote.run( # note use of -n to force a no-sync reboot
-            args=['sudo', 'reboot', '-f', '-n'],
+            args=[
+                'timeout', '5', 'sync',
+                run.Raw(';'),
+                'sudo', 'reboot', '-f', '-n'
+                ],
             wait=False
             )
         nodes[remote] = proc


### PR DESCRIPTION
We don't want to block on sync for fear of a hung kernel mount.  However, we
can give it a try and wait a few seconds to get what we can.

This fixes a problem where our recent modifications to the sudoers file are
lost, with a 0 byte file left in its place, because the task fails and we do
a reboot -f -n.

Signed-off-by: Sage Weil sage@inktank.com
