### PR TITLE
expose the install._get_baseurl template in .teuthology.yaml

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -68,3 +68,41 @@ Here is a sample configuration with many of the options set and documented::
     # How long a scheduled job should be allowed to run, in seconds, before 
     # it is killed by the worker process.
     max_job_time: 259200
+
+    # The template from which the URL of the repository containing packages
+    # is built.
+    #
+    # {host} is 'gitbuilder_host' from .teuthology.yaml
+    # {proj} is the value of 'project' from the job yaml file or 'ceph'
+    # {flavor} is the value of 'flavor' from the job yaml file or 'basic'
+    # {uri} is ref/tag if 'tag' is set in the job yaml file
+    #       or ref/branch if 'branch' is set in the job yaml file
+    #       or sha1/sha1 if 'sha1' is set in the job yaml file
+    #       or ref/master
+    # {pkg_type} is either 'deb' or 'rpm' depending on the host on which the
+    #            packages are to be installed
+    # {dist} If lsb_release -si is Fedora the value is:
+    #          Fedora 20 => fc20
+    #          Fedora 21 => fc21
+    #          etc.
+    #        If lsb_release -si is CentOS or RedHatEnterpriseServer it is
+    #          CentOS 6.5 => centos6
+    #          CentOS 7.0 => centos7
+    #          CentOS 7.1 => centos7
+    #          RedHatEnterpriseServer 6.4 => centos6
+    #          RedHatEnterpriseServer 7.0 => centos7
+    #          RedHatEnterpriseServer 7.1 => centos7
+    #          etc.
+    #       Everything else is whatever lsb_release -sc returns
+    #          Ubuntu 12.04 => precise
+    #          Ubuntu 14.04 => trusty
+    #          Debian GNU/Linux 7.0 => wheezy
+    #          Debian GNU/Linux 8.0 => jessie
+    #          etc.
+    # {arch} is the output of the 'arch' command on the host on which
+    #        the packages are to be installed
+    #           i386
+    #           x86_64
+    #           armv7l
+    #           etc.
+    baseurl_template: http://{host}/{proj}-{pkg_type}-{dist}-{arch}-{flavor}/{uri}

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -143,6 +143,7 @@ class TeuthologyConfig(YamlConfig):
         'kojihub_url': 'http://koji.fedoraproject.org/kojihub',
         'kojiroot_url': 'http://kojipkgs.fedoraproject.org/packages',
         'koji_task_url': 'https://kojipkgs.fedoraproject.org/work/',
+        'baseurl_template': 'http://{host}/{proj}-{pkg_type}-{dist}-{arch}-{flavor}/{uri}',
     }
 
     def __init__(self, yaml_path=None):

--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -196,9 +196,10 @@ def _get_baseurl(ctx, remote, config):
     :param config: the config dict
     :returns: str -- the URL
     """
+    template = teuth_config.baseurl_template
     # get distro name and arch
     baseparms = _get_baseurlinfo_and_dist(ctx, remote, config)
-    base_url = 'http://{host}/{proj}-{pkg_type}-{dist}-{arch}-{flavor}/{uri}'.format(
+    base_url = template.format(
         host=teuth_config.gitbuilder_host,
         proj=config.get('project', 'ceph'),
         pkg_type=remote.system_type,
@@ -420,11 +421,9 @@ def _update_rpm_package_list_and_install(ctx, remote, rpm, config):
     baseparms = _get_baseurlinfo_and_dist(ctx, remote, config)
     log.info("Installing packages: {pkglist} on remote rpm {arch}".format(
         pkglist=", ".join(rpm), arch=baseparms['arch']))
-    host = teuth_config.gitbuilder_host
     dist_release = baseparms['dist_release']
     project = config.get('project', 'ceph')
-    start_of_url = 'http://{host}/{proj}-rpm-{distro_release}-{arch}-{flavor}/{uri}'.format(
-        proj=project, host=host, **baseparms)
+    start_of_url = _get_baseurl(ctx, remote, config)
     proj_release = '{proj}-release-{release}.{dist_release}.noarch'.format(
         proj=project, release=RELEASE, dist_release=dist_release)
     rpm_name = "{rpm_nm}.rpm".format(rpm_nm=proj_release)

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -7,6 +7,30 @@ from teuthology.task import install
 
 class TestInstall(object):
 
+    @patch("teuthology.task.install.teuth_config")
+    @patch("teuthology.task.install._get_baseurlinfo_and_dist")
+    def test_get_baseurl(self, m_get_baseurlinfo_and_dist, m_config):
+        m_config.gitbuilder_host = 'FQDN'
+        config = {'project': 'CEPH'}
+        remote = Mock()
+        remote.system_type = 'rpm'
+        m_config.baseurl_template = (
+            'OVERRIDE: {host}/{proj}-{pkg_type}-{dist}-{arch}-{flavor}/{uri}')
+        baseurlinfo_and_dist = {
+            'dist': 'centos7',
+            'arch': 'i386',
+            'flavor': 'notcmalloc',
+            'uri': 'ref/master',
+        }
+        m_get_baseurlinfo_and_dist.return_value = baseurlinfo_and_dist
+        expected = m_config.baseurl_template.format(
+            host=m_config.gitbuilder_host,
+            proj=config['project'],
+            pkg_type=remote.system_type,
+            **baseurlinfo_and_dist)
+        actual = install._get_baseurl(Mock(), remote, config)
+        assert expected == actual
+
     @patch("teuthology.task.install._get_baseurl")
     @patch("teuthology.task.install._block_looking_for_package_version")
     @patch("teuthology.task.install.packaging.get_package_version")


### PR DESCRIPTION
Instead of hardcoding the template used by _get_baseurl to build the URL
of the repository where packages are to be found, make it a

   baseurl_template

configuration parameter in the teuthology.yaml file.

http://tracker.ceph.com/issues/11830 Fixes: #11830

Signed-off-by: Loic Dachary <loic@dachary.org>