### PR TITLE
Allow more strings in filters

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -65,9 +65,12 @@ Scheduler arguments:
   --timeout <timeout>         How long, in seconds, to wait for jobs to finish
                               before sending email. This does not kill jobs.
                               [default: 32400]
-  --filter <string>           Only run jobs containing the string specified.
-  --filter-out <string>       Do not run jobs containing the string specified.
-
+  --filter KEYWORDS           Only run jobs whose name contains at least one
+                              of the keywords in the comma separated keyword
+                              string specified.
+  --filter-out KEYWORDS       Do not run jobs whose name contains any of
+                              the keywords in the comma separated keyword
+                              string specified.
 """
 
 

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -448,6 +448,8 @@ def schedule_suite(job_config,
                 'Stopped after {limit} jobs due to --limit={limit}'.format(
                     limit=limit))
             break
+        # Break apart the filter parameter (one string) into comma separated
+        # components to be used in searches.
         if filter_in:
             filter_list = [x.strip() for x in filter_in.split(',')]
             if not any([x in description for x in filter_list]):


### PR DESCRIPTION
A comma separated list can now be used in filter and filter-out.

Fixes: 9925
Signed-off-by: Warren Usui warren.usui@inktank.com
