### PR TITLE
Added support for re-imaging baremetal using os_type.

### DIFF
--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -83,31 +83,38 @@ def lock_machines(ctx, config):
         newly_locked = lock.lock_many(ctx, how_many, machine_type, ctx.owner,
                                       ctx.archive)
         if len(newly_locked) == how_many:
-            vmlist = []
+            waitlist = []
             for lmach in newly_locked:
                 if lock.create_if_vm(ctx, lmach):
-                    vmlist.append(lmach)
-            if vmlist:
-                log.info('Waiting for virtual machines to come up')
+                    waitlist.append(lmach)
+
+                dist, release = teuthology.get_current_dist_and_release(lmach, newly_locked[lmach], machine_type)
+                if lock.reimage_if_wrong_os(ctx, lmach, machine_type, dist, release):
+                    waitlist.append(lmach)
+                    teuthology.get_current_dist_and_release(lmach, newly_locked[lmach], machine_type, reboot=True)
+
+            if waitlist:
+                log.info('Waiting for virtual/re-imaged machines to come up')
                 keyscan_out = ''
                 loopcount = 0
-                while len(keyscan_out.splitlines()) != len(vmlist):
+                while len(keyscan_out.splitlines()) != len(waitlist):
                     loopcount += 1
                     time.sleep(10)
                     keyscan_out, current_locks = lock.keyscan_check(ctx,
-                                                                    vmlist)
-                    log.info('virtual machine is stil unavailable')
-                    if loopcount == 40:
-                        loopcount = 0
-                        log.info('virtual machine(s) still not up, ' +
-                                 'recreating unresponsive ones.')
-                        for guest in vmlist:
-                            if guest not in keyscan_out:
-                                log.info('recreating: ' + guest)
-                                lock.destroy_if_vm(ctx, 'ubuntu@' + guest)
-                                lock.create_if_vm(ctx, 'ubuntu@' + guest)
+                                                                    waitlist)
+                    log.info('machine is stil unavailable')
+                    if machine_type == 'vps': 
+                        if loopcount == 40:
+                            loopcount = 0
+                            log.info('virtual machine(s) still not up, ' +
+                                     'recreating unresponsive ones.')
+                            for guest in waitlist:
+                                if guest not in keyscan_out:
+                                    log.info('recreating: ' + guest)
+                                    lock.destroy_if_vm(ctx, 'ubuntu@' + guest)
+                                    lock.create_if_vm(ctx, 'ubuntu@' + guest)
                 if lock.update_keys(ctx, keyscan_out, current_locks):
-                    log.info("Error in virtual machine keys")
+                    log.info("Error in virtual/re-imaged machine(s) keys")
                 newscandict = {}
                 for dkey in newly_locked.iterkeys():
                     stats = lockstatus.get_status(ctx, dkey)


### PR DESCRIPTION
It access cobbler API to re-image machines for baremetal. Uses
quite a bit of the same code-base as the vm stuff but for
baremetal instead.

Signed-off-by: Sandon Van Ness sandon@inktank.com
