### PR TITLE
Add a label to run.run

### DIFF
--- a/teuthology/exceptions.py
+++ b/teuthology/exceptions.py
@@ -33,16 +33,21 @@ class CommandFailedError(Exception):
     """
     Exception thrown on command failure
     """
-    def __init__(self, command, exitstatus, node=None):
+    def __init__(self, command, exitstatus, node=None, label=None):
         self.command = command
         self.exitstatus = exitstatus
         self.node = node
+        self.label = label
 
     def __str__(self):
-        return "Command failed on {node} with status {status}: {cmd!r}".format(
+        prefix = "Command failed"
+        if self.label:
+            prefix = "Command failed ({label})".format(label=self.label)
+        return "{prefix} on {node} with status {status}: {cmd!r}".format(
             node=self.node,
             status=self.exitstatus,
             cmd=self.command,
+            prefix=prefix,
             )
 
 

--- a/teuthology/task/tests.py
+++ b/teuthology/task/tests.py
@@ -1,0 +1,53 @@
+"""
+A place to put various testing functions for teuthology. Maybe at some point we
+can turn this into a proper test suite of sorts.
+"""
+import logging
+
+from functools import wraps
+
+from teuthology.exceptions import CommandFailedError
+
+log = logging.getLogger(__name__)
+
+
+def test(f):
+    @wraps(f)
+    def func(*args, **kwargs):
+        try:
+            log.info("running {name}...".format(name=f.func_name))
+            f(*args, **kwargs)
+        except AssertionError:
+            log.error("***** FAILED")
+            args[0].summary["status"] = "fail"
+        except Exception:
+            log.error("***** ERROR")
+            args[0].summary["status"] = "fail"
+        else:
+            log.info("***** PASSED")
+
+    return func
+
+
+@test
+def test_command_failed_label(ctx, config):
+    result = ""
+    try:
+        force_command_failure(ctx, config)
+    except CommandFailedError as e:
+        result = str(e)
+
+    assert "working as expected" in result
+
+
+def force_command_failure(ctx, config):
+    ctx.cluster.run(
+        args=["python", "-c", "assert False"],
+        label="working as expected, nothing to see here"
+    )
+
+
+def task(ctx, config):
+    # TODO: find a way to auto discover test functions in this file
+    # and execute them
+    test_command_failed_label(ctx, config)


### PR DESCRIPTION
With this feature we can label any remote calls we perform.  If the command fails during execution it'll print out the label so it's more apparent when looking at log output what the initial purpose of the command being ran was.  This can help us to determine if a job failure is environmental, a teuthology failure or a legit ceph test failure.  Of course, it depends on the writer of the test to properly use the new label kwarg.  See, http://tracker.ceph.com/issues/10699

Also, I've started a simple testing task I used to make sure this feature was working correctly.  I've got another branch that uses pytest to autodiscover tests in this new task but I thought that'd be best in another PR.

Here's sample output from a test run of this branch.

```
2015-02-03 10:04:25,981.981 INFO:teuthology.run_tasks:Running task tests...
2015-02-03 10:04:25,982.982 INFO:teuthology.task.tests:running test_command_failed_label...
2015-02-03 10:04:25,983.983 INFO:teuthology.orchestra.run.magna067:Running (working as expected, nothing to see here): "python -c 'assert False'"
2015-02-03 10:04:26,095.095 INFO:teuthology.orchestra.run.magna067.stderr:Traceback (most recent call last):
2015-02-03 10:04:26,096.096 INFO:teuthology.orchestra.run.magna067.stderr:  File "<string>", line 1, in <module>
2015-02-03 10:04:26,096.096 INFO:teuthology.orchestra.run.magna067.stderr:AssertionError
2015-02-03 10:04:26,098.098 INFO:teuthology.task.tests:***** PASSED
2015-02-03 10:04:26,098.098 INFO:teuthology.run_tasks:Running task tests.force_command_failure...
2015-02-03 10:04:26,098.098 INFO:teuthology.orchestra.run.magna067:Running (working as expected, nothing to see here): "python -c 'assert False'"
2015-02-03 10:04:26,146.146 INFO:teuthology.orchestra.run.magna067.stderr:Traceback (most recent call last):
2015-02-03 10:04:26,146.146 INFO:teuthology.orchestra.run.magna067.stderr:  File "<string>", line 1, in <module>
2015-02-03 10:04:26,147.147 INFO:teuthology.orchestra.run.magna067.stderr:AssertionError
2015-02-03 10:04:26,148.148 ERROR:teuthology.run_tasks:Saw exception from tasks.
Traceback (most recent call last):
  File "/home/andrewschoen/teuthology/teuthology/run_tasks.py", line 53, in run_tasks
    manager = run_one_task(taskname, ctx=ctx, config=config)
  File "/home/andrewschoen/teuthology/teuthology/run_tasks.py", line 41, in run_one_task
    return fn(**kwargs)
  File "/home/andrewschoen/teuthology/teuthology/task/tests.py", line 46, in force_command_failure
    label="working as expected, nothing to see here"
  File "/home/andrewschoen/teuthology/teuthology/orchestra/cluster.py", line 64, in run
    return [remote.run(**kwargs) for remote in remotes]
  File "/home/andrewschoen/teuthology/teuthology/orchestra/remote.py", line 128, in run
    r = self._runner(client=self.ssh, name=self.shortname, **kwargs)
  File "/home/andrewschoen/teuthology/teuthology/orchestra/run.py", line 378, in run
    r.wait()
  File "/home/andrewschoen/teuthology/teuthology/orchestra/run.py", line 114, in wait
    label=self.label)
CommandFailedError: Command failed on magna067 with status 1: 'working as expected, nothing to see here'
2015-02-03 10:04:26,152.152 WARNING:teuthology.run_tasks:Saw failure during task execution, going into interactive mode...
```
