### PR TITLE
tests: set HOME env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+env: HOME=/home/travis
+
 language: python
 python:
     - 2.7

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = docs, py27, py27-integration, flake8
 
 [testenv:py27]
+passenv = HOME
 sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt
@@ -14,6 +15,7 @@ deps=
 commands=py.test --cov=teuthology --cov-report=term -v {posargs:teuthology scripts}
 
 [testenv:py27-integration]
+passenv = HOME
 sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Travis CI's docs say that HOME is supposed to be set to `/home/travis` by default, however, it also says "do not depend on this value": http://docs.travis-ci.com/user/ci-environment/

Teuthology depends on the $HOME environment variable being set, and the test suites that depended on this recently failed to build in Travis CI.

Set the var explicitly so it's always available for the tests.