### PR TITLE
Bug #10803: Try apt-get -f install to workaround nuke failure.

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -245,8 +245,9 @@ def dpkg_configure(ctx):
         proc = remote.run(
             args=[
                 'sudo', 'dpkg', '--configure', '-a',
-                run.Raw('&&'),
-                'sudo', 'apt-get', '-f', 'install',
+                run.Raw(';'),
+                'sudo', 'DEBIAN_FRONTEND=noninteractive',
+                'apt-get', '-y', '--force-yes', '-f', 'install',
                 run.Raw('||'),
                 ':',
             ],


### PR DESCRIPTION
Sometimes packages or dpkg gets in a weird state where a nuke will
fail to run and simply running an apt-get -f install on the
machine will fix things up so it can be nuked again. Currently
we only ran that being dependent on dpkg --configure completing
where as I changed it so it will still try apt-get -f install
to potentially require less manual intervention when cleaning up
machines. I kept the original behavior but adding some arguments
to insure it will not prompt you for a yes/no (like apt-get -f
install usually would do).

Signed-off-by: Sandon Van Ness <sandon@redhat.com>