### PR TITLE
teuthology: some suites still use http://ceph.newdream.net

### DIFF
--- a/teuthology/test/test_repo_utils.py
+++ b/teuthology/test/test_repo_utils.py
@@ -14,7 +14,7 @@ repo_utils.log.setLevel(logging.WARNING)
 class TestRepoUtils(object):
     src_path = '/tmp/empty_src'
     # online_repo_url = 'https://github.com/ceph/teuthology.git'
-    # online_repo_url = 'git://ceph.newdream.net/git/teuthology.git'
+    # online_repo_url = 'git://ceph.com/git/teuthology.git'
     online_repo_url = 'https://github.com/ceph/empty.git'
     offline_repo_url = 'file://' + src_path
     repo_url = None


### PR DESCRIPTION
This probably redirects to http://ceph.com but ceph.newdream.net still appears in some places

http://tracker.ceph.com/issues/9922 Fixes: #9922

Signed-off-by: Armando Segnini  <armando.segnini@telecom-bretagne.eu>