### PR TITLE
Added calamari-server

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -255,8 +255,8 @@ def remove_installed_packages(ctx):
     install_task.remove_packages(
         ctx,
         config,
-        {"deb": install_task.deb_packages['ceph'] + ['salt-common', 'salt-minion'],
-         "rpm": install_task.rpm_packages['ceph']})
+        {"deb": install_task.deb_packages['ceph'] + ['salt-common', 'salt-minion', 'calamari-server'],
+         "rpm": install_task.rpm_packages['ceph'] + ['salt-common', 'salt-minion', 'calamari-server']})
     install_task.remove_sources(ctx, config)
     install_task.purge_data(ctx)
 


### PR DESCRIPTION
Calamari-server has been added to the list of installed packages
to be removed.  Also added salt-common and salt-minion to the list
of rpms to be removed.

Fixes #10034
Signed-off-by: Warren Usui warren.usui@inktank.com
