### PR TITLE
Make pytest capture stdout when running the tests task

### DIFF
--- a/teuthology/task/tests/__init__.py
+++ b/teuthology/task/tests/__init__.py
@@ -76,7 +76,7 @@ def task(ctx, config):
     """
     status = pytest.main(
         args=[
-            '-s', '-q',
+            '-q',
             '--pyargs', __name__
         ],
         plugins=[TeuthologyContextPlugin(ctx, config)]


### PR DESCRIPTION
This makes the logs easier to read.

With ``-s``:

```
2015-02-11T17:17:24.966 INFO:teuthology.run_tasks:Running task tests...
2015-02-11T17:17:25.106 INFO:teuthology.task.tests:test_locking:TestLocking.test_correct_os_type Skipped: os_type was not defined
2015-02-11T17:17:25.109 INFO:teuthology.task.tests:test_locking:TestLocking.test_correct_os_version Skipped: os_version was not defined
2015-02-11T17:17:25.173 INFO:teuthology.task.tests:test_locking:TestLocking.test_correct_machine_type Passed
2015-02-11T17:17:25.176 INFO:teuthology.orchestra.run.magna064:Running (working as expected, nothing to see here): "python -c 'assert False'"
2015-02-11T17:17:25.205 INFO:teuthology.orchestra.run.magna064.stderr:Traceback (most recent call last):
2015-02-11T17:17:25.205 INFO:teuthology.orchestra.run.magna064.stderr:  File "<string>", line 1, in <module>
2015-02-11T17:17:25.205 INFO:teuthology.orchestra.run.magna064.stderr:AssertionError
2015-02-11T17:17:25.207 INFO:teuthology.task.tests:test_run:TestRun.test_command_failed_label Passed
2015-02-11T17:17:25.209 INFO:teuthology.orchestra.run.magna064:Running: "python -c 'assert False'"
2015-02-11T17:17:25.301 INFO:teuthology.orchestra.run.magna064.stderr:Traceback (most recent call last):
2015-02-11T17:17:25.301 INFO:teuthology.orchestra.run.magna064.stderr:  File "<string>", line 1, in <module>
2015-02-11T17:17:25.301 INFO:teuthology.orchestra.run.magna064.stderr:AssertionError
2015-02-11T17:17:25.303 INFO:teuthology.task.tests:test_run:TestRun.test_command_failed_no_label Passed
2015-02-11T17:17:25.305 INFO:teuthology.orchestra.run.magna064:Running: 'python -c \'print \'"\'"\'hi\'"\'"\'\''
2015-02-11T17:17:25.400 INFO:teuthology.task.tests:test_run:TestRun.test_command_success Passed
2015-02-11T17:17:25.401 INFO:teuthology.task.tests:OK. All tests passed!
```

Without ``-s``:

```
2015-02-11 17:20:57,786.786 INFO:teuthology.run_tasks:Running task tests...
2015-02-11 17:20:57,927.927 INFO:teuthology.task.tests:test_locking:TestLocking.test_correct_os_type Skipped: os_type was not defined
2015-02-11 17:20:57,930.930 INFO:teuthology.task.tests:test_locking:TestLocking.test_correct_os_version Skipped: os_version was not defined
2015-02-11 17:20:57,954.954 INFO:teuthology.task.tests:test_locking:TestLocking.test_correct_machine_type Passed
2015-02-11 17:20:58,030.030 INFO:teuthology.task.tests:test_run:TestRun.test_command_failed_label Passed
2015-02-11 17:20:58,105.105 INFO:teuthology.task.tests:test_run:TestRun.test_command_failed_no_label Passed
2015-02-11 17:20:58,179.179 INFO:teuthology.task.tests:test_run:TestRun.test_command_success Passed
2015-02-11 17:20:58,181.181 INFO:teuthology.task.tests:OK. All tests passed!
```
