### PR TITLE
Add OS.codename

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -251,14 +251,24 @@ class Remote(object):
     @property
     def os(self):
         if not hasattr(self, '_os'):
+            proc = self.run(
+                args=[
+                    'python', '-c',
+                    'import platform; print platform.linux_distribution()'],
+                stdout=StringIO(), stderr=StringIO(), check_status=False)
+            if proc.exitstatus == 0:
+                self._os = OS.from_python(proc.stdout.getvalue().strip())
+                return self._os
+
             proc = self.run(args=['cat', '/etc/os-release'], stdout=StringIO(),
                             stderr=StringIO(), check_status=False)
             if proc.exitstatus == 0:
                 self._os = OS.from_os_release(proc.stdout.getvalue().strip())
-            else:
-                proc = self.run(args=['lsb_release', '-a'], stdout=StringIO(),
-                                stderr=StringIO())
-                self._os = OS.from_lsb_release(proc.stdout.getvalue().strip())
+                return self._os
+
+            proc = self.run(args=['lsb_release', '-a'], stdout=StringIO(),
+                            stderr=StringIO())
+            self._os = OS.from_lsb_release(proc.stdout.getvalue().strip())
         return self._os
 
     @property

--- a/teuthology/orchestra/test/test_opsys.py
+++ b/teuthology/orchestra/test/test_opsys.py
@@ -35,6 +35,8 @@ class TestOS(object):
         BUG_REPORT_URL="http://bugs.debian.org/"
     """)
 
+    str_ubuntu_12_04_python = "('Ubuntu', '12.04', 'precise')"
+
     str_ubuntu_12_04_lsb_release = dedent("""
         Distributor ID: Ubuntu
         Description:    Ubuntu 12.04.4 LTS
@@ -58,6 +60,8 @@ class TestOS(object):
         Release:        6.4
         Codename:       Santiago
     """)
+
+    str_rhel_7_python = "('Red Hat Enterprise Linux Server', '7.0', 'Maipo')"
 
     str_rhel_7_lsb_release = dedent("""
         LSB Version:    :core-4.1-amd64:core-4.1-noarch:cxx-4.1-amd64:cxx-4.1-noarch:desktop-4.1-amd64:desktop-4.1-noarch:languages-4.1-amd64:languages-4.1-noarch:printing-4.1-amd64:printing-4.1-noarch
@@ -89,54 +93,77 @@ class TestOS(object):
         os = OS.from_os_release(self.str_centos_7_os_release)
         assert os.name == 'centos'
         assert os.version == '7'
+        assert os.codename is None
         assert os.package_type == 'rpm'
 
     def test_debian_7_lsb_release(self):
         os = OS.from_lsb_release(self.str_debian_7_lsb_release)
         assert os.name == 'debian'
         assert os.version == '7.1'
+        assert os.codename == 'wheezy'
         assert os.package_type == 'deb'
 
     def test_debian_7_os_release(self):
         os = OS.from_os_release(self.str_debian_7_os_release)
         assert os.name == 'debian'
         assert os.version == '7'
+        assert os.codename is None
+        assert os.package_type == 'deb'
+
+    def test_ubuntu_12_04_python(self):
+        os = OS.from_python(self.str_ubuntu_12_04_python)
+        assert os.name == 'ubuntu'
+        assert os.version == '12.04'
+        assert os.codename == 'precise'
         assert os.package_type == 'deb'
 
     def test_ubuntu_12_04_lsb_release(self):
         os = OS.from_lsb_release(self.str_ubuntu_12_04_lsb_release)
         assert os.name == 'ubuntu'
         assert os.version == '12.04'
+        assert os.codename == 'precise'
         assert os.package_type == 'deb'
 
     def test_ubuntu_12_04_os_release(self):
         os = OS.from_os_release(self.str_ubuntu_12_04_os_release)
         assert os.name == 'ubuntu'
         assert os.version == '12.04'
+        assert os.codename is None
         assert os.package_type == 'deb'
 
     def test_rhel_6_4_lsb_release(self):
         os = OS.from_lsb_release(self.str_rhel_6_4_lsb_release)
         assert os.name == 'rhel'
         assert os.version == '6.4'
+        assert os.codename == 'santiago'
+        assert os.package_type == 'rpm'
+
+    def test_rhel_7_python(self):
+        os = OS.from_python(self.str_rhel_7_python)
+        assert os.name == 'rhel'
+        assert os.version == '7.0'
+        assert os.codename == 'maipo'
         assert os.package_type == 'rpm'
 
     def test_rhel_7_lsb_release(self):
         os = OS.from_lsb_release(self.str_rhel_7_lsb_release)
         assert os.name == 'rhel'
         assert os.version == '7.0'
+        assert os.codename == 'maipo'
         assert os.package_type == 'rpm'
 
     def test_rhel_7_os_release(self):
         os = OS.from_os_release(self.str_rhel_7_os_release)
         assert os.name == 'rhel'
         assert os.version == '7.0'
+        assert os.codename is None
         assert os.package_type == 'rpm'
 
     def test_repr(self):
-        os = OS(name='NAME', version='0.1.2')
-        assert repr(os) == "OS(name='NAME', version='0.1.2')"
+        os = OS(name='NAME', version='0.1.2', codename='code')
+        assert repr(os) == "OS(name='NAME', version='0.1.2', codename='code')"
 
     def test_to_dict(self):
-        os = OS(name='NAME', version='0.1.2')
-        assert os.to_dict() == dict(name='NAME', version='0.1.2')
+        os = OS(name='NAME', version='0.1.2', codename='code')
+        ref_dict = dict(name='NAME', version='0.1.2', codename='code')
+        assert os.to_dict() == ref_dict


### PR DESCRIPTION
The codename can be reliably set by parsing
platform.linux_distribution() or lsb_release -a. We now default to
trying the former first.

Signed-off-by: Zack Cerza zack@redhat.com
