### PR TITLE
swift: set full access to subusers creation

### DIFF
--- a/teuthology/task/swift.py
+++ b/teuthology/task/swift.py
@@ -87,6 +87,7 @@ def create_users(ctx, config):
                     '--secret', testswift_conf['func_test']['password{s}'.format(s=suffix)],
                     '--email', testswift_conf['func_test']['email{s}'.format(s=suffix)],
                     '--key-type', 'swift',
+                    '--access', 'full',
                 ],
             )
     try:


### PR DESCRIPTION
Default subuser permissions are 'none'.

Signed-off-by: Yehuda Sadeh yehuda@redhat.com
