### PR TITLE
prevent undefined values in finally block

### DIFF
--- a/teuthology/task/ceph-deploy.py
+++ b/teuthology/task/ceph-deploy.py
@@ -393,6 +393,11 @@ def build_ceph_cluster(ctx, config):
                 teuthology.pull_directory(remote, '/var/log/ceph',
                                           os.path.join(sub, 'log'))
 
+        # Prevent these from being undefined if the try block fails
+        all_nodes = get_all_nodes(ctx, config)
+        purge_nodes = './ceph-deploy purge'+" "+all_nodes
+        purgedata_nodes = './ceph-deploy purgedata'+" "+all_nodes
+
         log.info('Purging package...')
         execute_ceph_deploy(ctx, config, purge_nodes)
         log.info('Purging data...')


### PR DESCRIPTION
There is some copy pasta here from the `try` block. There is no way around this. The `finally` block should never ever depend on things defined in the `try` block because if there is an exception raised there there they will go undefined and the `finally` block will fail.
