### PR TITLE
Implement a watchdog for queued jobs

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -16,6 +16,7 @@ class Config(object):
         'ceph_git_base_url': 'https://github.com/ceph/',
         'lock_server': 'http://teuthology.front.sepia.ceph.com/locker/lock',
         'verify_host_keys': True,
+        'watchdog_interval': 600,
     }
 
     def __init__(self):


### PR DESCRIPTION
This continually posts the run's status to the results server, if
configured, at an interval defaulting to 600 seconds.

Signed-off-by: Zack Cerza zack.cerza@inktank.com
