### PR TITLE
misc: pass premable through when no valgrind

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1006,7 +1006,7 @@ def get_valgrind_args(testdir, name, preamble, v):
     v - valgrind arguments
     """
     if v is None:
-        return []
+        return preamble
     if not isinstance(v, list):
         v = [v]
     val_path = '/var/log/ceph/valgrind'.format(tdir=testdir)


### PR DESCRIPTION
The reason this doens't affect things other than radosgw is that those
tasks only call this method if valgrind is in fact defined, so they don't
hit this "no-op" case that rgw.py does.

This fixes the radosgw shutdown failures, #9069
