### PR TITLE
do not canonicalize hostnames if canonicalize_hostname is false

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -10,6 +10,12 @@ Here is a sample configuration with many of the options set and documented::
     # lab_domain: the domain name to append to all short hostnames
     lab_domain: example.com
 
+    # If true the hostname of the targets are canonicalized using an
+    # algorithm specific to the Ceph community lab. If false the
+    # targets hostname are left untouched.
+    # This is enabled by default.
+    canonicalize_hostname: true
+
     # The root directory to use for storage of all scheduled job logs and 
     # other data.
     archive_base: /home/teuthworker/archive

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -131,6 +131,7 @@ class TeuthologyConfig(YamlConfig):
         'ceph_git_base_url': 'https://github.com/ceph/',
         'gitbuilder_host': 'gitbuilder.ceph.com',
         'lab_domain': 'front.sepia.ceph.com',
+        'canonicalize_hostname': True,
         'lock_server': 'http://paddles.front.sepia.ceph.com/',
         'max_job_time': 259200,  # 3 days
         'results_server': 'http://paddles.front.sepia.ceph.com/',

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -41,6 +41,9 @@ hostname_expr_templ = '(?P<user>.*@)?(?P<shortname>.*)\.{lab_domain}'
 
 
 def canonicalize_hostname(hostname, user='ubuntu'):
+    if (config.canonicalize_hostname is False):
+        return hostname
+
     hostname_expr = hostname_expr_templ.format(
         lab_domain=config.lab_domain.replace('.', '\.'))
     match = re.match(hostname_expr, hostname)
@@ -66,6 +69,9 @@ def canonicalize_hostname(hostname, user='ubuntu'):
 
 
 def decanonicalize_hostname(hostname):
+    if (config.canonicalize_hostname is False):
+        return hostname
+
     hostname_expr = hostname_expr_templ.format(
         lab_domain=config.lab_domain.replace('.', '\.'))
     match = re.match(hostname_expr, hostname)

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -61,6 +61,13 @@ class TestHostnames(object):
     def teardown(self):
         config.load()
 
+    @patch("teuthology.misc.config")
+    def test_canonicalize_hostname_disabled(self, m_config):
+        m_config.canonicalize_hostname = False
+        host_base = 'box1'
+        result = misc.canonicalize_hostname(host_base)
+        assert result == host_base
+
     def test_canonicalize_hostname(self):
         host_base = 'box1'
         result = misc.canonicalize_hostname(host_base)


### PR DESCRIPTION
This is useful when running teuthology in a lab that does not enforce
the same naming conventions as the Ceph community lab.

http://tracker.ceph.com/issues/11844 Fixes: #11844

Signed-off-by: Loic Dachary <loic@dachary.org>