### PR TITLE
Fix update hang.

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -350,6 +350,8 @@ def list_locks(keyed_by_name=False, **kwargs):
 
 def update_lock(name, description=None, status=None, ssh_pub_key=None):
     name = misc.canonicalize_hostname(name, user=None)
+    # Only do VM specific things (key lookup) if we are not
+    # Just updating the status (like marking down).
     if not status:
         status_info = get_status(name)
         if status_info['is_vm']:


### PR DESCRIPTION
Don't check ssh keys of VM (attempting to update them) if we are
changing the state of the host (up/down) as there is a good chance
it will be down and will never return any keys.

Signed-off-by: Sandon Van Ness sandon@inktank.com
