### PR TITLE
Refactor downburst provisioning

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -8,7 +8,6 @@ import collections
 import os
 import requests
 import urllib
-from distutils.spawn import find_executable
 
 import teuthology
 from . import misc
@@ -47,7 +46,7 @@ def get_distro_from_downburst():
                                  u'14.04(trusty)', u'utopic(utopic)'],
                      u'sles': [u'11-sp2'],
                      u'debian': [u'6.0', u'7.0']}
-    executable_cmd = find_executable('downburst')
+    executable_cmd = provision.downburst_executable()
     if not executable_cmd:
         log.warn("Downburst not found!")
         log.info('Using default values for supported os_type/os_version')

--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -617,7 +617,8 @@ def ssh_keyscan(hostnames):
 
     keys_dict = dict()
     for line in p.stderr.readlines():
-        if not line.startswith('#'):
+        line = line.strip()
+        if line and not line.startswith('#'):
             log.error(line)
     for line in p.stdout.readlines():
         host, key = line.strip().split(' ', 1)

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -129,7 +129,8 @@ def destroy_if_vm(ctx, machine_name, user=None, description=None):
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
     owt, err = p.communicate()
     if err:
-        log.error(err)
+        log.error("Error destroying {machine}: {msg}".format(
+            machine=machine_name, msg=err))
         return False
     else:
         log.info("%s destroyed: %s" % (machine_name, owt))

--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -84,17 +84,20 @@ def create_if_vm(ctx, machine_name):
                               'create', metadata, createMe],
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
         owt, err = p.communicate()
-        if err:
-            log.info("Downburst completed on %s: %s" %
-                     (machine_name, err))
-        else:
-            log.info("%s created: %s" % (machine_name, owt))
-        # If the guest already exists first destroy then re-create:
-        if 'exists' in err:
-            log.info("Guest files exist. Re-creating guest: %s" %
-                     (machine_name))
-            destroy_if_vm(ctx, machine_name)
-            create_if_vm(ctx, machine_name)
+        if p.returncode == 0:
+            log.info("Downburst created %s: %s" % (machine_name, owt.strip()))
+        elif err:
+            # If the guest already exists first destroy then re-create:
+            # FIXME there is a recursion-depth issue here.
+            if 'exists' in err:
+                log.info("Guest files exist. Re-creating guest: %s" %
+                         (machine_name))
+                destroy_if_vm(ctx, machine_name)
+                create_if_vm(ctx, machine_name)
+            else:
+                log.info("Downburst failed on %s: %s" % (machine_name,
+                                                         err.strip()))
+                return False
     return True
 
 

--- a/teuthology/test/test_provision.py
+++ b/teuthology/test/test_provision.py
@@ -1,0 +1,103 @@
+from mock import Mock, MagicMock, patch
+
+from teuthology import provision
+
+
+class TestDownburst(object):
+    def setup(self):
+        self.ctx = Mock()
+        self.ctx.os_type = 'rhel'
+        self.ctx.os_version = '7.0'
+        self.ctx.config = dict()
+        self.name = 'vpm999'
+        self.status = dict(
+            vm_host=dict(name='host999'),
+            is_vm=True,
+        )
+
+    def test_create_if_vm_success(self):
+        name = self.name
+        ctx = self.ctx
+        status = self.status
+
+        dbrst = provision.Downburst(name, ctx.os_type, ctx.os_version, status)
+        dbrst.create = MagicMock(name='create')
+        dbrst.create.return_value = True
+        dbrst._run_create = MagicMock(name='_run_create')
+        dbrst._run_create.return_value = True
+        dbrst.build_config = MagicMock(name='build_config')
+        dbrst.remove_config = MagicMock(name='remove_config')
+
+        result = provision.create_if_vm(ctx, name, dbrst)
+        assert result is True
+
+        dbrst.create.assert_called_once()
+        dbrst._run_create.assert_called_once()
+        dbrst.build_config.assert_called_once()
+        dbrst.remove_config.assert_called_once()
+
+    def test_destroy_if_vm_success(self):
+        name = self.name
+        ctx = self.ctx
+        status = self.status
+
+        dbrst = provision.Downburst(name, ctx.os_type, ctx.os_version, status)
+        dbrst.destroy = MagicMock(name='destroy')
+        dbrst.destroy.return_value = True
+
+        result = provision.destroy_if_vm(ctx, name, _downburst=dbrst)
+        assert result is True
+
+        dbrst.destroy.assert_called_once()
+
+    def test_destroy_if_vm_wrong_owner(self):
+        name = self.name
+        ctx = self.ctx
+        status = self.status
+        status['locked_by'] = 'user@a'
+
+        dbrst = provision.Downburst(name, ctx.os_type, ctx.os_version, status)
+        dbrst.destroy = MagicMock(name='destroy')
+        dbrst.destroy.return_value = True
+
+        result = provision.destroy_if_vm(ctx, name, user='user@b',
+                                         _downburst=dbrst)
+        assert result is False
+
+        dbrst.destroy.assert_called_once()
+
+    def test_destroy_if_vm_wrong_description(self):
+        name = self.name
+        ctx = self.ctx
+        status = self.status
+        status['description'] = 'desc_a'
+
+        dbrst = provision.Downburst(name, ctx.os_type, ctx.os_version, status)
+        dbrst.destroy = MagicMock(name='destroy')
+        dbrst.destroy.return_value = True
+
+        result = provision.destroy_if_vm(ctx, name, description='desc_b',
+                                         _downburst=dbrst)
+        assert result is False
+
+        dbrst.destroy.assert_called_once()
+
+    @patch('teuthology.provision.downburst_executable')
+    def test_create_fails_without_executable(self, m_exec):
+        name = self.name
+        ctx = self.ctx
+        status = self.status
+        m_exec.return_value = ''
+        dbrst = provision.Downburst(name, ctx.os_type, ctx.os_version, status)
+        result = dbrst.create()
+        assert result is False
+
+    @patch('teuthology.provision.downburst_executable')
+    def test_destroy_fails_without_executable(self, m_exec):
+        name = self.name
+        ctx = self.ctx
+        status = self.status
+        m_exec.return_value = ''
+        dbrst = provision.Downburst(name, ctx.os_type, ctx.os_version, status)
+        result = dbrst.destroy()
+        assert result is False


### PR DESCRIPTION
This allows for better logging, easier debugging, and a proper way to give up attempting to start up instances that are somehow broken. I also intend for it to serve as a model to follow when adding support for e.g. Cobbler reimaging and OpenStack provisioning.