### PR TITLE
Further clarify 'too many values to unpack' error.

### DIFF
--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -82,6 +82,15 @@ def run_tasks(tasks, ctx):
             from .task import interactive
             log.warning('Saw failure, going into interactive mode...')
             interactive.task(ctx=ctx, config=None)
+        # Throughout teuthology, (x,) = y has been used to assign values
+        # from yaml files where only one entry of type y is correct.  This
+        # causes failures with 'too many values to unpack.'  We want to
+        # fail as before, but with easier to understand error indicators.
+        if type(e) == ValueError:
+            if e.message == 'too many values to unpack':
+                emsg = 'Possible configuration error in yaml file'
+                log.error(emsg)
+                ctx.summary['failure_info'] = emsg
     finally:
         try:
             exc_info = sys.exc_info()


### PR DESCRIPTION
Many errors in yaml configurations cause ValueError to get thrown
with the message 'too many values to unpack.'  A previously reverted
change tried to handle all these situations and print an appropriate
message.

The current behavior of thrown the exception and exiting is probably
what we still want in these cases.  So instead of handling the error,
the code now catches the exception at the top-most call and displays
appropriate messages in log.error and in the ctx.summary data itself.

Fixes: 7510
Signed-off-by: Warren Usui warren.usui@inktank.com
