### PR TITLE
Use FQDN in downburst yaml.

### DIFF
--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -71,7 +71,8 @@ def create_if_vm(ctx, machine_name):
         file_info['additional-disks-size'] = lcnfg.get(
             'additional-disks-size', '200G')
         file_info['arch'] = lcnfg.get('arch', 'x86_64')
-        file_out = {'downburst': file_info}
+        fqdn = machine_name.split('@')[1]
+        file_out = {'downburst': file_info, 'local-hostname': fqdn}
         yaml.safe_dump(file_out, tmp)
         metadata = "--meta-data=%s" % tmp.name
         dbrst = _get_downburst_exec()


### PR DESCRIPTION
As newer rhel's like to default to localdomain screwing with things
if its not set. Older cloud-init/distros appear to just ignore the
domain.

Signed-off-by: Sandon Van Ness sandon@redhat.com
