### PR TITLE
Allow .teuthology.yaml to set downburst path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -418,6 +418,12 @@ These values are used by downburst to create the virtual machine.
 When locking a file, a downburst meta-data yaml file can be specified by using
 the downburst-conf parameter on the command line.
 
+To find the downburst executable, teuthology first checks the PATH environment
+variable.  If not defined, teuthology next checks for
+src/downburst/virtualenv/bin/downburst executables in the user's home
+directory, /home/ubuntu, and /home/teuthology.  This can all be overridden if
+the user specifies a downburst field in the user's .teuthology.yaml file.
+
 HOST KEYS:
 ----------
 

--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -419,6 +419,8 @@ def _get_downburst_exec():
     Then check in ~/src, ~ubuntu/src, and ~teuthology/src.
     Return '' if no executable downburst is found.
     """
+    if config.downburst:
+        return config.downburst
     path = os.environ.get('PATH', None)
     if path:
         for p in os.environ.get('PATH', '').split(os.pathsep):
@@ -448,21 +450,10 @@ def create_if_vm(ctx, machine_name):
 
     createMe = decanonicalize_hostname(machine_name)
     with tempfile.NamedTemporaryFile() as tmp:
-        try:
-            lfile = ctx.downburst_conf
-            with open(lfile) as downb_yaml:
-                lcnfg = yaml.safe_load(downb_yaml)
-                if lcnfg.keys() == ['downburst']:
-                    lcnfg = lcnfg['downburst']
-        except (TypeError, AttributeError):
-            if hasattr(ctx, 'config') and ctx.config is not None:
-                lcnfg = ctx.config.get('downburst', dict())
-            else:
-                lcnfg = {}
-        except IOError:
-            print "Error reading %s" % lfile
-            return False
-
+        if hasattr(ctx, 'config') and ctx.config is not None:
+            lcnfg = ctx.config.get('downburst', dict())
+        else:
+            lcnfg = {}
         distro = lcnfg.get('distro', os_type.lower())
         distroversion = lcnfg.get('distroversion', os_version)
 


### PR DESCRIPTION
If .teuthology.yaml defines downburst, _get_downburst_exec()
now returns that value as the path to the downburst executable.

Also cleaned up code in create_if_vm.  ctx.downburst_conf was
never defined, so the code that handled the AttributeError
was always being executed.

Fixes: 6921

Signed-off-by: Warren Usui warren.usui@inktank.com
