### PR TITLE
Allow execution on the targets from the configuration files

### DIFF
--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -210,7 +210,7 @@ def connect(ctx, config):
     for name in ctx.config['targets'].iterkeys():
         machs.append(name)
     for t, key in ctx.config['targets'].iteritems():
-        if ctx.config.get('check-locks') != False:
+        if ctx.config.get('as-is-hostname') != True:
             t = misc.canonicalize_hostname(t)
         log.debug('connecting to %s', t)
         try:


### PR DESCRIPTION
Currently when you try to specify a target with username@hostname it is always turned into ubuntu@username@hostname.front.sepia.ceph.com, even when check-locks is set to false.

Signed-off-by: Federico Gimenez fgimenez@coit.es
