### PR TITLE
Check description of machines before nuking when -a is passed

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -353,6 +353,7 @@ def main():
             ctx.owner = info.get('owner')
             if not ctx.owner:
                 ctx.owner = open(ctx.archive + '/owner').read().rstrip('\n')
+        ctx.run_name = info.get('name')
 
     from teuthology.misc import read_config
     read_config(ctx)
@@ -379,7 +380,19 @@ def main():
 def nuke(ctx, log, should_unlock, sync_clocks=True, reboot_all=True,
          noipmi=False):
     from teuthology.parallel import parallel
+    from teuthology.lock import list_locks
     total_unnuked = {}
+    targets = dict(ctx.config['targets'])
+    if ctx.run_name:
+        log.info('Checking targets against current locks')
+        locks = list_locks(ctx)
+        #Remove targets who's description doesn't match archive name.
+        for lock in locks:
+            for target in targets:
+                 if target == lock['name']:
+                     if ctx.run_name not in lock['description']:
+                         del ctx.config['targets'][lock['name']]
+                         log.info('Not nuking %s because description doesn\'t match', lock['name'])
     with parallel() as p:
         for target, hostkey in ctx.config['targets'].iteritems():
             p.spawn(


### PR DESCRIPTION
When teuthology-nuke is passed with --archive/-a to kill and nuke machines
from an archive folder it blindly will nuke all the targets it grabs from the
config.yaml in the archive dir. This change will check the description of
locked machines and make sure the run name is in the description. if not it
removes the target from the list passed to nuke().

Signed-off-by: Sandon Van Ness sandon@inktank.com
