### PR TITLE
rbd: bump the default scratch size for xfstests to 10G

### DIFF
--- a/teuthology/task/rbd.py
+++ b/teuthology/task/rbd.py
@@ -393,10 +393,10 @@ def xfstests(ctx, config):
             properties = {}
 
         test_image = properties.get('test_image', 'test_image.{role}'.format(role=role))
-        test_size = properties.get('test_size', 2000)
+        test_size = properties.get('test_size', 2000) # 2G
         test_fmt = properties.get('test_format', 1)
         scratch_image = properties.get('scratch_image', 'scratch_image.{role}'.format(role=role))
-        scratch_size = properties.get('scratch_size', 2000)
+        scratch_size = properties.get('scratch_size', 10000) # 10G
         scratch_fmt = properties.get('scratch_format', 1)
 
         images_config[role] = dict(


### PR DESCRIPTION
autobuild-ceph.git commit 53db7a34aba5 had silently changed the default
elevator from cfq to deadline, which made xfstests 167 very unhappy.
It looks like with deadline and noop elevators it requires a ~6G
scratch partition.  Bump the default scratch image size to 10G.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
