### PR TITLE
Schedule jobs with missing packages, but fail them quickly

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -168,7 +168,7 @@ def validate_tasks(config):
 
 
 def get_initial_tasks(lock, config, machine_type):
-    init_tasks = []
+    init_tasks = [{'internal.check_packages': None}]
     if lock:
         msg = ('You cannot specify targets in a config file when using the ' +
                '--lock option')

--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -59,7 +59,9 @@ def run_tasks(tasks, ctx):
             # Prevent connection issues being flagged as failures
             set_status(ctx.summary, 'dead')
         else:
-            set_status(ctx.summary, 'fail')
+            # the status may have been set to dead, leave it as-is if so
+            if not ctx.summary.get('status', '') == 'dead':
+                set_status(ctx.summary, 'fail')
         if 'failure_reason' not in ctx.summary:
             ctx.summary['failure_reason'] = str(e)
         log.exception('Saw exception from tasks.')

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -402,9 +402,9 @@ def get_gitbuilder_url(project, distro, pkg_type, arch, kernel_flavor):
     :param arch:          A string like 'x86_64'
     :param kernel_flavor: A string like 'basic'
     """
-    templ = 'http://gitbuilder.ceph.com/{proj}-{pkg}-{distro}-{arch}-{flav}/'
+    templ = 'http://{host}/{proj}-{pkg}-{distro}-{arch}-{flav}/'
     return templ.format(proj=project, pkg=pkg_type, distro=distro, arch=arch,
-                        flav=kernel_flavor)
+                        flav=kernel_flavor, host=config.gitbuilder_host)
 
 
 def package_version_for_hash(hash, kernel_flavor='basic',


### PR DESCRIPTION
This changes existing functionality in teuthology-suite that used to block runs from being scheduled if they contained jobs with missing packages.  This check is now done with a new task that is always ran first and will fail the job with the 'dead' status if there are packages missing.

A count of jobs with missing packages can be seen if you use the ``--dry-run`` flag with teuthology-suite.