### PR TITLE
Enablement for chef -> ansible transition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ docopt
 psutil >= 2.1.0
 configparser
 pytest
+ansible==1.9.1
 
 # Test Dependencies
 # nose >=1.0.0

--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -4,9 +4,19 @@ from .orchestra import monkey
 monkey.patch_all()
 
 import logging
+import os
+import sys
 
 
 __version__ = '0.1.0'
+
+
+# If we are running inside a virtualenv, ensure we have its 'bin' directory in
+# our PATH. This doesn't happen automatically if scripts are called without
+# first activating the virtualenv.
+exec_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
+if os.path.split(exec_dir)[-1] == 'bin' and exec_dir not in os.environ['PATH']:
+    os.environ['PATH'] = ':'.join((exec_dir, os.environ['PATH']))
 
 # We don't need to see log entries for each connection opened
 logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -7,6 +7,7 @@ import yaml
 from cStringIO import StringIO
 from tempfile import NamedTemporaryFile
 
+from teuthology.config import config as teuth_config
 from teuthology.exceptions import CommandFailedError
 from teuthology.repo_utils import fetch_repo
 
@@ -242,4 +243,24 @@ class Ansible(Task):
         super(Ansible, self).teardown()
 
 
+class CephLab(Ansible):
+    __doc__ = """
+    A very simple subclass of Ansible that defaults to:
+
+    - ansible:
+        repo: {git_base}ceph-cm-ansible.git
+        playbook: cephlab.yml
+    """.format(git_base=teuth_config.ceph_git_base_url)
+
+    def __init__(self, ctx, config):
+        config = config or dict()
+        if 'playbook' not in config:
+            config['playbook'] = 'cephlab.yml'
+        if 'repo' not in config:
+            config['repo'] = os.path.join(teuth_config.ceph_git_base_url,
+                                          'ceph-cm-ansible.git')
+        super(CephLab, self).__init__(ctx, config)
+
+
 task = Ansible
+cephlab = CephLab

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import requests
 import os
@@ -224,8 +225,12 @@ class Ansible(Task):
         Assemble the list of args to be executed
         """
         fqdns = [r.hostname for r in self.cluster.remotes.keys()]
+        # Assume all remotes use the same username
+        user = self.cluster.remotes.keys()[0].user
+        extra_vars = dict(ansible_ssh_user=user)
         args = [
             'ansible-playbook', '-v',
+            "--extra-vars='%s'" % json.dumps(extra_vars),
             '-i', self.inventory,
             '--limit', ','.join(fqdns),
             self.playbook_file.name,

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -161,7 +161,7 @@ class Ansible(Task):
         we're using an existing file.
         """
         hosts = self.cluster.remotes.keys()
