### PR TITLE
teuthology-suite: fix handling of extra YAML files

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -72,6 +72,10 @@ def main(args):
     if owner:
         job_config.owner = owner
 
+    # Interpret any relative paths as being relative to ceph-qa-suite (absolute
+    # paths are unchanged by this)
+    base_yaml_paths = [os.path.join(suite_repo_path, b) for b in base_yaml_paths]
+
     with NamedTemporaryFile(prefix='schedule_suite_',
                             delete=False) as base_yaml:
         base_yaml.write(str(job_config))


### PR DESCRIPTION
Previously these had to be checked into ceph-qa-suite
_and_ present into the folder you were running
teuthology-suite from.

Signed-off-by: John Spray john.spray@redhat.com
