### PR TITLE
teuthology.run: conditionally add fake_ctx to teuthology.config.config

### DIFF
--- a/teuthology/contextutil.py
+++ b/teuthology/contextutil.py
@@ -3,6 +3,7 @@ import sys
 import logging
 import time
 import itertools
+from .config import config
 
 log = logging.getLogger(__name__)
 
@@ -30,6 +31,11 @@ def nested(*managers):
     except Exception:
         log.exception('Saw exception from nested tasks')
         exc = sys.exc_info()
+        # FIXME this needs to be more generic
+        if config.ctx and config.ctx.config.get('interactive-on-error'):
+            from .task import interactive
+            log.warning('Saw failure, going into interactive mode...')
+            interactive.task(ctx=config.ctx, config=None)
     finally:
         while exits:
             exit = exits.pop()

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -307,6 +307,12 @@ def main(args):
     args["<config>"] = config
     fake_ctx = FakeNamespace(args)
 
+    # store on global config if interactive-on-error, for contextutil.nested()
+    # FIXME this should become more generic, and the keys should use
+    # '_' uniformly
+    if fake_ctx.config.get('interactive-on-error'):
+        teuthology.config.config.ctx = fake_ctx
+
     try:
         run_tasks(tasks=config['tasks'], ctx=fake_ctx)
     finally:


### PR DESCRIPTION
The intent here is to get the 'interactive-on-error' config value
passed down to contextutil.nested(), but it is recognized that we need
a way to share global configuration; for now, since nested() really
needs the entire ctx, we can get it out of fake_ctx.config, but there
needs to be a cleaner way as FakeNamespace is phased out.

Fixes: #10260
Signed-off-by: Dan Mick dan.mick@redhat.com
