### PR TITLE
deprecate support for a custom downburst config

### DIFF
--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -158,10 +158,5 @@ def parse_args():
         default=None,
         help='OS (distro) version such as "12.10"',
     )
-    parser.add_argument(
-        '--downburst-conf',
-        default=None,
-        help='Downburst meta-data yaml file to be used for vps machines',
-    )
 
     return parser.parse_args()

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1154,17 +1154,17 @@ def get_distro(ctx):
     """
     Get the name of the distro that we are using (usually the os_type).
     """
-    # ubuntu is our default distro choice
-    os_type = "ubuntu"
+    os_type = None
     if ctx.os_type:
         return ctx.os_type
 
     try:
-        os_type = ctx.config.get('os_type', os_type)
+        os_type = ctx.config.get('os_type', None)
     except AttributeError:
         pass
 
-    return os_type
+    # if os_type is None, return the default of ubuntu
+    return os_type or "ubuntu"
 
 
 def get_distro_version(ctx):

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1154,26 +1154,16 @@ def get_distro(ctx):
     """
     Get the name of the distro that we are using (usually the os_type).
     """
-    os_type = None
+    # ubuntu is our default distro choice
+    os_type = "ubuntu"
     if ctx.os_type:
         return ctx.os_type
 
     try:
-        os_type = ctx.config.get('os_type', None)
+        os_type = ctx.config.get('os_type', os_type)
     except AttributeError:
         pass
-    # next, look for an override in the downburst config for os_type
-    # FIXME: checking the downburst config for distro shouldn't be needed
-    # as it's only used in provision.create_if_vm and that function performs
-    # this check again while building the config for downburst. Leaving it
-    # here for now until we can fully investigate and test it's removal.
-    try:
-        os_type = ctx.config['downburst'].get('distro', os_type)
-    except (KeyError, AttributeError):
-        pass
-    if os_type is None:
-        # default to ubuntu if we can't find the os_type anywhere else
-        return "ubuntu"
+
     return os_type
 
 
@@ -1197,10 +1187,7 @@ def get_distro_version(ctx):
         os_version = ctx.config.get('os_version', default_os_version[distro])
     except AttributeError:
         os_version = default_os_version[distro]
-    try:
-        return ctx.config['downburst'].get('distroversion', os_version)
-    except (KeyError, AttributeError):
-        return os_version
+    return os_version
 
 
 def get_multi_machine_types(machinetype):

--- a/teuthology/test/test_get_distro.py
+++ b/teuthology/test/test_get_distro.py
@@ -40,3 +40,8 @@ class TestGetDistro(object):
         self.fake_ctx.os_type = None
         distro = get_distro(self.fake_ctx)
         assert distro == 'ubuntu'
+
+    def test_config_os_type_is_none(self):
+        self.fake_ctx.config["os_type"] = None
+        distro = get_distro(self.fake_ctx)
+        assert distro == 'ubuntu'

--- a/teuthology/test/test_get_distro.py
+++ b/teuthology/test/test_get_distro.py
@@ -35,11 +35,6 @@ class TestGetDistro(object):
         distro = get_distro(self.fake_ctx)
         assert distro == 'centos'
 
-    def test_teuth_config_downburst(self):
-        self.fake_ctx.config = {'downburst' : {'distro': 'sles'}}
-        distro = get_distro(self.fake_ctx)
-        assert distro == 'sles'
-
     def test_no_config_or_os_type(self):
         self.fake_ctx = Mock()
         self.fake_ctx.os_type = None

--- a/teuthology/test/test_get_distro_version.py
+++ b/teuthology/test/test_get_distro_version.py
@@ -34,19 +34,14 @@ class TestGetDistroVersion(object):
         distroversion = get_distro_version(self.fake_ctx)
         assert distroversion == '13.04'
 
-    def test_teuth_config_downburst_version(self):
-        #Argument takes precidence
-        self.fake_ctx.os_version = '13.10'
-        self.fake_ctx.config = {'downburst' : {'distroversion': '13.04'}}
-        distroversion = get_distro_version(self.fake_ctx)
-        assert distroversion == '13.10'
-
     def test_teuth_config_noarg_version(self):
         self.fake_ctx_noarg.config = {'os_version': '13.04'}
         distroversion = get_distro_version(self.fake_ctx_noarg)
         assert distroversion == '13.04'
 
-    def test_teuth_config_downburst_noarg_version(self):
-        self.fake_ctx_noarg.config = {'downburst' : {'distroversion': '13.04'}}
-        distroversion = get_distro_version(self.fake_ctx_noarg)
+    def test_no_teuth_config(self):
+        self.fake_ctx = Mock()
+        self.fake_ctx.os_type = None
+        self.fake_ctx.os_version = '13.04'
+        distroversion = get_distro_version(self.fake_ctx)
         assert distroversion == '13.04'


### PR DESCRIPTION
We don't think this is being used anymore so we're gonna deprecate this feature and remove the unused code.

See, http://tracker.ceph.com/issues/10625