### PR TITLE
add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+    - 2.7
+
+install:
+    - pip install tox
+
+script: tox -rv


### PR DESCRIPTION
This will allow Travis CI to run tox to check for test failures.

This should allow us to avoid depending on Jenkins to test pull requests.