-        hostnames = [remote.name.split('@')[-1] for remote in hosts]
+        hostnames = [remote.hostname for remote in hosts]
         hostnames.sort()
         hosts_str = '\n'.join(hostnames + [''])
         hosts_file = NamedTemporaryFile(prefix="teuth_ansible_hosts_",
@@ -223,7 +223,7 @@ class Ansible(Task):
         """
         Assemble the list of args to be executed
         """
-        fqdns = [r.name.split('@')[-1] for r in self.cluster.remotes.keys()]
+        fqdns = [r.hostname for r in self.cluster.remotes.keys()]
         args = [
             'ansible-playbook', '-v',
             '-i', self.inventory,

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -99,7 +99,7 @@ class Ansible(Task):
         Locate the repo we're using; cloning it from a remote repo if necessary
         """
         repo = self.config.get('repo', '.')
-        if repo.startswith(('http://', 'https://', 'git@')):
+        if repo.startswith(('http://', 'https://', 'git@', 'git://')):
             repo_path = fetch_repo(
                 repo,
                 self.config.get('branch', 'master'),

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -39,7 +39,9 @@ class Ansible(Task):
 
     Required configuration parameters:
         playbook:   Required; can either be a list of plays, or a path/URL to a
-                    playbook
+                    playbook. In the case of a path, it may be relative to the
+                    repo's on-disk location (if a repo is provided), or
+                    teuthology's working directory.
 
     Optional configuration parameters:
         repo:       A path or URL to a repo (defaults to '.'). Given a repo
@@ -122,6 +124,13 @@ class Ansible(Task):
         elif isinstance(playbook, str):
             try:
                 playbook_path = os.path.expanduser(playbook)
+                if not playbook_path.startswith('/'):
+                    # If the path is not absolute at this point, look for the
+                    # playbook in the repo dir. If it's not there, we assume
+                    # the path is relative to the working directory
+                    pb_in_repo = os.path.join(self.repo_path, playbook_path)
+                    if os.path.exists(pb_in_repo):
+                        playbook_path = pb_in_repo
                 self.playbook_file = file(playbook_path)
                 playbook_yaml = yaml.safe_load(self.playbook_file)
                 self.playbook = playbook_yaml

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -5,12 +5,12 @@ from mock import patch, DEFAULT, Mock
 from pytest import raises
 from StringIO import StringIO
 
-from teuthology.config import FakeNamespace
+from teuthology.config import config, FakeNamespace
 from teuthology.exceptions import CommandFailedError
 from teuthology.orchestra.cluster import Cluster
 from teuthology.orchestra.remote import Remote
 from teuthology.task import ansible
-from teuthology.task.ansible import Ansible
+from teuthology.task.ansible import Ansible, CephLab
 
 from . import TestTask
 
@@ -308,3 +308,32 @@ class TestAnsibleTask(TestTask):
         with patch.object(ansible.os, 'remove') as m_remove:
             task.teardown()
             assert m_remove.called_once_with('fake')
+
+
+class TestCephLabTask(TestTask):
+    def setup(self):
+        self.ctx = FakeNamespace()
+        self.ctx.cluster = Cluster()
+        self.ctx.cluster.add(Remote('remote1'), ['role1'])
+        self.ctx.cluster.add(Remote('remote2'), ['role2'])
+        self.ctx.config = dict()
+
+    @patch('teuthology.task.ansible.fetch_repo')
+    def test_find_repo_http(self, m_fetch_repo):
+        repo = os.path.join(config.ceph_git_base_url,
+                            'ceph-cm-ansible.git')
+        task = CephLab(self.ctx, dict())
+        task.find_repo()
+        m_fetch_repo.assert_called_once_with(repo, 'master')
+
+    def test_playbook_file(self):
+        fake_playbook = [dict(fake_playbook=True)]
+        fake_playbook_obj = StringIO(yaml.safe_dump(fake_playbook))
+        playbook = 'cephlab.yml'
+        fake_playbook_obj.name = playbook
+        task = CephLab(self.ctx, dict())
+        task.repo_path = '/tmp/fake/repo'
+        with patch('teuthology.task.ansible.file', create=True) as m_file:
+            m_file.return_value = fake_playbook_obj
+            task.get_playbook()
+        assert task.playbook_file.name == playbook

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -19,8 +19,8 @@ class TestAnsibleTask(TestTask):
     def setup(self):
         self.ctx = FakeNamespace()
         self.ctx.cluster = Cluster()
-        self.ctx.cluster.add(Remote('remote1'), ['role1'])
-        self.ctx.cluster.add(Remote('remote2'), ['role2'])
+        self.ctx.cluster.add(Remote('user@remote1'), ['role1'])
+        self.ctx.cluster.add(Remote('user@remote2'), ['role2'])
         self.ctx.config = dict()
 
     def test_setup(self):

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -67,6 +67,16 @@ class TestAnsibleTask(TestTask):
         assert task.repo_path == os.path.expanduser(task_config['repo'])
 
     @patch('teuthology.task.ansible.fetch_repo')
+    def test_find_repo_path_remote(self, m_fetch_repo):
+        task_config = dict(
+            repo='git://fake_host/repo.git',
+        )
+        m_fetch_repo.return_value = '/tmp/repo'
+        task = Ansible(self.ctx, task_config)
+        task.find_repo()
+        assert task.repo_path == os.path.expanduser('/tmp/repo')
+
+    @patch('teuthology.task.ansible.fetch_repo')
     def test_find_repo_http(self, m_fetch_repo):
         task_config = dict(
             repo='http://example.com/my/repo',


### PR DESCRIPTION
This doesn't move us over yet, but adds all of the (teuthology-side) tweaks we need to make the real transition.