### PR TITLE
Added support for re-imaging baremetal using os_type.

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -6,16 +6,13 @@ import urllib
 import yaml
 import re
 import collections
-import tempfile
-import os
 import time
 
 import teuthology
 from .config import config
 from . import lockstatus as ls
 from . import misc
-from teuthology.misc import get_distro
-from teuthology.misc import get_distro_version
+from . import provision
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +39,7 @@ def lock_many(ctx, num, machinetype, user=None, description=None):
             if machinetype == 'vps':
                 ok_machs = {}
                 for machine in machines:
-                    if create_if_vm(ctx, machine):
+                    if provision.create_if_vm(ctx, machine):
                         ok_machs[machine] = machines[machine]
                     else:
                         log.error('Unable to create virtual machine: %s' % machine)
@@ -79,7 +76,7 @@ def unlock_one(ctx, name, user=None):
         urllib.urlencode(dict(user=user)))
     if success:
         log.debug('unlocked %s', name)
-        if not destroy_if_vm(ctx, name):
+        if not provision.destroy_if_vm(ctx, name):
             log.error('downburst destroy failed for %s', name)
             log.info('%s is not locked' % name)
     else:
@@ -255,7 +252,7 @@ def main(ctx):
                     return ret
             else:
                 machines_to_update.append(machine)
-                create_if_vm(ctx, machine)
+                provision.create_if_vm(ctx, machine)
     elif ctx.unlock:
         for machine in machines:
             if not unlock_one(ctx, machine, user):
@@ -402,131 +399,3 @@ def do_summary(ctx):
 
     print "         ---  ---"
     print "{cnt:12d}  {up:3d}".format(cnt=total_count, up=total_up)
