### PR TITLE
Log the teuthology command being ran at the debug level

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -243,6 +243,28 @@ def report_outcome(config, archive, summary, fake_ctx):
         sys.exit(1)
 
 
+def get_teuthology_command(args):
+    """
+    Rebuilds the teuthology command used to run this job
+    and returns it as a string.
+    """
+    cmd = ["teuthology"]
+    for key, value in args.iteritems():
+        if value:
+            # an option, not an argument
+            if not key.startswith("<"):
+                cmd.append(key)
+            else:
+                # this is the <config> argument
+                for arg in value:
+                    cmd.append(str(arg))
+                continue
+            # so we don't print something like --verbose True
+            if isinstance(value, str):
+                cmd.append(value)
+    return " ".join(cmd)
+
+
 def main(args):
     verbose = args["--verbose"]
     archive = args["--archive"]
@@ -258,6 +280,9 @@ def main(args):
     os_version = args["--os-version"]
 
     set_up_logging(verbose, archive)
+
+    # print the command being ran
+    log.debug("Teuthology command: {0}".format(get_teuthology_command(args)))
 
     if owner is None:
         args["--owner"] = owner = get_user()

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -197,3 +197,30 @@ class TestRun(object):
         # ensures os_type and os_version are property overwritten
         assert fake_ctx["config"]["os_type"] == "os_type"
         assert fake_ctx["config"]["os_version"] == "os_version"
+
+    def test_get_teuthology_command(self):
+        doc = scripts_run.__doc__
+        args = docopt.docopt(doc, [
+            "--archive", "some/archive/dir",
+            "--description", "the_description",
+            "--lock",
+            "--block",
+            "--name", "the_name",
+            "--suite-path", "some/suite/dir",
+            "path/to/config.yml", "path/to/config2.yaml",
+        ])
+        result = run.get_teuthology_command(args)
+        result = result.split()
+        expected = [
+            "teuthology",
+            "path/to/config.yml", "path/to/config2.yaml",
+            "--suite-path", "some/suite/dir",
+            "--lock",
+            "--description", "the_description",
+            "--name", "the_name",
+            "--block",
+            "--archive", "some/archive/dir",
+        ]
+        assert len(result) == len(expected)
+        for arg in expected:
+            assert arg in result


### PR DESCRIPTION
I often find myself wanting the original teuthology command when debugging a failed job.  This will give me that.