### PR TITLE
lock.py: allow --brief to stand on its own (without --list)

### DIFF
--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -26,6 +26,7 @@ def parse_args():
             teuthology-lock --lock -t target.yaml
             teuthology-lock --list-targets plana01
             teuthology-lock --list --brief --owner user@host
+            teuthology-lock --brief
             teuthology-lock --update --status down --desc testing plana01
         '''),
         formatter_class=argparse.RawTextHelpFormatter)
@@ -42,6 +43,12 @@ def parse_args():
         default=False,
         help='Show lock info for machines owned by you, or only machines ' +
         'specified. Can be restricted by --owner, --status, and --locked.',
+    )
+    group.add_argument(
+        '--brief',
+        action='store_true',
+        default=False,
+        help='Like --list, but with summary instead of detail',
     )
     group.add_argument(
         '--list-targets',
@@ -126,12 +133,6 @@ def parse_args():
         default=None,
         choices=['true', 'false'],
         help='whether a machine is locked',
-    )
-    parser.add_argument(
-        '--brief',
-        action='store_true',
-        default=False,
-        help='Shorten information reported from --list',
     )
     parser.add_argument(
         '-t', '--targets',

--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -156,7 +156,8 @@ def main(ctx):
             or ctx.update, \
             'machines cannot be specified with that operation'
     else:
-        assert ctx.num_to_lock or ctx.list or ctx.list_targets or ctx.summary,\
+        assert ctx.num_to_lock or ctx.list or ctx.list_targets or \
+            ctx.summary or ctx.brief, \
             'machines must be specified for that operation'
     if ctx.all:
         assert ctx.list or ctx.list_targets, \
@@ -169,11 +170,8 @@ def main(ctx):
         assert ctx.machine_type, \
             'must specify machine type to lock'
 
-    if ctx.brief:
-        assert ctx.list, '--brief only applies to --list'
-
-    if ctx.list or ctx.list_targets:
-        assert ctx.desc is None, '--desc does nothing with --list'
+    if ctx.brief or ctx.list or ctx.list_targets:
+        assert ctx.desc is None, '--desc does nothing with --list/--brief'
 
         if machines:
             statuses = []
@@ -224,16 +222,17 @@ def main(ctx):
                             if status['description'] is not None and
                             status['description'].find(ctx.desc_pattern) >= 0]
             if ctx.list:
-                if ctx.brief:
-                    for s in statuses:
-                        locked = "un" if s['locked'] == 0 else "  "
-                        mo = re.match('\w+@(\w+?)\..*', s['name'])
-                        host = mo.group(1) if mo else s['name']
-                        print '{host} {locked}locked {owner} "{desc}"'.format(
-                            locked=locked, host=host,
-                            owner=s['locked_by'], desc=s['description'])
-                else:
                     print json.dumps(statuses, indent=4)
+
+            elif ctx.brief:
+                for s in statuses:
+                    locked = "un" if s['locked'] == 0 else "  "
+                    mo = re.match('\w+@(\w+?)\..*', s['name'])
+                    host = mo.group(1) if mo else s['name']
+                    print '{host} {locked}locked {owner} "{desc}"'.format(
+                        locked=locked, host=host,
+                        owner=s['locked_by'], desc=s['description'])
+
             else:
                 frag = {'targets': {}}
                 for f in statuses:


### PR DESCRIPTION
I use --brief all the time, and it's annoying to have to type
the useless --list at the same time.

Signed-off-by: Dan Mick dan.mick@inktank.com
