### PR TITLE
ceph_manager: reset osd weights to 1 when waiting for clean

### DIFF
--- a/teuthology/task/ceph_manager.py
+++ b/teuthology/task/ceph_manager.py
@@ -374,6 +374,9 @@ class Thrasher:
             if random.uniform(0, 1) < (float(delay) / cleanint):
                 while len(self.dead_osds) > maxdead:
                     self.revive_osd()
+                for osd in self.in_osds:
+                    self.ceph_manager.raw_cluster_cmd('osd', 'reweight',
+                                                      str(osd), str(1))
                 if random.uniform(0, 1) < float(
                     self.config.get('chance_test_map_discontinuity', 0)):
                     self.test_map_discontinuity()


### PR DESCRIPTION
If we leave the weights adjusted, we can get PGs stuck in a remapped state 
because we are probabilistically rejecting placement.  Avoid this by setting
on in osds to 1.0 before waiting for clean.

Signed-off-by: Sage Weil sage@inktank.com
