### PR TITLE
Use SFTPClienti get for long reads/writes

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -625,7 +625,7 @@ def pull_directory(remote, remotedir, localdir):
               remote.shortname, remotedir, localdir)
     if not os.path.exists(localdir):
         os.mkdir(localdir)
-    _, local_tarfile = tempfile.mkstemp()
+    _, local_tarfile = tempfile.mkstemp(dir=localdir)
     remote.get_tar(remotedir, local_tarfile, sudo=True)
     with open(local_tarfile, 'r+') as fb1:
         tar = tarfile.open(mode='r|', fileobj=fb1)

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -74,10 +74,6 @@ class Remote(object):
         return self.name.split('@')[1]
 
     @property
-    def username(self):
-        return self.name.split('@')[0]
-
-    @property
     def is_online(self):
         if self.ssh is None:
             return False
@@ -159,11 +155,7 @@ class Remote(object):
         return result
 
     def _sftp_copy_file(self, file_path, to_path):
-        client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.load_system_host_keys()
-        client.connect(self.hostname, username=self.username)
-        sftp = client.open_sftp()
+        sftp = self.ssh.open_sftp()
         sftp.get(file_path, to_path)
 
     def remove(self, path):


### PR DESCRIPTION
Modified remote.py to use the paramiko SFTPClient get
method to extract long files (mostly tar files) from
the remote host.  The code formerly saved the data
in a long local string which was very inefficient.

Fixes: 8261
Signed-off-by: Warren Usui warren.usui@inktank.com
