### PR TITLE
In add_remote method, first evaluate if the user has passed any value

### DIFF
--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -272,10 +272,13 @@ def add_remotes(ctx, config):
     """
     remotes = []
     machs = []
+    user = teuth_config.test_user
+    if not user:
+        user = None
     for name in ctx.config['targets'].iterkeys():
         machs.append(name)
     for t, key in ctx.config['targets'].iteritems():
-        t = misc.canonicalize_hostname(t)
+        t = misc.canonicalize_hostname(t, user)
         try:
             if ctx.config['sshkeys'] == 'ignore':
                 key = None


### PR DESCRIPTION
In add_remote method, first evaluate if the user has passed any
test_user from .teuthology.yaml file. If yes, then pass that test_user
as the second parameter to misc.canonicalize_hostname method else
pass the default test_user which would be ubuntu.

Signed-off-by: Kapil Sharma ksharma@suse.com