### PR TITLE
Make teuthology-lock respect --os-type

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1155,13 +1155,11 @@ def get_distro(ctx):
     Get the name of the distro that we are using (usually the os_type).
     """
     os_type = None
-    # first, try to get the os_type from the config or --os-type
-    # FIXME: checking for ctx.os_type here should not be needed as
-    # ctx.os_type is assigned to ctx.config["os_type"] if provided
-    # in teuthology.run. We're gonna leave it here for now until we
-    # have the time to fully investigate and test it's removal.
+    if ctx.os_type:
+        return ctx.os_type
+
     try:
-        os_type = ctx.config.get('os_type', ctx.os_type)
+        os_type = ctx.config.get('os_type', None)
     except AttributeError:
         pass
     # next, look for an override in the downburst config for os_type

--- a/teuthology/test/test_get_distro.py
+++ b/teuthology/test/test_get_distro.py
@@ -18,6 +18,8 @@ class TestGetDistro(object):
         assert distro == 'ubuntu'
 
     def test_argument(self):
+        # we don't want fake_ctx to have a config
+        self.fake_ctx = Mock()
         self.fake_ctx.os_type = 'centos'
         distro = get_distro(self.fake_ctx)
         assert distro == 'centos'
@@ -27,6 +29,12 @@ class TestGetDistro(object):
         distro = get_distro(self.fake_ctx)
         assert distro == 'fedora'
 
+    def test_argument_takes_precedence(self):
+        self.fake_ctx.config = {'os_type': 'fedora'}
+        self.fake_ctx.os_type = "centos"
+        distro = get_distro(self.fake_ctx)
+        assert distro == 'centos'
+
     def test_teuth_config_downburst(self):
         self.fake_ctx.config = {'downburst' : {'distro': 'sles'}}
         distro = get_distro(self.fake_ctx)
@@ -34,5 +42,6 @@ class TestGetDistro(object):
 
     def test_no_config_or_os_type(self):
         self.fake_ctx = Mock()
+        self.fake_ctx.os_type = None
         distro = get_distro(self.fake_ctx)
         assert distro == 'ubuntu'

--- a/teuthology/test/test_get_distro_version.py
+++ b/teuthology/test/test_get_distro_version.py
@@ -13,6 +13,8 @@ class TestGetDistroVersion(object):
         self.fake_ctx_noarg = Mock()
         self.fake_ctx_noarg.config = {}
         self.fake_ctx_noarg.os_version = None
+        self.fake_ctx.os_type = None
+        self.fake_ctx_noarg.os_type = None
 
     def test_default_distro_version(self):
         #Default distro is ubuntu, default version of ubuntu is 12.04


### PR DESCRIPTION
This fixes the regression in issue #10621

Signed-off-by: Andrew Schoen <aschoen@redhat.com>