### PR TITLE
kernel: fix commit hash matching in need_to_install()

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -166,7 +166,7 @@ def need_to_install(ctx, role, version):
                 cur_sha1 = cur_sha1[0:dloc]
             log.debug('extracting sha1, {ver} -> {sha1}'.format(
                       ver=cur_version, sha1=cur_sha1))
-            if version.startswith(cur_sha1):
+            if cur_sha1.startswith(version):
                 log.debug('extracted sha1 matches, do not need to install')
                 ret = False
         else:


### PR DESCRIPTION
We don't need to install a new kernel if the "want" (version) commit
hash and the "have" (cur_sha1) commit hash match but the former is
shorter than the latter.

Signed-off-by: Ilya Dryomov idryomov@redhat.com
