### PR TITLE
Fix a bug where ctx.config['targets'] was looped through again

### DIFF
--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -189,10 +189,9 @@ def connect(ctx, config):
                 key = None
         except (AttributeError, KeyError):
             pass
-        for machine in ctx.config['targets'].iterkeys():
-            if teuthology.is_vm(machine):
+        if key.startswith('ssh-rsa ') or key.startswith('ssh-dss '):
+            if teuthology.is_vm(t):
                 key = None
-                break
         remotes.append(
             remote.Remote(name=t,
                           ssh=connection.connect(user_at_host=t,


### PR DESCRIPTION
in connect().  The bug caused vm behavior to happen for a
target if any of the machines in the cluster was a vm.  The code
was also changed to set the key to none only if rsa or dsa keys
were used on a vm.

Fixes: 7113
Signed-off-by: Warren Usui warren.usui@inktank.com
