### PR TITLE
include E9 errors for flake8 runs in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ basepython=python2.7
 [testenv:flake8]
 deps=
   flake8
-commands=flake8 --select=F {posargs:teuthology scripts}
+commands=flake8 --select=F,E9 {posargs:teuthology scripts}
 
 [testenv:docs]
 basepython=python


### PR DESCRIPTION
What this does is the ability to catch SyntaxErrors with flake8 when tox runs:

    flake8 --select=F,E9 kernel.py
    kernel.py:645:64: E901 SyntaxError: EOL while scanning string literal

Reference issue: http://tracker.ceph.com/issues/11491