### PR TITLE
hadoop: remove parallel from import; fixes linter warning

### DIFF
--- a/teuthology/task/hadoop.py
+++ b/teuthology/task/hadoop.py
@@ -3,7 +3,6 @@ import contextlib
 import logging
 from teuthology import misc as teuthology
 from teuthology import contextutil
-from teuthology.parallel import parallel
 from ..orchestra import run
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Signed-off-by: Greg Farnum <gfarnum@redhat.com>

Sorry Zack! :(