### PR TITLE
docker based integration tests

### DIFF
--- a/docker-integration/delegate.py
+++ b/docker-integration/delegate.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015 <contact@redhat.com>
+#
+# Author: Loic Dachary <loic@dachary.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import logging
+import subprocess
+import sys
+
+logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s',
+                    level=logging.DEBUG)
+
+
+def run(os):
+    name = 'teuthology-' + os
+    script = """\
+user_id=$(id -u) perl -p -e 's/%%(\w+)%%/$ENV{$1}/g' < docker-integration/{os}.dockerfile > docker-integration/{os}.dockerfile.real
+docker build -t {name} --file docker-integration/{os}.dockerfile.real .
+docker run -v $HOME:$HOME -w $(pwd) --user $(id -u) {name} env HOME=$HOME tox -e docker-integration
+""".replace('{name}', name).replace('{os}', os)
+    return subprocess.check_call(script, shell=True)
+
+def main():
+    if subprocess.call(['docker', 'ps']) != 0:
+        logging.info("docker ps return on error"
+                     "docker is not available, do not run tests")
+        return 1
+    return run('ubuntu-14.04')
+
+sys.exit(main())
+
+# Local Variables:
+# compile-command: "cd .. ; tox -e docker-delegate"
+# End:

--- a/docker-integration/setup.sh
+++ b/docker-integration/setup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 <contact@redhat.com>
+#
+# Author: Loic Dachary <loic@dachary.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+if ! test -d paddles ; then
+    git clone https://github.com/ceph/paddles.git
+fi
+
+cd paddles
+
+git pull --rebase
+git clean -ffqdx
+
+perl -p -e "s|^address.*|address = 'http://localhost'|" < config.py.in > config.py
+virtualenv ./virtualenv
+source ./virtualenv/bin/activate
+pip install -r requirements.txt 
+pip install sqlalchemy tzlocal requests
+python setup.py develop
+pecan populate config.py
+for id in 1 2 3 ; do sqlite3 dev.db "insert into nodes (id,name,machine_type,is_vm,locked,up) values ($id, 'testmachine00$id', 'testmachine', 0, 0, 1);" ; done
+pecan serve config.py &
+sleep 2
+
+cd ..

--- a/docker-integration/test.py
+++ b/docker-integration/test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015 <contact@redhat.com>
+#
+# Author: Loic Dachary <loic@dachary.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import logging
+import shutil
+import subprocess
+import testtools
+import sys
+import tempfile
+import teuthology.lock
+import scripts.lock
+from cStringIO import StringIO
+import json
+
+class Integration(testtools.TestCase):
+    def setUp(self):
+        super(Integration, self).setUp()
+        self.d = tempfile.mkdtemp()
+        config = self.d + '/teuthology-config.yaml'
+        open(config, 'w').write("""\
+lock_server: http://localhost:8080/
+queue_host: 127.0.0.1
+results_server:
+""")
+        self.options = ['--verbose',
+                        '--config-file', config]
+
+    def tearDown(self):
+        shutil.rmtree(self.d)
+        super(Integration, self).tearDown()
+
+class TestLock(Integration):
+
+    def test_list(self):
+        my_stream = StringIO()
+        self.patch(sys, 'stdout', my_stream)
+        args = scripts.lock.parse_args(self.options + ['--list', '--all'])
+        teuthology.lock.main(args)
+        out = my_stream.getvalue()
+        self.assertIn('machine_type', out);
+        status = json.loads(out)
+        self.assertEquals(3, len(status))
+
+# Local Variables:
+# compile-command: "cd .. ; tox -e docker-delegate"
+# End:

--- a/docker-integration/ubuntu-14.04.dockerfile
+++ b/docker-integration/ubuntu-14.04.dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:14.04
+
+RUN apt-get update
+# http://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread
+RUN apt-get install -y python-setuptools && easy_install -U pip
+RUN apt-get install -y python-virtualenv python-tox libmysqlclient-dev beanstalkd git
+RUN apt-get install -y python2.7-dev
+RUN apt-get install -y libevent-dev
+RUN apt-get install -y sqlite3 jq
+RUN useradd -M --uid %%user_id%% %%USER%% && echo '%%USER%% ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/scripts/kill.py
+++ b/scripts/kill.py
@@ -18,6 +18,7 @@ Kill running teuthology jobs:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --config-file         path to the config file (default ~/.teuthology.yaml)
   -a ARCHIVE, --archive ARCHIVE
                         The base archive directory
                         [default: {archive_base}]

