### PR TITLE
lock.py: not all virtual machines have a dedicated host

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -266,6 +266,9 @@ def main(ctx):
             for s in statuses:
                 if not s.get('is_vm', False):
                     continue
+                # with an OpenStack API, there is no host for a VM
+                if s['vm_host'] is None:
+                    continue
                 vm_host_name = s.get('vm_host', dict())['name']
                 if vm_host_name:
                     s['vm_host'] = vm_host_name


### PR DESCRIPTION
Gracefully handle the case where a virtual machine has no dedicated
host. It's the case for OpenStack.

Signed-off-by: Loic Dachary <loic@dachary.org>