### PR TITLE
Make log messages in run_tasks.py specify when the exception occurred.

### DIFF
--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -98,7 +98,7 @@ def run_tasks(tasks, ctx):
 
         if ctx.config.get('interactive-on-error'):
             from .task import interactive
-            log.warning('Saw failure, going into interactive mode...')
+            log.warning('Saw failure during task execution, going into interactive mode...')
             interactive.task(ctx=ctx, config=None)
         # Throughout teuthology, (x,) = y has been used to assign values
         # from yaml files where only one entry of type y is correct.  This
@@ -135,7 +135,7 @@ def run_tasks(tasks, ctx):
                     if ctx.config.get('interactive-on-error'):
                         from .task import interactive
                         log.warning(
-                            'Saw failure, going into interactive mode...')
+                            'Saw failure during task cleanup, going into interactive mode...')
                         interactive.task(ctx=ctx, config=None)
                 else:
                     if suppress:


### PR DESCRIPTION
There are other log messages in run_tasks that you could use to figure out if you went into interactive mode during task execution or clean up, but this makes it clearer without having to do that.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>