### PR TITLE
suite: append flavor key only if kernel version is specified

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -186,9 +186,10 @@ def create_initial_config(suite, suite_branch, ceph_branch, teuthology_branch,
     if kernel_hash:
         log.info("kernel sha1: {hash}".format(hash=kernel_hash))
         kernel_dict = dict(kernel=dict(kdb=True, sha1=kernel_hash))
+        if kernel_hash is not 'distro':
+            kernel_dict['kernel']['flavor'] = kernel_flavor
     else:
         kernel_dict = dict(kernel=dict())
-    kernel_dict['kernel']['flavor'] = kernel_flavor
 
     # Get the ceph hash
     ceph_hash = get_hash('ceph', ceph_branch, kernel_flavor, machine_type,
@@ -542,7 +543,7 @@ def schedule_suite(job_config,
 
         parsed_yaml = yaml.load(raw_yaml)
         os_type = parsed_yaml.get('os_type') or job_config.os_type
-        kernel_flavor = job_config.kernel['flavor']
+        kernel_flavor = job_config.kernel.get('flavor', 'basic')
         exclude_arch = parsed_yaml.get('exclude_arch')
         exclude_os_type = parsed_yaml.get('exclude_os_type')
 


### PR DESCRIPTION
There are three cases: a) don't install a kernel, b) install a distro
kernel or c) install a specified version.  Appending 'flavor: basic' to
kernel task config in the former two cases is wrong.  In case a)
appending flavor is not only bogus but also leads to bug: a { 'kernel':
{ 'flavor': 'basic' } } config confuses kernel task and it installs
a default version of the kernel (branch master) on all remotes when the
user's intent was to not install any kernel.  As for case b), distro
kernels are built by distros and don't have flavors.

Fix this by appending 'flavor: basic' to kernel task config only in
case c).

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>