### PR TITLE
Pass '--object-sync-timeout 30' to radosgw-agent

### DIFF
--- a/teuthology/task/radosgw-agent.py
+++ b/teuthology/task/radosgw-agent.py
@@ -91,6 +91,7 @@ def run_radosgw_agent(ctx, config):
             '--log-file', '{tdir}/archive/rgw_sync_agent.{client}.log'.format(
                 tdir=testdir,
                 client=client),
+            '--object-sync-timeout', '30',
             ]
 
         if cconf.get('metadata-only', False):
@@ -103,7 +104,7 @@ def run_radosgw_agent(ctx, config):
             in_args.append('--test-server-port')
             in_args.append(str(port))
             log.debug('Starting a sync test server on {client}'.format(client=client))
-            # Stash the radosgw-agent server / port # for use by subsequent tasks 
+            # Stash the radosgw-agent server / port # for use by subsequent tasks
             ctx.radosgw_agent.endpoint = (client, str(port))
         else:
             in_args.append('--sync-scope')


### PR DESCRIPTION
http://tracker.ceph.com/issues/7749

Signed-off-by: Zack Cerza zack.cerza@inktank.com
