### PR TITLE
Do not lock vms when downburst fails.

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -331,7 +331,7 @@ def get_worker(machine_type):
 
 
 def get_hash(project='ceph', branch='master', flavor='basic',
-             machine_type='plana', distro='ubuntu'):
+             distro='ubuntu', machine_type='plana'):
     """
     Find the hash representing the head of the project's repository via
     querying a gitbuilder repo.

--- a/teuthology/test/test_suite.py
+++ b/teuthology/test/test_suite.py
@@ -64,15 +64,11 @@ class TestSuiteOnline(object):
         if 'TEST_ONLINE' not in os.environ:
             skip("To run these sets, set the environment variable TEST_ONLINE")
 
-    def test_ceph_hash_simple(self):
+    def test_ceph_hash(self):
         resp = requests.get(
             'https://api.github.com/repos/ceph/ceph/git/refs/heads/master')
         ref_hash = resp.json()['object']['sha']
         assert suite.get_hash('ceph') == ref_hash
-
-    def test_kernel_hash_saya(self):
-        # We don't currently have these packages.
-        assert suite.get_hash('kernel', 'master', 'basic', 'saya') is None
 
     def test_all_master_branches(self):
         # Don't attempt to send email


### PR DESCRIPTION
Invalid os-type formerly threw KeyErrors and silently locked vms.
Other invalid os-type and invalid os-version permutations would print
error messages, lock a vms, and report that vms as being locked.

In all these cases, the vms created was unusable.

This new version does not lock in all these cases, and prints
appropriate log.info messages.  Code was also added to avoid confusing
messages as well.

Fixes: 8712
Signed-off-by: Warren Usui warren.usui@inktank.com
