### PR TITLE
Safer vps unlocking

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -427,13 +427,14 @@ def unlock_many(names, user):
     return response.ok
 
 
-def unlock_one(ctx, name, user=None):
+def unlock_one(ctx, name, user=None, description=None):
     if user is None:
         user = misc.get_user()
     name = misc.canonicalize_hostname(name, user=None)
-    if not provision.destroy_if_vm(ctx, name, user):
+    if not provision.destroy_if_vm(ctx, name, user, description):
         log.error('downburst destroy failed for %s', name)
-    request = dict(name=name, locked=False, locked_by=user, description=None)
+    request = dict(name=name, locked=False, locked_by=user,
+                   description=description)
     uri = os.path.join(config.lock_server, 'nodes', name, 'lock', '')
     response = requests.put(uri, json.dumps(request))
     success = response.ok

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -98,7 +98,7 @@ def create_if_vm(ctx, machine_name):
     return True
 
 
-def destroy_if_vm(ctx, machine_name, user=None):
+def destroy_if_vm(ctx, machine_name, user=None, description=None):
     """
     Use downburst to destroy a virtual machine
 
@@ -110,6 +110,10 @@ def destroy_if_vm(ctx, machine_name, user=None):
     if user is not None and user != status_info['locked_by']:
         log.error("Tried to destroy {node} as {as_user} but it is locked by {locked_by}".format(
             node=machine_name, as_user=user, locked_by=status_info['locked_by']))
+        return False
+    if description is not None and description != status_info['description']:
+        log.error("Tried to destroy {node} with description {desc_arg} but it is locked with description {desc_lock}".format(
+            node=machine_name, desc_arg=description, desc_lock=status_info['description']))
         return False
     phys_host = decanonicalize_hostname(status_info['vm_host']['name'])
     destroyMe = decanonicalize_hostname(machine_name)

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -167,7 +167,7 @@ def lock_machines(ctx, config):
                 get_status(ctx.summary) == 'pass':
             log.info('Unlocking machines...')
             for machine in ctx.config['targets'].iterkeys():
-                lock.unlock_one(ctx, machine, ctx.owner)
+                lock.unlock_one(ctx, machine, ctx.owner, ctx.archive)
 
 
 def save_config(ctx, config):


### PR DESCRIPTION
Previously we'd see things like this:
```
07:44:30 vpm011 locked by job 749579
07:44:32 downburst created vpm011 for job 749579
07:46:01 downburst destroyed vpm011 for job 749584
07:46:02 vpm011 unlocked by job 749584
07:46:03 vpm011 locked by job 749554
07:46:05 downburst created vpm011 for job 749554
07:46:16 job 749579 lost connection to vpm011
07:46:16 downburst destroyed vpm011 for job 749579
07:46:17 vpm011 unlocked by job 749579
```

It was because:
1. Before destroying a VM, teuthology didn't check to see if it had the same ``description`` on the lock server, or even if it had the same ``locked_by`` value
2. teuthology didn't pass the ``description`` the the lock server when unlocking
3. Paddles didn't even care about ``description``s when unlocking single nodes

3 is fixed by https://github.com/ceph/paddles/pull/52. 1 and 2 are fixed by this; if we try to destroy or unlock a VM that doesn't have matching ``locked_by`` and ``description`` values, each action will fail.