-
-
-def decanonicalize_hostname(s):
-    if re.match('ubuntu@.*\.front\.sepia\.ceph\.com', s):
-        s = s[len('ubuntu@'): -len('.front.sepia.ceph.com')]
-    return s
-
-
-def _get_downburst_exec():
-    """
-    First check for downburst in the user's path.
-    Then check in ~/src, ~ubuntu/src, and ~teuthology/src.
-    Return '' if no executable downburst is found.
-    """
-    path = os.environ.get('PATH', None)
-    if path:
-        for p in os.environ.get('PATH', '').split(os.pathsep):
-            pth = os.path.join(p, 'downburst')
-            if os.access(pth, os.X_OK):
-                return pth
-    import pwd
-    little_old_me = pwd.getpwuid(os.getuid()).pw_name
-    for user in [little_old_me, 'ubuntu', 'teuthology']:
-        pth = "/home/%s/src/downburst/virtualenv/bin/downburst" % user
-        if os.access(pth, os.X_OK):
-            return pth
-    return ''
-
-#
-# Use downburst to create a virtual machine
-#
-
-
-def create_if_vm(ctx, machine_name):
-    status_info = ls.get_status(ctx, machine_name)
-    phys_host = status_info['vpshost']
-    if not phys_host:
-        return False
-    os_type = get_distro(ctx)
-    os_version = get_distro_version(ctx)
-
-    createMe = decanonicalize_hostname(machine_name)
-    with tempfile.NamedTemporaryFile() as tmp:
-        try:
-            lfile = ctx.downburst_conf
-            with open(lfile) as downb_yaml:
-                lcnfg = yaml.safe_load(downb_yaml)
-                if lcnfg.keys() == ['downburst']:
-                    lcnfg = lcnfg['downburst']
-        except (TypeError, AttributeError):
-            try:
-                lcnfg = {}
-                for tdict in ctx.config['downburst']:
-                    for key in tdict:
-                        lcnfg[key] = tdict[key]
-            except (KeyError, AttributeError):
-                lcnfg = {}
-        except IOError:
-            print "Error reading %s" % lfile 
-            return False
-
-        distro = lcnfg.get('distro', os_type.lower())
-        distroversion = lcnfg.get('distroversion', os_version)
-
-        file_info = {}
-        file_info['disk-size'] = lcnfg.get('disk-size', '30G')
-        file_info['ram'] = lcnfg.get('ram', '1.9G')
-        file_info['cpus'] = lcnfg.get('cpus', 1)
-        file_info['networks'] = lcnfg.get('networks',
-                 [{'source': 'front', 'mac': status_info['mac']}])
-        file_info['distro'] = distro
-        file_info['distroversion'] = distroversion
-        file_info['additional-disks'] = lcnfg.get(
-            'additional-disks', 3)
-        file_info['additional-disks-size'] = lcnfg.get(
-            'additional-disks-size', '200G')
-        file_info['arch'] = lcnfg.get('arch', 'x86_64')
-        file_out = {'downburst': file_info}
-        yaml.safe_dump(file_out, tmp)
-        metadata = "--meta-data=%s" % tmp.name
-        dbrst = _get_downburst_exec()
-        if not dbrst:
-            log.error("No downburst executable found.")
-            return False
-        p = subprocess.Popen([dbrst, '-c', phys_host,
-                              'create', metadata, createMe],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
-        owt, err = p.communicate()
-        if err:
-            log.info("Downburst completed on %s: %s" %
-                    (machine_name, err))
-        else:
-            log.info("%s created: %s" % (machine_name, owt))
-        # If the guest already exists first destroy then re-create:
-        if 'exists' in err:
-            log.info("Guest files exist. Re-creating guest: %s" %
-                    (machine_name))
-            destroy_if_vm(ctx, machine_name)
-            create_if_vm(ctx, machine_name)
-    return True
-#
-# Use downburst to destroy a virtual machine
-#
-
-
-def destroy_if_vm(ctx, machine_name):
-    """
-    Return False only on vm downburst failures.
-    """
-    status_info = ls.get_status(ctx, machine_name)
-    phys_host = status_info['vpshost']
-    if not phys_host:
-        return True
-    destroyMe = decanonicalize_hostname(machine_name)
-    dbrst = _get_downburst_exec()
-    if not dbrst:
-        log.error("No downburst executable found.")
-        return False
-    p = subprocess.Popen([dbrst, '-c', phys_host,
-                          'destroy', destroyMe],
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
-    owt, err = p.communicate()
-    if err:
-        log.error(err)
-        return False
-    else:
-        log.info("%s destroyed: %s" % (machine_name, owt))
-    return True

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -967,3 +967,80 @@ def get_multi_machine_types(machinetype):
     if not machinetypes:
         machinetypes.append(machinetype)
     return machinetypes
+
+def pre_targets_ssh_connect(machine_name, ssh_pubkey, machine_type):
+    """
+    SSH to the machine (intended for use before targets have been built)
+    """
+    # This is expected to run before SSH connection shave been made and targets generated.
+    # Because ssh connections are not active, first connect to SSH.
+    from orchestra import connection, remote
+    connection = remote.Remote(name=machine_name,
+                  ssh=connection.connect(user_at_host=machine_name,
+                                         host_key=ssh_pubkey,
+                                         keep_alive=True),
+                  console=None)
+    return connection
+
+def get_current_dist_and_release(machine_name, ssh_pubkey, machine_type):
+    """
+    Get lsb id and release and return values (Pre targets)
+    """
+    # VPS are destroyed, they are down before targets are listed so ignore them.
+    if machine_type == 'vps':
+        return None, None
+
+    connection = pre_targets_ssh_connect(machine_name, ssh_pubkey, machine_type)
+    r = connection.run(
+        args=[
+            'lsb_release', '-sir',
+        ],
+    stdout=StringIO(),
+    )
+    system_value = r.stdout.getvalue().strip().split()
+    dist = system_value[0].lower()
+    release = system_value[1]
+    # lsb on Redhat is 'RedHatEnterpriseServer'
+    if 'redhat' in dist:
+        dist = 'rhel'
+
+    #Close connection to ssh
+    connection.ssh.close()
+    return dist, release
+
+def nosync_reboot(machine_name, ssh_pubkey, machine_type):
+    """
+    Reboot with no sync for instant reboot intended for imaging. (Pre targets)
+    """
+    connection = pre_targets_ssh_connect(machine_name, ssh_pubkey, machine_type)
+    connection.run(
+        args=[
+            'sudo','reboot', '-f', '-n',
+        ],
+    wait=False,
+    )
+
+    #Close connection to ssh
+    connection.ssh.close()
+    return
+
+def resolve_equivelent_arch(arch, reverse=False):
+    """
+    Get a list of common arch names from proper arch name.
+    If reverse is true it takes a proper/inproper name and
+    does a reverse search and returns the proper arch name.
+    """
+    os_architectures = {
+        'x86_64': ['x86_64', '64-bit', 'amd64'],
+        'i386':   ['i386', '32-bit', 'i686', 'i586'],
+        'armv7l': ['armv7l', 'armhf', 'arm']
+    }
+    if reverse:
+        for key,value in os_architectures.items():
+            if arch in value:
+                return key
+        raise Exception('Unable to resolve arch \'{arch}\' into valid architecture.'.format(arch=arch))
+    try:
+        return os_architectures[arch]
+    except KeyError:
+        raise Exception('Unable to expand \'{arch}\' into valid common architecture.'.format(arch=arch))

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1024,7 +1024,7 @@ def nosync_reboot(machine_name, ssh_pubkey, machine_type):
     connection.ssh.close()
     return
 
-def resolve_equivelent_arch(arch, reverse=False):
+def resolve_equivalent_arch(arch, reverse=False):
     """
     Get a list of common arch names from proper arch name.
     If reverse is true it takes a proper/inproper name and

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -972,8 +972,8 @@ def pre_targets_ssh_connect(machine_name, ssh_pubkey, machine_type):
     """
     SSH to the machine (intended for use before targets have been built)
     """
-    # This is expected to run before SSH connection shave been made and targets generated.
-    # Because ssh connections are not active, first connect to SSH.
+    # This is expected to run before ssh connections have been made
+    # and targets generated, so we must make the ssh connection now
     from orchestra import connection, remote
     connection = remote.Remote(name=machine_name,
                   ssh=connection.connect(user_at_host=machine_name,
@@ -986,11 +986,14 @@ def get_current_dist_and_release(machine_name, ssh_pubkey, machine_type):
     """
     Get lsb id and release and return values (Pre targets)
     """
-    # VPS are destroyed, they are down before targets are listed so ignore them.
+
+    # vpses are destroyed; they are down before targets are listed
+    # so ignore them.
     if machine_type == 'vps':
         return None, None
 
-    connection = pre_targets_ssh_connect(machine_name, ssh_pubkey, machine_type)
+    connection = pre_targets_ssh_connect(machine_name, ssh_pubkey,
+                                         machine_type)
     r = connection.run(
         args=[
             'lsb_release', '-sir',
@@ -1012,12 +1015,13 @@ def nosync_reboot(machine_name, ssh_pubkey, machine_type):
     """
     Reboot with no sync for instant reboot intended for imaging. (Pre targets)
     """
-    connection = pre_targets_ssh_connect(machine_name, ssh_pubkey, machine_type)
+    connection = pre_targets_ssh_connect(machine_name, ssh_pubkey,
+                                         machine_type)
     connection.run(
         args=[
             'sudo','reboot', '-f', '-n',
         ],
-    wait=False,
+        wait=False,
     )
 
     #Close connection to ssh
@@ -1027,8 +1031,8 @@ def nosync_reboot(machine_name, ssh_pubkey, machine_type):
 def resolve_equivalent_arch(arch, reverse=False):
     """
     Get a list of common arch names from proper arch name.
-    If reverse is true it takes a proper/inproper name and
-    does a reverse search and returns the proper arch name.
+    If 'reverse' is True, take a proper/improper name and
+    return the proper arch name.
     """
     os_architectures = {
         'x86_64': ['x86_64', '64-bit', 'amd64'],
@@ -1039,8 +1043,10 @@ def resolve_equivalent_arch(arch, reverse=False):
         for key,value in os_architectures.items():
             if arch in value:
                 return key
-        raise Exception('Unable to resolve arch \'{arch}\' into valid architecture.'.format(arch=arch))
+        raise Exception('Can\'t find valid arch name for \'{arch}\''.
+                        format(arch=arch))
     try:
         return os_architectures[arch]
     except KeyError:
-        raise Exception('Unable to expand \'{arch}\' into valid common architecture.'.format(arch=arch))
+        raise Exception('Can\'t find common arch name for \'{arch}\''.
+                        format(arch=arch))

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -36,12 +36,11 @@ def _get_downburst_exec():
             return pth
     return ''
 
-#
-# Use downburst to create a virtual machine
-#
-
 
 def create_if_vm(ctx, machine_name):
+    """
+    Use downburst to create a virtual machine
+    """
     status_info = ls.get_status(ctx, machine_name)
     phys_host = status_info['vpshost']
     if not phys_host:
@@ -108,13 +107,11 @@ def create_if_vm(ctx, machine_name):
             destroy_if_vm(ctx, machine_name)
             create_if_vm(ctx, machine_name)
     return True
-#
-# Use downburst to destroy a virtual machine
-#
 
 
 def destroy_if_vm(ctx, machine_name):
     """
+    Use downburst to destroy a virtual machine
     Return False only on vm downburst failures.
     """
     status_info = ls.get_status(ctx, machine_name)
@@ -138,25 +135,26 @@ def destroy_if_vm(ctx, machine_name):
     return True
 
 
-#
-# Set machine's cobbler profile and enable PXE.
-#
 def set_cobbler_profile(profile, servername, dist, release, cobbler_url):
-    #Set Profile:
+    """
+    Set machine's cobbler profile and enable PXE.
+    """
+    # Set Profile
     err_msg = 'Cobbler Failed to change server: {servername} to profile: {profile}'.format(servername=servername, profile=profile)
     cobbler_request(cobbler_url + "/svc/op/changeprofile/system/" + servername + "/profile/" + profile, err_msg)
 
-    #Enable PXE
+    # Enable PXE
     err_msg = 'Cobbler Failed to enable PXE for server: {servername}'.format(servername=servername)
     cobbler_request(cobbler_url + "/svc/op/dopxe/system/" + servername, err_msg)
 
     log.info('Imaging of server: {server} from: {dist}-{release} using cobbler profile: {profile}'.format(
         server=servername, dist=dist, release=release, profile=profile)) 
 
-#
-# Find cobbler profile from os type, verison, arch.
-#
+
 def find_cobbler_profile(os_type, os_version, os_arch, cobbler_url):
+    """
+    Find cobbler profile from os type, version, arch.
+    """
     # Get list of common archs from standardized name
     archs = misc.resolve_equivalent_arch(os_arch)
 
@@ -179,10 +177,11 @@ def find_cobbler_profile(os_type, os_version, os_arch, cobbler_url):
 
     raise Exception('Unable to find distro in Cobbler Profiles')
 
-#
-# Check current OS/version and re-image if wrong.
-#
+
 def reimage_if_wrong_os(ctx, machine_name, machine_type, dist, release):
+    """
+    Check current OS/version and re-image if wrong.
+    """
     # This is for baremetal so ignore VPS
     if machine_type == 'vps':
         return False
@@ -226,16 +225,17 @@ def reimage_if_wrong_os(ctx, machine_name, machine_type, dist, release):
     set_cobbler_profile(profile, servername, dist, release, cobbler_url)
     return True
 
-#
-# Helper for interactig with cobbler.
-#
 def cobbler_request(url, err_msg='Unknown Error'):
+    """
+    Helper for interacting with cobbler.
+    """
     http = httplib2.Http()
-    # Send Get request to server.
+    # Send GET request to server.
     resp, content = http.request(url, "GET")
     succeeded = content.strip('\n')
     status = resp['status']
-    # What queries to cobbler returns data instead of a True/False suceeded message.
+    # 'what' queries to cobbler return data instead of a
+    # True/False succeeded message.
     if 'what' not in url:
         if succeeded  != 'True':
             raise Exception(err_msg)

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -185,6 +185,10 @@ def reimage_if_wrong_os(ctx, machine_name, machine_type, dist, release):
     # This is for baremetal so ignore VPS
     if machine_type == 'vps':
         return False
+    cobbler_url = ctx.teuthology_config.get('cobbler_url', None)
+    if not cobbler_url:
+        log.error('No cobbler_url in config, can\'t reimage %s', machine_name)
+        return False
     servername = decanonicalize_hostname(machine_name)
     os_type = misc.get_distro(ctx)
 
@@ -220,7 +224,6 @@ def reimage_if_wrong_os(ctx, machine_name, machine_type, dist, release):
            return False
 
     # Find cobbler profile for re-image, set, and reboot
-    cobbler_url = ctx.teuthology_config.get('cobbler_url', 'http://plana01.front.sepia.ceph.com/cblr')
     profile = find_cobbler_profile(os_type, os_version, os_arch, cobbler_url)
     set_cobbler_profile(profile, servername, dist, release, cobbler_url)
     return True

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -158,7 +158,7 @@ def set_cobbler_profile(profile, servername, dist, release, cobbler_url):
 #
 def find_cobbler_profile(os_type, os_version, os_arch, cobbler_url):
     # Get list of common archs from standardized name
-    archs = misc.resolve_equivelent_arch(os_arch)
+    archs = misc.resolve_equivalent_arch(os_arch)
 
     # Grab list of available profiles from cobbler server
     profiles = cobbler_request(cobbler_url + "/svc/op/list/what/profiles").strip('\n').split()
@@ -213,7 +213,7 @@ def reimage_if_wrong_os(ctx, machine_name, machine_type, dist, release):
         os_arch = 'x86_64'
 
     # Allow other common writings for arch.
-    os_arch = misc.resolve_equivelent_arch(os_arch, reverse=True)
+    os_arch = misc.resolve_equivalent_arch(os_arch, reverse=True)
 
     # Check if machine is already the requested os/version.
     if dist in os_type:

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -6,8 +6,6 @@ import logging
 import tempfile
 import re
 
-import teuthology
-from .config import config
 from . import lockstatus as ls
 from . import misc
 

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -1,0 +1,246 @@
+import subprocess
+import os
+import yaml
+import httplib2
+import logging
+import tempfile
+import re
+
+import teuthology
+from .config import config
+from . import lockstatus as ls
+from . import misc
+
+log = logging.getLogger(__name__)
+
+def decanonicalize_hostname(s):
+    if re.match('ubuntu@.*\.front\.sepia\.ceph\.com', s):
+        s = s[len('ubuntu@'): -len('.front.sepia.ceph.com')]
+    return s
+
+def _get_downburst_exec():
+    """
+    First check for downburst in the user's path.
+    Then check in ~/src, ~ubuntu/src, and ~teuthology/src.
+    Return '' if no executable downburst is found.
+    """
+    path = os.environ.get('PATH', None)
+    if path:
+        for p in os.environ.get('PATH', '').split(os.pathsep):
+            pth = os.path.join(p, 'downburst')
+            if os.access(pth, os.X_OK):
+                return pth
+    import pwd
+    little_old_me = pwd.getpwuid(os.getuid()).pw_name
+    for user in [little_old_me, 'ubuntu', 'teuthology']:
+        pth = "/home/%s/src/downburst/virtualenv/bin/downburst" % user
+        if os.access(pth, os.X_OK):
+            return pth
+    return ''
+
+#
+# Use downburst to create a virtual machine
+#
+
+
+def create_if_vm(ctx, machine_name):
+    status_info = ls.get_status(ctx, machine_name)
+    phys_host = status_info['vpshost']
+    if not phys_host:
+        return False
+    os_type = misc.get_distro(ctx)
+    os_version = misc.get_distro_version(ctx)
+
+    createMe = decanonicalize_hostname(machine_name)
+    with tempfile.NamedTemporaryFile() as tmp:
+        try:
+            lfile = ctx.downburst_conf
+            with open(lfile) as downb_yaml:
+                lcnfg = yaml.safe_load(downb_yaml)
+                if lcnfg.keys() == ['downburst']:
+                    lcnfg = lcnfg['downburst']
+        except (TypeError, AttributeError):
+            try:
+                lcnfg = {}
+                for tdict in ctx.config['downburst']:
+                    for key in tdict:
+                        lcnfg[key] = tdict[key]
+            except (KeyError, AttributeError):
+                lcnfg = {}
+        except IOError:
+            print "Error reading %s" % lfile
+            return False
+
+        distro = lcnfg.get('distro', os_type.lower())
+        distroversion = lcnfg.get('distroversion', os_version)
+
+        file_info = {}
+        file_info['disk-size'] = lcnfg.get('disk-size', '30G')
+        file_info['ram'] = lcnfg.get('ram', '1.9G')
+        file_info['cpus'] = lcnfg.get('cpus', 1)
+        file_info['networks'] = lcnfg.get('networks',
+                 [{'source': 'front', 'mac': status_info['mac']}])
+        file_info['distro'] = distro
+        file_info['distroversion'] = distroversion
+        file_info['additional-disks'] = lcnfg.get(
+            'additional-disks', 3)
+        file_info['additional-disks-size'] = lcnfg.get(
+            'additional-disks-size', '200G')
+        file_info['arch'] = lcnfg.get('arch', 'x86_64')
+        file_out = {'downburst': file_info}
+        yaml.safe_dump(file_out, tmp)
+        metadata = "--meta-data=%s" % tmp.name
+        dbrst = _get_downburst_exec()
+        if not dbrst:
+            log.error("No downburst executable found.")
+            return False
+        p = subprocess.Popen([dbrst, '-c', phys_host,
+                              'create', metadata, createMe],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
+        owt, err = p.communicate()
+        if err:
+            log.info("Downburst completed on %s: %s" %
+                    (machine_name, err))
+        else:
+            log.info("%s created: %s" % (machine_name, owt))
+        # If the guest already exists first destroy then re-create:
+        if 'exists' in err:
+            log.info("Guest files exist. Re-creating guest: %s" %
+                    (machine_name))
+            destroy_if_vm(ctx, machine_name)
+            create_if_vm(ctx, machine_name)
+    return True
+#
+# Use downburst to destroy a virtual machine
+#
+
+
+def destroy_if_vm(ctx, machine_name):
+    """
+    Return False only on vm downburst failures.
+    """
+    status_info = ls.get_status(ctx, machine_name)
+    phys_host = status_info['vpshost']
+    if not phys_host:
+        return True
+    destroyMe = decanonicalize_hostname(machine_name)
+    dbrst = _get_downburst_exec()
+    if not dbrst:
+        log.error("No downburst executable found.")
+        return False
+    p = subprocess.Popen([dbrst, '-c', phys_host,
+                          'destroy', destroyMe],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
+    owt, err = p.communicate()
+    if err:
+        log.error(err)
+        return False
+    else:
+        log.info("%s destroyed: %s" % (machine_name, owt))
+    return True
+
+
+#
+# Set machine's cobbler profile and enable PXE.
+#
+def set_cobbler_profile(profile, servername, dist, release, cobbler_url):
+    #Set Profile:
+    err_msg = 'Cobbler Failed to change server: {servername} to profile: {profile}'.format(servername=servername, profile=profile)
+    cobbler_request(cobbler_url + "/svc/op/changeprofile/system/" + servername + "/profile/" + profile, err_msg)
+
+    #Enable PXE
+    err_msg = 'Cobbler Failed to enable PXE for server: {servername}'.format(servername=servername)
+    cobbler_request(cobbler_url + "/svc/op/dopxe/system/" + servername, err_msg)
+
+    log.info('Imaging of server: {server} from: {dist}-{release} using cobbler profile: {profile}'.format(
+        server=servername, dist=dist, release=release, profile=profile)) 
+
+#
+# Find cobbler profile from os type, verison, arch.
+#
+def find_cobbler_profile(os_type, os_version, os_arch, cobbler_url):
+    # Get list of common archs from standardized name
+    archs = misc.resolve_equivelent_arch(os_arch)
+
+    # Grab list of available profiles from cobbler server
+    profiles = cobbler_request(cobbler_url + "/svc/op/list/what/profiles").strip('\n').split()
+
+    for profile in profiles:
+        # Skip profiles with vserver or vercoi in their names, vserver images
+        if 'vserver' in profile:
+            continue
+        if 'vercoi' in profile:
+            continue
+
+        # Search for profile in profile list.
+        if os_type in profile:
+            if os_version in profile:
+                for arch in archs:
+                    if arch in profile:
+                        return profile
+
+    raise Exception('Unable to find distro in Cobbler Profiles')
+
+#
+# Check current OS/version and re-image if wrong.
+#
+def reimage_if_wrong_os(ctx, machine_name, machine_type, dist, release):
+    # This is for baremetal so ignore VPS
+    if machine_type == 'vps':
+        return False
+    servername = decanonicalize_hostname(machine_name)
+    os_type = misc.get_distro(ctx)
+
+    # Dictionray of default versions if not specified.
+    default_os_version = dict(
+        ubuntu="12.04",
+        fedora="18",
+        centos="6.4",
+        opensuse="12.2",
+        sles="11-sp2",
+        rhel="6.4",
+        debian='7.0'
+        )
+
+    # Try to grab os version or default from dict if it fails.
+    try:
+        os_version = ctx.config.get('os_version', default_os_version[os_type])
+    except AttributeError:
+        os_version = default_os_version[os_type]
+
+    # Try to grab os arch or default of x86_64.
+    try:
+        os_arch = ctx.config.get('os_arch', 'x86_64')
+    except AttributeError:
+        os_arch = 'x86_64'
+
+    # Allow other common writings for arch.
+    os_arch = misc.resolve_equivelent_arch(os_arch, reverse=True)
+
+    # Check if machine is already the requested os/version.
+    if dist in os_type:
+       if release in os_version:
+           return False
+
+    # Find cobbler profile for re-image, set, and reboot
+    cobbler_url = ctx.teuthology_config.get('cobbler_url', 'http://plana01.front.sepia.ceph.com/cblr')
+    profile = find_cobbler_profile(os_type, os_version, os_arch, cobbler_url)
+    set_cobbler_profile(profile, servername, dist, release, cobbler_url)
+    return True
+
+#
+# Helper for interactig with cobbler.
+#
+def cobbler_request(url, err_msg='Unknown Error'):
+    http = httplib2.Http()
+    # Send Get request to server.
+    resp, content = http.request(url, "GET")
+    succeeded = content.strip('\n')
+    status = resp['status']
+    # What queries to cobbler returns data instead of a True/False suceeded message.
+    if 'what' not in url:
+        if succeeded  != 'True':
+            raise Exception(err_msg)
+    if status != '200':
+        raise Exception('Received non 200 HTTP response code: {status}'.format(status=status))
+    return content

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -140,15 +140,21 @@ def set_cobbler_profile(profile, servername, dist, release, cobbler_url):
     Set machine's cobbler profile and enable PXE.
     """
     # Set Profile
-    err_msg = 'Cobbler Failed to change server: {servername} to profile: {profile}'.format(servername=servername, profile=profile)
-    cobbler_request(cobbler_url + "/svc/op/changeprofile/system/" + servername + "/profile/" + profile, err_msg)
+    err_msg = 'Cobbler failed to change server: {servername}' \
+              'to profile: {profile}'.\
+              format(servername=servername, profile=profile)
+    cobbler_request(cobbler_url + "/svc/op/changeprofile/system/" + \
+                    servername + "/profile/" + profile, err_msg)
 
     # Enable PXE
-    err_msg = 'Cobbler Failed to enable PXE for server: {servername}'.format(servername=servername)
-    cobbler_request(cobbler_url + "/svc/op/dopxe/system/" + servername, err_msg)
+    err_msg = 'Cobbler failed to enable PXE for server: {servername}'.\
+              format(servername=servername)
+    cobbler_request(cobbler_url + "/svc/op/dopxe/system/" + servername,
+                     err_msg)
 
-    log.info('Imaging of server: {server} from: {dist}-{release} using cobbler profile: {profile}'.format(
-        server=servername, dist=dist, release=release, profile=profile)) 
+    log.info('Imaging server: {server} from: {dist}-{release} ' \
+             'using cobbler profile: {profile}'.format(
+             server=servername, dist=dist, release=release, profile=profile))
 
 
 def find_cobbler_profile(os_type, os_version, os_arch, cobbler_url):
@@ -159,7 +165,8 @@ def find_cobbler_profile(os_type, os_version, os_arch, cobbler_url):
     archs = misc.resolve_equivalent_arch(os_arch)
 
     # Grab list of available profiles from cobbler server
-    profiles = cobbler_request(cobbler_url + "/svc/op/list/what/profiles").strip('\n').split()
+    profiles = cobbler_request(cobbler_url + "/svc/op/list/what/profiles").\
+        strip('\n').split()
 
     for profile in profiles:
         # Skip profiles with vserver or vercoi in their names, vserver images
@@ -175,7 +182,7 @@ def find_cobbler_profile(os_type, os_version, os_arch, cobbler_url):
                     if arch in profile:
                         return profile
 
-    raise Exception('Unable to find distro in Cobbler Profiles')
+    raise Exception('Unable to find distro in Cobbler profiles')
 
 
 def reimage_if_wrong_os(ctx, machine_name, machine_type, dist, release):
@@ -243,5 +250,6 @@ def cobbler_request(url, err_msg='Unknown Error'):
         if succeeded  != 'True':
             raise Exception(err_msg)
     if status != '200':
-        raise Exception('Received non 200 HTTP response code: {status}'.format(status=status))
+        raise Exception('Received non 200 HTTP response code: {status}'.\
+            format(status=status))
     return content

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -95,10 +95,13 @@ def lock_machines(ctx, config):
                 if provision.create_if_vm(ctx, lmach):
                     waitlist.append(lmach)
 
-                dist, release = teuthology.get_current_dist_and_release(lmach, newly_locked[lmach], machine_type)
-                if provision.reimage_if_wrong_os(ctx, lmach, machine_type, dist, release):
+                dist, release = teuthology.get_current_dist_and_release(
+                    lmach, newly_locked[lmach], machine_type)
+                if provision.reimage_if_wrong_os(ctx, lmach, machine_type,
+                                                 dist, release):
                     waitlist.append(lmach)
-                    teuthology.nosync_reboot(lmach, newly_locked[lmach], machine_type)
+                    teuthology.nosync_reboot(lmach, newly_locked[lmach],
+                                             machine_type)
 
             if waitlist:
                 log.info('Waiting for virtual/re-imaged machines to come up')
@@ -117,8 +120,9 @@ def lock_machines(ctx, config):
                         for guest in waitlist:
                             if guest not in keyscan_out:
                                 log.info('recreating: ' + guest)
-                                provision.destroy_if_vm(ctx, 'ubuntu@' + guest)
-                                provision.create_if_vm(ctx, 'ubuntu@' + guest)
+                                fullguest = 'ubuntu@' + guest
+                                provision.destroy_if_vm(ctx, fullguest)
+                                provision.create_if_vm(ctx, fullguest)
                 if lock.update_keys(ctx, keyscan_out, current_locks):
                     log.info("Error in machine(s) keys")
                 newscandict = {}

--- a/teuthology/test/test_resolve_equivalent_arch.py
+++ b/teuthology/test/test_resolve_equivalent_arch.py
@@ -2,34 +2,34 @@ from .. import misc as teuthology
 
 class Mock: pass
 
-class TestResolveEquivelentArch(object):
+class TestResolveEquivalentArch(object):
 
     def test_forward_64(self):
-        arch = teuthology.resolve_equivelent_arch('x86_64')
+        arch = teuthology.resolve_equivalent_arch('x86_64')
         assert 'x86_64' in arch
         assert '64-bit' in arch
         assert 'amd64' in arch
 
     def test_forward_32(self):
-        arch = teuthology.resolve_equivelent_arch('i386')
+        arch = teuthology.resolve_equivalent_arch('i386')
         assert 'i386' in arch
         assert '32-bit' in arch
         assert 'i686' in arch
 
     def test_forward_arm(self):
-        arch = teuthology.resolve_equivelent_arch('armv7l')
+        arch = teuthology.resolve_equivalent_arch('armv7l')
         assert 'armv7l' in arch
         assert 'armhf' in arch
         assert 'arm' in arch
 
     def test_reverse_64(self):
         for arch in ['x86_64', '64-bit', 'amd64']:
-            assert teuthology.resolve_equivelent_arch(arch, reverse=True) == 'x86_64'
+            assert teuthology.resolve_equivalent_arch(arch, reverse=True) == 'x86_64'
 
     def test_reverse_32(self):
         for arch in ['i386', '32-bit', 'i686']:
-            assert teuthology.resolve_equivelent_arch(arch, reverse=True) == 'i386'
+            assert teuthology.resolve_equivalent_arch(arch, reverse=True) == 'i386'
 
     def test_reverse_arm(self):
         for arch in ['armv7l', 'armhf', 'arm']:
-            assert teuthology.resolve_equivelent_arch(arch, reverse=True) == 'armv7l'
+            assert teuthology.resolve_equivalent_arch(arch, reverse=True) == 'armv7l'

--- a/teuthology/test/test_resolve_equivelent_arch.py
+++ b/teuthology/test/test_resolve_equivelent_arch.py
@@ -1,0 +1,35 @@
+from .. import misc as teuthology
+
+class Mock: pass
+
+class TestResolveEquivelentArch(object):
+
+    def test_forward_64(self):
+        arch = teuthology.resolve_equivelent_arch('x86_64')
+        assert 'x86_64' in arch
+        assert '64-bit' in arch
+        assert 'amd64' in arch
+
+    def test_forward_32(self):
+        arch = teuthology.resolve_equivelent_arch('i386')
+        assert 'i386' in arch
+        assert '32-bit' in arch
+        assert 'i686' in arch
+
+    def test_forward_arm(self):
+        arch = teuthology.resolve_equivelent_arch('armv7l')
+        assert 'armv7l' in arch
+        assert 'armhf' in arch
+        assert 'arm' in arch
+
+    def test_reverse_64(self):
+        for arch in ['x86_64', '64-bit', 'amd64']:
+            assert teuthology.resolve_equivelent_arch(arch, reverse=True) == 'x86_64'
+
+    def test_reverse_32(self):
+        for arch in ['i386', '32-bit', 'i686']:
+            assert teuthology.resolve_equivelent_arch(arch, reverse=True) == 'i386'
+
+    def test_reverse_arm(self):
+        for arch in ['armv7l', 'armhf', 'arm']:
+            assert teuthology.resolve_equivelent_arch(arch, reverse=True) == 'armv7l'


### PR DESCRIPTION
Access cobbler API to re-image machines for baremetal. Uses
quite a bit of the same code-base as the vm stuff but for
baremetal instead.

VM/Baremetal code added to new module 'provision.py'

Signed-off-by: Sandon Van Ness <sandon@inktank.com>