### PR TITLE
Enable kernel installs from brew

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -138,6 +138,8 @@ class TeuthologyConfig(YamlConfig):
         'src_base_path': os.path.expanduser('~/src'),
         'verify_host_keys': True,
         'watchdog_interval': 120,
+        'kojihub_url': 'http://koji.fedoraproject.org/kojihub',
+        'kojiroot_url': 'http://kojipkgs.fedoraproject.org/packages',
     }
 
     def __init__(self, yaml_path=None):

--- a/teuthology/exceptions.py
+++ b/teuthology/exceptions.py
@@ -21,6 +21,13 @@ class BootstrapError(RuntimeError):
     pass
 
 
+class ConfigError(RuntimeError):
+    """
+    Meant to be used when an invalid config entry is found.
+    """
+    pass
+
+
 class CommandFailedError(Exception):
 
     """

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -1,5 +1,10 @@
 import logging
+import ast
+
+from cStringIO import StringIO
+
 from teuthology import misc
+from .config import config
 
 log = logging.getLogger(__name__)
 
@@ -94,3 +99,101 @@ def remove_package(package, remote):
         log.error('remove_package: bad flavor ' + flavor + '\n')
         return False
     return remote.run(args=pkgcmd)
+
+
+def get_koji_build_info(build_id, remote, ctx):
+    """
+    Queries kojihub and retrieves information about
+    the given build_id. The package, koji, must be installed
+    on the remote for this command to work.
+
+    We need a remote here because koji can only be installed
+    on rpm based machines and teuthology runs on Ubuntu.
+
+    Here is an example of the build info returned:
+
+    {'owner_name': 'kdreyer', 'package_name': 'ceph',
+     'task_id': 8534149, 'completion_ts': 1421278726.1171,
+     'creation_event_id': 10486804, 'creation_time': '2015-01-14 18:15:17.003134',
+     'epoch': None, 'nvr': 'ceph-0.80.5-4.el7ost', 'name': 'ceph',
+     'completion_time': '2015-01-14 18:38:46.1171', 'state': 1, 'version': '0.80.5',
+     'volume_name': 'DEFAULT', 'release': '4.el7ost', 'creation_ts': 1421277317.00313,
+     'package_id': 34590, 'id': 412677, 'volume_id': 0, 'owner_id': 2826
+    }
+
+    :param build_id:  The brew build_id we want to retrieve info on.
+    :param remote:    The remote to run the koji command on.
+    :param ctx:       The ctx from the current run, used to provide a
+                      failure_reason and status if the koji command fails.
+    :returns:         A python dict containing info about the build.
+    """
+    py_cmd = ('import koji; '
+              'hub = koji.ClientSession("{kojihub_url}"); '
+              'print hub.getBuild({build_id})')
+    py_cmd = py_cmd.format(
+        build_id=build_id,
+        kojihub_url=config.kojihub_url
+    )
+    proc = remote.run(
+        args=[
+            'python', '-c', py_cmd
+        ],
+        stdout=StringIO(), stderr=StringIO(), check_status=False
+    )
+    if proc.exitstatus == 0:
+        # returns the __repr__ of a python dict
+        stdout = proc.stdout.getvalue().strip()
+        # take the __repr__ and makes it a python dict again
+        build_info = ast.literal_eval(stdout)
+    else:
+        msg = "Failed to query koji for build {0}".format(build_id)
+        log.error(msg)
+        log.error("stdout: {0}".format(proc.stdout.getvalue().strip()))
+        log.error("stderr: {0}".format(proc.stderr.getvalue().strip()))
+        ctx.summary["failure_reason"] = msg
+        ctx.summary["status"] = "dead"
+        raise RuntimeError(msg)
+
+    return build_info
+
+
+def get_kojiroot_base_url(build_info, arch="x86_64"):
+    """
+    Builds the base download url for kojiroot given the current
+    build information.
+
+    :param build_info:  A dict of koji build information, possibly
+                        retrieved from get_koji_build_info.
+    :param arch:        The arch you want to download rpms for.
+    :returns:           The base_url to use when downloading rpms
+                        from brew.
+    """
+    base_url = "{kojiroot}/{package_name}/{ver}/{rel}/{arch}/".format(
+        kojiroot=config.kojiroot_url,
+        package_name=build_info["package_name"],
+        ver=build_info["version"],
+        rel=build_info["release"],
+        arch=arch,
+    )
+    return base_url
+
+
+def get_koji_package_name(package, build_info, arch="x86_64"):
+    """
+    Builds the package name for a brew rpm.
+
+    :param package:     The name of the package
+    :param build_info:  A dict of koji build information, possibly
+                        retrieved from get_brew_build_info.
+    :param arch:        The arch you want to download rpms for.
+    :returns:           A string representing the file name for the
+                        requested package in koji.
+    """
+    pkg_name = "{name}-{ver}-{rel}.{arch}.rpm".format(
+        name=package,
+        ver=build_info["version"],
+        rel=build_info["release"],
+        arch=arch,
+    )
+
+    return pkg_name

--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -1069,12 +1069,14 @@ def task(ctx, config):
 
             # get information about this build from koji
             build_info = get_koji_build_info(build_id, role_remote, ctx)
-
-            need_install[role] = build_info
-            need_version[role] = "{ver}-{rel}.x86_64".format(
+            version = "{ver}-{rel}.x86_64".format(
                 ver=build_info["version"],
                 rel=build_info["release"]
             )
+
+            if need_to_install(ctx, role, version):
+                need_install[role] = build_info
+                need_version[role] = version
         else:
             package_type = role_remote.os.package_type
             larch = role_remote.arch

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -1,0 +1,147 @@
+import pytest
+
+from mock import patch, Mock
+
+from teuthology import packaging
+
+
+class TestPackaging(object):
+
+    @patch("teuthology.packaging.misc")
+    def test_get_package_name_deb(self, m_misc):
+        m_misc.get_system_type.return_value = "deb"
+        assert packaging.get_package_name('sqlite', Mock()) == "sqlite3"
+
+    @patch("teuthology.packaging.misc")
+    def test_get_package_name_rpm(self, m_misc):
+        m_misc.get_system_type.return_value = "rpm"
+        assert packaging.get_package_name('sqlite', Mock()) is None
+
+    @patch("teuthology.packaging.misc")
+    def test_get_package_name_not_found(self, m_misc):
+        m_misc.get_system_type.return_value = "rpm"
+        assert packaging.get_package_name('notthere', Mock()) is None
+
+    @patch("teuthology.packaging.misc")
+    def test_get_service_name_deb(self, m_misc):
+        m_misc.get_system_type.return_value = "deb"
+        assert packaging.get_service_name('httpd', Mock()) == 'apache2'
+
+    @patch("teuthology.packaging.misc")
+    def test_get_service_name_rpm(self, m_misc):
+        m_misc.get_system_type.return_value = "rpm"
+        assert packaging.get_service_name('httpd', Mock()) == 'httpd'
+
+    @patch("teuthology.packaging.misc")
+    def test_get_service_name_not_found(self, m_misc):
+        m_misc.get_system_type.return_value = "rpm"
+        assert packaging.get_service_name('notthere', Mock()) is None
+
+    @patch("teuthology.packaging.misc")
+    def test_install_package_deb(self, m_misc):
+        m_misc.get_system_type.return_value = "deb"
+        m_remote = Mock()
+        expected = [
+            'DEBIAN_FRONTEND=noninteractive',
+            'sudo',
+            '-E',
+            'apt-get',
+            '-y',
+            'install',
+            'apache2'
+        ]
+        packaging.install_package('apache2', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    @patch("teuthology.packaging.misc")
+    def test_install_package_rpm(self, m_misc):
+        m_misc.get_system_type.return_value = "rpm"
+        m_remote = Mock()
+        expected = [
+            'sudo',
+            'yum',
+            '-y',
+            'install',
+            'httpd'
+        ]
+        packaging.install_package('httpd', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    @patch("teuthology.packaging.misc")
+    def test_remove_package_deb(self, m_misc):
+        m_misc.get_system_type.return_value = "deb"
+        m_remote = Mock()
+        expected = [
+            'DEBIAN_FRONTEND=noninteractive',
+            'sudo',
+            '-E',
+            'apt-get',
+            '-y',
+            'purge',
+            'apache2'
+        ]
+        packaging.remove_package('apache2', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    @patch("teuthology.packaging.misc")
+    def test_remove_package_rpm(self, m_misc):
+        m_misc.get_system_type.return_value = "rpm"
+        m_remote = Mock()
+        expected = [
+            'sudo',
+            'yum',
+            '-y',
+            'erase',
+            'httpd'
+        ]
+        packaging.remove_package('httpd', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    def test_get_koji_package_name(self):
+        build_info = dict(version="3.10.0", release="123.20.1")
+        result = packaging.get_koji_package_name("kernel", build_info)
+        assert result == "kernel-3.10.0-123.20.1.x86_64.rpm"
+
+    @patch("teuthology.packaging.config")
+    def test_get_kojiroot_base_url(self, m_config):
+        m_config.kojiroot_url = "http://kojiroot.com"
+        build_info = dict(
+            package_name="kernel",
+            version="3.10.0",
+            release="123.20.1",
+        )
+        result = packaging.get_kojiroot_base_url(build_info)
+        expected = "http://kojiroot.com/kernel/3.10.0/123.20.1/x86_64/"
+        assert result == expected
+
+    @patch("teuthology.packaging.config")
+    def test_get_koji_build_info_success(self, m_config):
+        m_config.kojihub_url = "http://kojihub.com"
+        m_proc = Mock()
+        expected = dict(foo="bar")
+        m_proc.exitstatus = 0
+        m_proc.stdout.getvalue.return_value = str(expected)
+        m_remote = Mock()
+        m_remote.run.return_value = m_proc
+        result = packaging.get_koji_build_info(1, m_remote, dict())
+        assert result == expected
+        args, kwargs = m_remote.run.call_args
+        expected_args = [
+            'python', '-c',
+            'import koji; '
+            'hub = koji.ClientSession("http://kojihub.com"); '
+            'print hub.getBuild(1)',
+        ]
+        assert expected_args == kwargs['args']
+
+    @patch("teuthology.packaging.config")
+    def test_get_koji_build_info_fail(self, m_config):
+        m_config.kojihub_url = "http://kojihub.com"
+        m_proc = Mock()
+        m_proc.exitstatus = 1
+        m_remote = Mock()
+        m_remote.run.return_value = m_proc
+        m_ctx = Mock()
+        m_ctx.summary = dict()
+        with pytest.raises(RuntimeError):
+            packaging.get_koji_build_info(1, m_remote, m_ctx)


### PR DESCRIPTION
If you have 'brew: <build_id>' in the 'kernel' stanza of your teuthology yaml config this will install the kernel from that build_id on the specified node.  This only works on rhel systems.

I've also tried to abstract the functions that talk with brew into their own functions in teuthology.packaging so we can reuse them in the future to download other things from brew.

For: http://tracker.ceph.com/issues/10561

(I might still want to write tests for this, looking mainly for feedback right now)