### PR TITLE
remove the status from the call to paddles from worker.py

### DIFF
--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -189,7 +189,8 @@ def run_with_watchdog(process, job_config):
             kill_job(job_info['name'], job_info['job_id'],
                      teuth_config.archive_base)
 
-        report.try_push_job_info(job_info, dict(status='running'))
+        # calling this without a status just updates the jobs updated time
+        report.try_push_job_info(job_info)
         time.sleep(teuth_config.watchdog_interval)
 
     # The job finished. Let's make sure paddles knows.


### PR DESCRIPTION
This allows the job's updated time to change without changing it's status. The status of the job could be either running or waiting

Signed-off-by: Andrew Schoen aschoen@redhat.com
