### PR TITLE
rgw: set data extra pool correctly

### DIFF
--- a/teuthology/task/rgw.py
+++ b/teuthology/task/rgw.py
@@ -341,10 +341,12 @@ def extract_zone_info(ctx, client, client_config):
 
     index_pool = '.' + region + '.' + zone + '.' + 'index_pool'
     data_pool = '.' + region + '.' + zone + '.' + 'data_pool'
+    data_extra_pool = '.' + region + '.' + zone + '.' + 'data_extra_pool'
 
     zone_info['placement_pools'] = [{'key': 'default_placement',
                                      'val': {'index_pool': index_pool,
-                                             'data_pool': data_pool}
+                                             'data_pool': data_pool,
+                                             'data_extra_pool': data_extra_pool}
                                      }]
 
     # these keys are meant for the zones argument in the region info.  We


### PR DESCRIPTION
When configuring multiregion zone, set the data extra pool

Signed-off-by: Yehuda Sadeh yehuda@inktank.com
