### PR TITLE
Improve unlock error messages.

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -73,7 +73,7 @@ def lock_one(ctx, name, user=None, description=None):
 def unlock_one(ctx, name, user=None):
     if user is None:
         user = misc.get_user()
-    success, _, _ = ls.send_request(
+    success, _, http_ret = ls.send_request(
         'DELETE',
         config.lock_server + '/' + name + '?' +
         urllib.urlencode(dict(user=user)))
@@ -84,6 +84,10 @@ def unlock_one(ctx, name, user=None):
             log.info('%s is not locked' % name)
     else:
         log.error('failed to unlock %s', name)
+        failure_types = {403: 'You do not have %s locked',
+                         404: '%s is an invalid host name'}
+        if http_ret in failure_types:
+            log.error(failure_types[http_ret], name)
     return success
 
 


### PR DESCRIPTION
Added messages if the hostname is invalid, and if
the user is not the owner of the lock.

Fixes: 6295
Signed-off-by: Warren Usui warren.usui@inktank.com