--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -108,6 +108,11 @@ def parse_args():
         "unlocking other machines",
     )
     parser.add_argument(
+        '--config-file',
+        default=None,
+        help='path to the config file (defaults ~/.teuthology.yaml)',
+    )
+    parser.add_argument(
         '--desc',
         default=None,
         help='lock description',

--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -14,10 +14,10 @@ def _positive_int(string):
 
 
 def main():
-    sys.exit(teuthology.lock.main(parse_args()))
+    sys.exit(teuthology.lock.main(parse_args(sys.argv[1:])))
 
 
-def parse_args():
+def parse_args(argv):
     parser = argparse.ArgumentParser(
         description='Lock, unlock, or query lock status of machines',
         epilog=textwrap.dedent('''
@@ -176,4 +176,4 @@ def parse_args():
             with value mira003.front.sepia.ceph.com.'''),
     )
 
-    return parser.parse_args()
+    return parser.parse_args(argv)

--- a/scripts/ls.py
+++ b/scripts/ls.py
@@ -9,6 +9,7 @@ positional arguments:
 optional arguments:
   -h, --help     show this help message and exit
   -v, --verbose  show reasons tests failed
+  --config-file  path to the config file (default ~/.teuthology.yaml)
 """
 import docopt
 import teuthology.ls

--- a/scripts/nuke.py
+++ b/scripts/nuke.py
@@ -13,6 +13,7 @@ Reset test machines
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         be more verbose
+  --config-file         path to the config file (default ~/.teuthology.yaml)
   -t CONFIG [CONFIG ...], --targets CONFIG [CONFIG ...]
                         yaml config containing machines to nuke
   -a DIR, --archive DIR

--- a/scripts/queue.py
+++ b/scripts/queue.py
@@ -19,6 +19,7 @@ Arguments:
 
 optional arguments:
   -h, --help            Show this help message and exit
+  --config-file         path to the config file (default ~/.teuthology.yaml)
   -D, --delete PATTERN  Delete Jobs with PATTERN in their name
   -d, --description     Show job descriptions
   -r, --runs            Only show run names

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -13,6 +13,7 @@ Submit test results to a web service
 
 optional arguments:
   -h, --help            show this help message and exit
+  --config-file         path to the config file (default ~/.teuthology.yaml)
   -a ARCHIVE, --archive ARCHIVE
                         The base archive directory
                         [default: {archive_base}]

--- a/scripts/results.py
+++ b/scripts/results.py
@@ -6,6 +6,7 @@ Email teuthology suite results
 optional arguments:
   -h, --help         show this help message and exit
   -v, --verbose      be more verbose
+  --config-file      path to the config file (default ~/.teuthology.yaml)
   --dry-run          Instead of sending the email, just print it
   --email EMAIL      address to email test failures to
   --timeout TIMEOUT  how many seconds to wait for all tests to finish (default

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -11,6 +11,7 @@ positional arguments:
 optional arguments:
   -h, --help                     show this help message and exit
   -v, --verbose                  be more verbose
+  --config-file                  path to the config file (default ~/.teuthology.yaml)
   --version                      the current installed version of teuthology
   -a DIR, --archive DIR          path to archive results in
   --description DESCRIPTION      job description

--- a/scripts/schedule.py
+++ b/scripts/schedule.py
@@ -15,6 +15,7 @@ positional arguments:
 optional arguments:
   -h, --help                           Show this help message and exit
   -v, --verbose                        Be more verbose
+  --config-file                        path to the config file (default ~/.teuthology.yaml)
   -n <name>, --name <name>             Name of suite run the job is part of
   -d <desc>, --description <desc>      Job description
   -o <owner>, --owner <owner>          Job owner

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -19,6 +19,7 @@ runs the dumpling-x facet of the upgrade suite.
 Miscellaneous arguments:
   -h, --help                  Show this help message and exit
   -v, --verbose               Be more verbose
+  --config-file               path to the config file (default ~/.teuthology.yaml)
   --dry-run                   Do a dry run; do not schedule anything
 
 Standard arguments:

--- a/scripts/test/test_kill.py
+++ b/scripts/test/test_kill.py
@@ -1,0 +1,5 @@
+from script import Script
+
+
+class TestLock(Script):
+    script_name = 'teuthology-kill'

--- a/scripts/update_inventory.py
+++ b/scripts/update_inventory.py
@@ -15,6 +15,7 @@ Update the given nodes' inventory information on the lock server
 
   -h, --help            show this help message and exit
   -v, --verbose         be more verbose
+  --config-file         path to the config file (default ~/.teuthology.yaml)
   REMOTE                hostnames of machines whose information to update
 
 """

--- a/scripts/updatekeys.py
+++ b/scripts/updatekeys.py
@@ -16,6 +16,7 @@ positional arguments:
 optional arguments:
   -h, --help            Show this help message and exit
   -v, --verbose         Be more verbose
+  --config-file         path to the config file (default ~/.teuthology.yaml)
   -t <targets>, --targets <targets>
                         Input yaml containing targets to check
   -a, --all             Update hostkeys of all machines in the db

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -18,6 +18,11 @@ describe. One job is run at a time.
         help='be more verbose',
     )
     parser.add_argument(
+        '--config-file',
+        default=None,
+        help='path to the config file (defaults ~/.teuthology.yaml)',
+    )
+    parser.add_argument(
         '--archive-dir',
         metavar='DIR',
         help='path under which to archive results',

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -166,6 +166,8 @@ class FakeNamespace(YamlConfig):
             yaml_path = _get_config_path()
         if not config_dict:
             config_dict = dict()
+        if 'config_file' not in config_dict:
+            config_dict['config_file'] = yaml_path
         self._conf = self._clean_config(config_dict)
         # avoiding circular imports
         from .misc import read_config

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -162,8 +162,6 @@ class FakeNamespace(YamlConfig):
     to still be passed a single namespace object for the time being.
     """
     def __init__(self, config_dict=None, yaml_path=None):
-        if not yaml_path:
-            yaml_path = _get_config_path()
         if not config_dict:
             config_dict = dict()
         if 'config_file' not in config_dict:

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1003,12 +1003,17 @@ def read_config(ctx):
     read the default teuthology yaml configuration file.
     """
     ctx.teuthology_config = {}
-    filename = os.path.join(os.environ['HOME'], '.teuthology.yaml')
+    if ctx.config_file:
+        filename = ctx.config_file
+        config.yaml_path = filename
+        config.load()
+    else:
+        filename = os.path.join(os.environ['HOME'], '.teuthology.yaml')
 
     if not os.path.exists(filename):
         log.debug("%s not found", filename)
         return
-
+    log.debug("read_config from: %s", filename)
     with file(filename) as f:
         g = yaml.safe_load_all(f)
         for new in g:

--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,20 @@ deps=sphinx
 commands=
     sphinx-apidoc -f -o . ../teuthology ../teuthology/test ../teuthology/orchestra/test ../teuthology/task/test
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+
+[testenv:docker-delegate]
+basepython=python2
+commands={envbindir}/python docker-integration/delegate.py
+
+[testenv:docker-integration]
+basepython=python2
+deps=
+  -r{toxinidir}/requirements.txt
+  mock
+  fudge
+  nose
+  pytest-cov==1.6
+  coverage==3.7.1
+  testtools>=0.9.32
+commands=
+   {toxinidir}/docker-integration/setup.sh

--- a/tox.ini
+++ b/tox.ini
@@ -57,3 +57,4 @@ deps=
   testtools>=0.9.32
 commands=
    {toxinidir}/docker-integration/setup.sh
+   py.test -v docker-integration/test.py


### PR DESCRIPTION
If docker is available, running

   tox -e docker-delegate

will do the following:

   * create or re-use an Ubuntu 14.04 docker image with minimal python
     dependencies from docker-integration/ubuntu-14.04.dockerfile

   * run tox -e docker-integration in a container based
     on this image

The docker-integration environment runs docker-integration/setup.sh
which setup and run a paddles server using a clone of the paddles master
branch. If setup.sh succeeds, it returns on success.