### PR TITLE
we need to use fake_ctx.summary when reporting the outcome of a run

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -301,4 +301,4 @@ def main(args):
         run_tasks(tasks=config['tasks'], ctx=fake_ctx)
     finally:
         # print to stdout the results and possibly send an email on any errors
-        report_outcome(config, archive, args["summary"], fake_ctx)
+        report_outcome(config, archive, fake_ctx.summary, fake_ctx)


### PR DESCRIPTION
I didn't realize in my first refactor of run that the tasks would mutate fake_ctx.summary during the run and we'd need to use it when reporting the final outcome.  This fixes that.
