### PR TITLE
lock.py: Add '--json-query' to allow complex search for --list/--brief

### DIFF
--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -158,5 +158,17 @@ def parse_args():
         default=None,
         help='OS (distro) version such as "12.10"',
     )
+    parser.add_argument(
+        '--json-query',
+        default=None,
+        help=textwrap.dedent('''\
+            JSON fragment, explicitly given, or a file containing
+            JSON, containing a query for --list or --brief.
+            Example: teuthology-lock --list --all --json-query
+            '{"vm_host":{"name":"mira003.front.sepia.ceph.com"}'
+            will list all machines who have a vm_host entry
+            with a dictionary that contains at least the name key
+            with value mira003.front.sepia.ceph.com.'''),
+    )
 
     return parser.parse_args()

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1223,3 +1223,37 @@ def get_multi_machine_types(machinetype):
     if not machinetypes:
         machinetypes.append(machinetype)
     return machinetypes
+
+
+def is_in_dict(searchkey, searchval, d):
+    """
+    Test if searchkey/searchval are in dictionary.  searchval may
+    itself be a dict, in which case, recurse.  searchval may be
+    a subset at any nesting level (that is, all subkeys in searchval
+    must be found in d at the same level/nest position, but searchval
+    is not required to fully comprise d[searchkey]).
+
+    >>> is_in_dict('a', 'foo', {'a':'foo', 'b':'bar'})
+    True
+
+    >>> is_in_dict(
+    ...     'a',
+    ...     {'sub1':'key1', 'sub2':'key2'},
+    ...     {'a':{'sub1':'key1', 'sub2':'key2', 'sub3':'key3'}}
+    ... )
+    True
+
+    >>> is_in_dict('a', 'foo', {'a':'bar', 'b':'foo'})
+    False
+
+    >>> is_in_dict('a', 'foo', {'a':{'a': 'foo'}})
+    False
+    """
+    val = d.get(searchkey, None)
+    if isinstance(val, dict) and isinstance(searchval, dict):
+        for foundkey, foundval in searchval.iteritems():
+            if not is_in_dict(foundkey, foundval, val):
+                return False
+        return True
+    else:
+        return searchval == val

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -150,3 +150,20 @@ class TestMergeConfigs(object):
     def test_invalid_b_deep_merge(self):
         with pytest.raises(AssertionError):
             misc.deep_merge({"a": "b"}, "invalid")
+
+
+class TestIsInDict(object):
+    def test_simple_membership(self):
+        assert misc.is_in_dict('a', 'foo', {'a':'foo', 'b':'bar'})
+
+    def test_dict_membership(self):
+        assert misc.is_in_dict(
+            'a', {'sub1':'key1', 'sub2':'key2'},
+            {'a':{'sub1':'key1', 'sub2':'key2', 'sub3':'key3'}}
+        )
+
+    def test_simple_nonmembership(self):
+        assert not misc.is_in_dict('a', 'foo', {'a':'bar', 'b':'foo'})
+
+    def test_nonmembership_with_presence_at_lower_level(self):
+        assert not misc.is_in_dict('a', 'foo', {'a':{'a': 'foo'}})


### PR DESCRIPTION
--json-query <file> or --json-query <string> allows filtering search
results conveniently; the JSON must be a dictionary that is a subset
of the lock record to be matched.  The reason this was invented:
Find all VPSes on a particular vmhost:

teuthology-lock --list --all --json-query \
	'{"vm_host":{"name":"mira003.front.sepia.ceph.com"}}'

Signed-off-by: Dan Mick <dan.mick@redhat.com>