### PR TITLE
Added --limit option to teuthology-suite.

### DIFF
--- a/schedule_suite.sh
+++ b/schedule_suite.sh
@@ -9,6 +9,14 @@ teuthology_branch=$6
 mtype=$7
 template=$8
 distro=$9
+limit=${10}
+
+if [ -z "$limit" ]
+then
+    limitline=''
+else
+    limitline="--limit $limit"
+fi
 
 if [ -z "$kernel" ]; then
     echo "usage: $0 <suite> <ceph branch> <kernel branch> [email] [flavor] [teuthology-branch] [machinetype] [template] [distro]"
@@ -190,5 +198,6 @@ echo "name $name"
     --collections $suite \
     --email $email \
     --timeout 36000 \
+    $limitline \
     --name $name \
     --worker $tube

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -70,6 +70,12 @@ combination, and will override anything in the suite.
         help='number of times to run/queue each job'
     )
     parser.add_argument(
+        '-l', '--limit',
+        default=0,
+        type=int,
+        help='limit number of jobs in loop to N'
+    )
+    parser.add_argument(
         '-w', '--worker',
         default='plana',
         help='which worker to use (type of machine)',

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -37,7 +37,8 @@ def main(args):
         (os.path.join(args.base, collection), collection)
         for collection in args.collections
     ]
-
+    
+    count = 1
     num_jobs = 0
     for collection, collection_name in sorted(collections):
         log.debug('Collection %s in %s' % (collection_name, collection))
@@ -50,6 +51,12 @@ def main(args):
         arch = get_arch(args.config)
         machine_type = get_machine_type(args.config)
         for description, config in configs:
+            if args.limit > 0:
+                if count > args.limit:
+                    log.info('Stopped after {limit} jobs due to --limit={limit}'.format(
+                    limit=args.limit))
+
+                    break
             raw_yaml = '\n'.join([file(a, 'r').read() for a in config])
 
             parsed_yaml = yaml.load(raw_yaml)
@@ -95,6 +102,7 @@ def main(args):
                 subprocess.check_call(
                     args=arg,
                 )
+            count += 1
 
     if num_jobs:
         arg = copy.deepcopy(base_arg)


### PR DESCRIPTION
Use --limit to limit the number of jobs being scheduled during
teuthology-suite. Also can be used with schedule_suite.sh via the
10th argument.

Signed-off-by: Sandon Van Ness sandon@inktank.com
Signed-off-by: Yuri Weinstein yuri.weinstein@inktank.com
