### PR TITLE
Add timeouts to Remote connection functions

### DIFF
--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -37,7 +37,7 @@ def create_key(keytype, key):
         raise ValueError('keytype must be ssh-rsa or ssh-dsa')
 
 
-def connect(user_at_host, host_key=None, keep_alive=False,
+def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,
             _SSHClient=None, _create_key=None):
     """
     ssh connection routine.
@@ -45,6 +45,7 @@ def connect(user_at_host, host_key=None, keep_alive=False,
     :param user_at_host: user@host
     :param host_key: ssh key
     :param keep_alive: keep_alive indicator
+    :param timeout:    timeout in seconds
     :param _SSHClient: client, default is paramiko ssh client
     :param _create_key: routine to create a key (defaults to local reate_key)
     :return: ssh connection.
@@ -73,7 +74,7 @@ def connect(user_at_host, host_key=None, keep_alive=False,
     connect_args = dict(
         hostname=host,
         username=user,
-        timeout=60
+        timeout=timeout
     )
 
     ssh_config_path = os.path.expanduser("~/.ssh/config")

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -51,7 +51,7 @@ class Remote(object):
         self._host_key = host_key
         self.keep_alive = keep_alive
         self.console = console
-        self.ssh = ssh or self.connect()
+        self.ssh = ssh
 
     def connect(self):
         self.ssh = connection.connect(user_at_host=self.name,

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -326,6 +326,10 @@ class Remote(object):
         node['up'] = True
         return node
 
+    def __del__(self):
+        if self.ssh is not None:
+            self.ssh.close()
+
 
 def getShortName(name):
     """

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -53,10 +53,13 @@ class Remote(object):
         self.console = console
         self.ssh = ssh
 
-    def connect(self):
-        self.ssh = connection.connect(user_at_host=self.name,
-                                      host_key=self._host_key,
-                                      keep_alive=self.keep_alive)
+    def connect(self, timeout=None):
+        args = dict(user_at_host=self.name, host_key=self._host_key,
+                    keep_alive=self.keep_alive)
+        if timeout:
+            args['timeout'] = timeout
+
+        self.ssh = connection.connect(**args)
         return self.ssh
 
     def reconnect(self, timeout=None):
@@ -67,7 +70,7 @@ class Remote(object):
         if self.ssh is not None:
             self.ssh.close()
         if not timeout:
-            return self._reconnect()
+            return self._reconnect(timeout=timeout)
         start_time = time.time()
         elapsed_time = lambda: time.time() - start_time
         while elapsed_time() < timeout:
@@ -81,9 +84,9 @@ class Remote(object):
             time.sleep(sleep_val)
         return success
 
-    def _reconnect(self):
+    def _reconnect(self, timeout=None):
         try:
-            self.connect()
+            self.connect(timeout=timeout)
             return self.is_online
         except Exception as e:
             log.debug(e)

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -181,6 +181,7 @@ def get_initial_tasks(lock, config, machine_type):
     init_tasks.extend([
         {'internal.save_config': None},
         {'internal.check_lock': None},
+        {'internal.add_remotes': None},
         {'internal.connect': None},
         {'internal.push_inventory': None},
         {'internal.serialize_remote_roles': None},

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -280,8 +280,9 @@ def connect(ctx, config):
                 key = None
         except (AttributeError, KeyError):
             pass
-        remotes.append(
-            remote.Remote(name=t, host_key=key, keep_alive=True, console=None))
+        rem = remote.Remote(name=t, host_key=key, keep_alive=True)
+        rem.connect()
+        remotes.append(rem)
     ctx.cluster = cluster.Cluster()
     if 'roles' in ctx.config:
         for rem, roles in zip(remotes, ctx.config['roles']):

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -263,25 +263,22 @@ def timer(ctx, config):
         ctx.summary['duration'] = duration
 
 
-def connect(ctx, config):
+def add_remotes(ctx, config):
     """
-    Open a connection to a remote host.
+    Create a ctx.cluster object populated with remotes mapped to roles
     """
-    log.info('Opening connections...')
     remotes = []
     machs = []
     for name in ctx.config['targets'].iterkeys():
         machs.append(name)
     for t, key in ctx.config['targets'].iteritems():
         t = misc.canonicalize_hostname(t)
-        log.debug('connecting to %s', t)
         try:
             if ctx.config['sshkeys'] == 'ignore':
                 key = None
         except (AttributeError, KeyError):
             pass
         rem = remote.Remote(name=t, host_key=key, keep_alive=True)
-        rem.connect()
         remotes.append(rem)
     ctx.cluster = cluster.Cluster()
     if 'roles' in ctx.config:
@@ -293,6 +290,16 @@ def connect(ctx, config):
     else:
         for rem in remotes:
             ctx.cluster.add(rem, rem.name)
+
+
+def connect(ctx, config):
+    """
+    Connect to all remotes in ctx.cluster
+    """
+    log.info('Opening connections...')
+    for rem in ctx.cluster.remotes.iterkeys():
+        log.debug('connecting to %s', rem.name)
+        rem.connect()
 
 
 def push_inventory(ctx, config):


### PR DESCRIPTION
This PR also splits ``task.internal.connect()`` into two subtasks.

Both of these changes are needed to support the provisioning work I'm doing in other branches.