### PR TITLE
kernel: recognize flavor key

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -69,7 +69,8 @@ def normalize_config(ctx, config):
     """
     if config is None or \
             len(filter(lambda x: x in ['tag', 'branch', 'sha1', 'kdb',
-                                       'deb', 'rpm', 'koji', 'koji_task'],
+                                       'deb', 'rpm', 'koji', 'koji_task',
+                                       'flavor'],
                        config.keys())) == len(config.keys()):
         new_config = {}
         if config is None:


### PR DESCRIPTION
Since commit 7da76fa78f63 ("Use kernel_flavor when polling
gitbuilders"), teuthology-suite appends 'flavor: basic' to kernel task
config.  This broke all scheduled kernel suites, because
normalize_config() treats unknown keys as role types and when it
doesn't find a valid one it bails and returns {}, which means "do
nothing".

Fix this temporarily by adding flavor to a list of recognized keys.
This is wrong a bunch of levels, but it fixes a regression while
sticking to the way normalize_config() currently works.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>