### PR TITLE
Don't assert status==up when using internal.check_lock.

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -497,7 +497,9 @@ def nuke_helper(ctx, should_unlock):
             log.info('console ready on %s' % cname)
 
     if ctx.check_locks:
-        check_lock(ctx, None)
+        # does not check to ensure if the node is 'up'
+        # we want to be able to nuke a downed node
+        check_lock(ctx, None, check_up=False)
     add_remotes(ctx, None)
     connect(ctx, None)
 

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -184,7 +184,7 @@ def save_config(ctx, config):
         with file(os.path.join(ctx.archive, 'config.yaml'), 'w') as f:
             yaml.safe_dump(ctx.config, f, default_flow_style=False)
 
-def check_lock(ctx, config):
+def check_lock(ctx, config, check_up=True):
     """
     Check lock status of remote machines.
     """
@@ -197,7 +197,10 @@ def check_lock(ctx, config):
         log.debug('machine status is %s', repr(status))
         assert status is not None, \
             'could not read lock status for {name}'.format(name=machine)
-        assert status['up'], 'machine {name} is marked down'.format(name=machine)
+        if check_up:
+            assert status['up'], 'machine {name} is marked down'.format(
+                name=machine
+            )
         assert status['locked'], \
             'machine {name} is not locked'.format(name=machine)
         assert status['locked_by'] == ctx.owner, \


### PR DESCRIPTION
internal.check_lock seems to only be used by nuke and it's sometimes helpful
to be able to nuke a node that is marked down.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>