### PR TITLE
Adds a machine_type property to orchestra.remote.Remote

### DIFF
--- a/teuthology/lockstatus.py
+++ b/teuthology/lockstatus.py
@@ -1,7 +1,10 @@
 import requests
 import os
+import logging
 from .config import config
 from .misc import canonicalize_hostname
+
+log = logging.getLogger(__name__)
 
 
 def get_status(name):
@@ -11,4 +14,6 @@ def get_status(name):
     success = response.ok
     if success:
         return response.json()
+    log.warning(
+        "Failed to query lock server for status of {name}".format(name=name))
     return None

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -82,6 +82,15 @@ class Remote(object):
         return self._hostname
 
     @property
+    def machine_type(self):
+        if not getattr(self, '_machine_type', None):
+            remote_info = ls.get_status(self.hostname)
+            if not remote_info:
+                return None
+            self._machine_type = remote_info.get("machine_type", None)
+        return self._machine_type
+
+    @property
     def shortname(self):
         if self._shortname is None:
             self._shortname = self.hostname.split('.')[0]

--- a/teuthology/task/tests/test_locking.py
+++ b/teuthology/task/tests/test_locking.py
@@ -1,5 +1,4 @@
 import pytest
-import re
 
 
 class TestLocking(object):
@@ -21,7 +20,4 @@ class TestLocking(object):
     def test_correct_machine_type(self, ctx, config):
         machine_type = ctx.machine_type
         for remote in ctx.cluster.remotes.iterkeys():
-            # gotta be a better way to get machine_type
-            # if not, should we move this to Remote?
-            remote_type = re.sub("[0-9]", "", remote.shortname)
-            assert remote_type in machine_type
+            assert remote.machine_type in machine_type


### PR DESCRIPTION
There is also some minor test clean up and I made the existing machine_type test use the new property.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>