### PR TITLE
ignore errors if 'ps aux' fails

### DIFF
--- a/teuthology/task/ceph_deploy.py
+++ b/teuthology/task/ceph_deploy.py
@@ -353,10 +353,10 @@ def build_ceph_cluster(ctx, config):
                               'sudo', 'service',  'status', 'ceph-all'])
 
         # and now just check for the processes themselves, as if upstart/sysvinit
-        # is lying to us
+        # is lying to us. Ignore errors if the grep fails
         ctx.cluster.run(args=['sudo', 'ps', 'aux', run.Raw('|'),
                               'grep', '-v', 'grep', run.Raw('|'),
-                              'grep', 'ceph'])
+                              'grep', 'ceph'], check_status=False)
 
         if ctx.archive is not None:
             # archive mon data, too


### PR DESCRIPTION
we just want to see if something is running, no need to bomb the whole test run

reference issue: http://tracker.ceph.com/issues/9024
