### PR TITLE
Install scratch built kernels from koji

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -141,6 +141,7 @@ class TeuthologyConfig(YamlConfig):
         'watchdog_interval': 120,
         'kojihub_url': 'http://koji.fedoraproject.org/kojihub',
         'kojiroot_url': 'http://kojipkgs.fedoraproject.org/packages',
+        'koji_task_url': 'https://kojipkgs.fedoraproject.org/work/',
     }
 
     def __init__(self, yaml_path=None):

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -4,6 +4,27 @@ from mock import patch, Mock
 
 from teuthology import packaging
 
+KOJI_TASK_RPMS_MATRIX = [
+    ('tasks/6745/9666745/kernel-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel'),
+    ('tasks/6745/9666745/kernel-modules-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-modules'),
+    ('tasks/6745/9666745/kernel-tools-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-tools'),
+    ('tasks/6745/9666745/kernel-tools-libs-devel-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-tools-libs-devel'),
+    ('tasks/6745/9666745/kernel-headers-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-headers'),
+    ('tasks/6745/9666745/kernel-tools-debuginfo-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-tools-debuginfo'),
+    ('tasks/6745/9666745/kernel-debuginfo-common-x86_64-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-debuginfo-common-x86_64'),
+    ('tasks/6745/9666745/perf-debuginfo-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'perf-debuginfo'),
+    ('tasks/6745/9666745/kernel-modules-extra-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-modules-extra'),
+    ('tasks/6745/9666745/kernel-tools-libs-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-tools-libs'),
+    ('tasks/6745/9666745/kernel-core-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-core'),
+    ('tasks/6745/9666745/kernel-debuginfo-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-debuginfo'),
+    ('tasks/6745/9666745/python-perf-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'python-perf'),
+    ('tasks/6745/9666745/kernel-devel-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'kernel-devel'),
+    ('tasks/6745/9666745/python-perf-debuginfo-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'python-perf-debuginfo'),
+    ('tasks/6745/9666745/perf-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm', 'perf'),
+]
+
+KOJI_TASK_RPMS = [rpm[0] for rpm in KOJI_TASK_RPMS_MATRIX]
+
 
 class TestPackaging(object):
 
@@ -178,6 +199,24 @@ class TestPackaging(object):
         with pytest.raises(RuntimeError):
             packaging.get_koji_task_result(1, m_remote, m_ctx)
 
+    @patch("teuthology.packaging.config")
+    def test_get_koji_task_rpm_info_success(self, m_config):
+        m_config.koji_task_url = "http://kojihub.com/work"
+        expected = dict(
+            base_url="http://kojihub.com/work/tasks/6745/9666745/",
+            version="4.1.0-0.rc2.git2.1.fc23.x86_64",
+            rpm_name="kernel-4.1.0-0.rc2.git2.1.fc23.x86_64.rpm",
+            package_name="kernel",
+        )
+        result = packaging.get_koji_task_rpm_info('kernel', KOJI_TASK_RPMS)
+        assert expected == result
+
+    @patch("teuthology.packaging.config")
+    def test_get_koji_task_rpm_info_fail(self, m_config):
+        m_config.koji_task_url = "http://kojihub.com/work"
+        with pytest.raises(RuntimeError):
+            packaging.get_koji_task_rpm_info('ceph', KOJI_TASK_RPMS)
+
     def test_get_package_version_deb_found(self):
         remote = Mock()
         remote.os.package_type = "deb"
@@ -236,3 +275,7 @@ class TestPackaging(object):
         remote.run.return_value = proc
         result = packaging.get_package_version(remote, "httpd")
         assert result is None
+
+    @pytest.mark.parametrize("input, expected", KOJI_TASK_RPMS_MATRIX)
+    def test_get_koji_task_result_package_name(self, input, expected):
+        assert packaging._get_koji_task_result_package_name(input) == expected


### PR DESCRIPTION
This allows us to install kernels from koji that have been scratch built, meaning we must install from a taskID not a buildID.

For reference: http://tracker.ceph.com/issues/11552