### PR TITLE
remove configuration files when nuking

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -284,7 +284,7 @@ def remove_testing_tree(ctx):
         proc.wait()
 
 
-def remove_configuration_files(remotes):
+def remove_configuration_files(ctx):
     """
     Goes through a list of commonly used configuration files used for testing
     that should not be left behind.
@@ -296,7 +296,7 @@ def remove_configuration_files(remotes):
 
     nodes = {}
 
-    for remote in remotes:
+    for remote in ctx.cluster.remotes.iterkeys():
         proc = remote.run(
             args=[
                 'rm', '-f', '/home/ubuntu/.cephdeploy.conf'


### PR DESCRIPTION
Reference issue: http://tracker.ceph.com/issues/9975

Example of a successful run:

```
2014-11-06 09:50:13,139.139 INFO:teuthology.nuke:removing temporary configuration files on ubuntu@plana07.front.sepia.ceph.com
2014-11-06 09:50:13,140.140 INFO:teuthology.nuke:removing temporary configuration files on ubuntu@plana48.front.sepia.ceph.com
2014-11-06 09:50:13,141.141 INFO:teuthology.nuke:removing temporary configuration files on ubuntu@plana41.front.sepia.ceph.com
```

After nuking them here is one of the servers confirming that file is gone: 

```
(virtualenv)alfredo@teuthology:~/code/teuthology$ ssh ubuntu@plana07.front.sepia.ceph.com cat .cephdeploy.conf
The authenticity of host 'plana07.front.sepia.ceph.com (10.214.131.33)' can't be established.
ECDSA key fingerprint is 9d:98:79:b4:5a:fd:ec:f4:3d:e0:ea:24:22:0f:10:e7.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'plana07.front.sepia.ceph.com,10.214.131.33' (ECDSA) to the list of known hosts.
cat: .cephdeploy.conf: No such file or directory
```
