### PR TITLE
Fix RPM kernel downgrade.

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -290,7 +290,18 @@ def download_kernel(ctx, config):
                     continue
                 output.close()
                 err_mess.close()
-                proc = role_remote.run(args=['sudo', 'yum', 'install', '-y', kernel_url], wait=False)
+                proc = role_remote.run(
+                    args=[
+                        'sudo',
+                        'rpm',
+                        '-ivh',
+                        '--oldpackage',
+                        '--replacefiles',
+                        '--replacepkgs', 
+                        kernel_url
+                        ],
+                    wait=False
+                    )
                 procs[role_remote.name] = proc
                 continue
 


### PR DESCRIPTION
Force even if an older version or existing.

Signed-off-by: Sandon Van Ness sandon@inktank.com
