### PR TITLE
test improvements

### DIFF
--- a/teuthology/orchestra/test/test_cluster.py
+++ b/teuthology/orchestra/test/test_cluster.py
@@ -1,7 +1,7 @@
 import fudge
 import pytest
 
-from mock import patch
+from mock import patch, Mock
 
 from .. import cluster, remote
 
@@ -208,20 +208,33 @@ class TestCluster(object):
         c_foo = c.exclude('foo', lambda role: role.startswith('b'))
         assert c_foo.remotes == {r2: ['bar'], r3: ['foo']}
 
-    @patch("teuthology.misc.write_file")
-    @patch("teuthology.misc.sudo_write_file")
-    def test_write_file(self, m_sudo_write_file, m_write_file):
-        r1 = remote.Remote('r1', ssh=fudge.Fake('SSH'))
-        c = cluster.Cluster(
+
+class TestWriteFile(object):
+    """ Tests for cluster.write_file """
+    def setup(self):
+        self.r1 = remote.Remote('r1', ssh=Mock())
+        self.c = cluster.Cluster(
             remotes=[
-                (r1, ['foo', 'bar']),
-                ],
-            )
-        c.write_file("filename", "content", sudo=True)
-        m_sudo_write_file.assert_called_with(r1, "filename", "content", owner=None, perms=None)
+                (self.r1, ['foo', 'bar']),
+            ],
+        )
+
+    @patch("teuthology.misc.write_file")
+    def test_write_file(self, m_write_file):
+        self.c.write_file("filename", "content")
+        m_write_file.assert_called_with(self.r1, "filename", "content")
+
+    @patch("teuthology.misc.write_file")
+    def test_fails_with_invalid_perms(self, m_write_file):
         with pytest.raises(ValueError):
-            c.write_file("filename", "content", sudo=False, perms="perms")
-        c.write_file("filename", "content")
-        m_write_file.assert_called_with(r1, "filename", "content")
+            self.c.write_file("filename", "content", sudo=False, perms="invalid")
 
+    @patch("teuthology.misc.write_file")
+    def test_fails_with_invalid_owner(self, m_write_file):
+        with pytest.raises(ValueError):
+            self.c.write_file("filename", "content", sudo=False, owner="invalid")
 
+    @patch("teuthology.misc.sudo_write_file")
+    def test_with_sudo(self, m_sudo_write_file):
+        self.c.write_file("filename", "content", sudo=True)
+        m_sudo_write_file.assert_called_with(self.r1, "filename", "content", owner=None, perms=None)


### PR DESCRIPTION
refactors orchestra.cluster.write_file tests to have one assertion per test case

Signed-off-by: Andrew Schoen aschoen@redhat.com
