### PR TITLE
enable lsof when unmounting nfs clients

### DIFF
--- a/teuthology/task/knfsd.py
+++ b/teuthology/task/knfsd.py
@@ -133,10 +133,21 @@ def task(ctx, config):
         for id_, remote in clients:
             log.debug('Unexporting client client.{id}...'.format(id=id_))
             mnt = os.path.join(teuthology.get_testdir(ctx), 'mnt.{id}'.format(id=id_))
-            remote.run(
-                args=[
-                    'sudo',
-                    'exportfs',
-                    '-au',
-                    ],
-                )
+            log.debug('Checking active files on mount {mnt}'.format(mnt=mnt))
+            try:
+                remote.run(
+                    args=[
+                        'sudo',
+                        'lsof', '-V',
+                        '{mnt}'.format(mnt=mnt),
+                        ],
+                    check_status=False
+                    )
+            finally:
+                remote.run(
+                    args=[
+                        'sudo',
+                        'exportfs',
+                        '-au',
+                        ],
+                    )


### PR DESCRIPTION
This should help us track down anything still in use by an NFS export after the NFS users unmount, which we believe has been causing unmount failures in testing.

Because the lsof interface is strange, use the verbose flag so we get
some output even if there is no use, and ignore errors because it will
return 1 if there's no filesystem use.
