### PR TITLE
valgrind: ignore lttng warning on un-cleaned-up state

### DIFF
--- a/teuthology/task/valgrind.supp
+++ b/teuthology/task/valgrind.supp
@@ -235,3 +235,12 @@
 	...
 	fun:exit
 }
+{
+	lttng appears to not clean up state
+	Memcheck:Leak
+	...
+	fun:lttng_ust_baddr_statedump_init
+	fun:lttng_ust_init
+	fun:call_init.part.0
+	...
+}


### PR DESCRIPTION
This appears to have come from dca722ec7b2a7fc9214844ec92310074b5cb2faa,
which merged in support for use of lttng ust functions on fork. Valgrind
started warning on a Leak_StillReachable with lttng_ust_init in
the function call trace.

Hopefully this is specific enough that we don't mask out any other
lttng errors.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>