### PR TITLE
lock.py: request only rsa keys from ssh-keyscan

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -346,7 +346,7 @@ def keyscan_check(ctx, machines):
     for i, machine in enumerate(machines):
         if '@' in machine:
             _, machines[i] = machine.rsplit('@')
-    args = ['ssh-keyscan']
+    args = ['ssh-keyscan', '-t', 'rsa']
     args.extend(machines)
     p = subprocess.Popen(
         args=args,


### PR DESCRIPTION
New versions of ssh-keyscan return two keytypes if possible; this
breaks the comparison of "number of lines of output from keyscan"
to "number of hosts we request keys from".  Fix by asking for only
one type of key (as older ssh-keyscans did).

Fixes: #7164
Signed-off-by: Dan Mick dan.mick@inktank.com
