### PR TITLE
lock.py: allow machines list for --brief

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -150,7 +150,7 @@ def main(ctx):
             '-f is only supported by --lock and --unlock'
     if machines:
         assert ctx.lock or ctx.unlock or ctx.list or ctx.list_targets \
-            or ctx.update, \
+            or ctx.update or ctx.brief, \
             'machines cannot be specified with that operation'
     else:
         assert ctx.num_to_lock or ctx.list or ctx.list_targets or \


### PR DESCRIPTION
There was never any reason not to.

Fixes: #11167
Signed-off-by: Dan Mick <dan.mick@redhat.com>