### PR TITLE
lock.py: make main() argv as an argument

### DIFF
--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -14,10 +14,10 @@ def _positive_int(string):
 
 
 def main():
-    sys.exit(teuthology.lock.main(parse_args()))
+    sys.exit(teuthology.lock.main(parse_args(sys.argv[1:])))
 
 
-def parse_args():
+def parse_args(argv):
     parser = argparse.ArgumentParser(
         description='Lock, unlock, or query lock status of machines',
         epilog=textwrap.dedent('''
@@ -172,4 +172,4 @@ def parse_args():
             Note: be careful about quoting and the shell.'''),
     )
 
-    return parser.parse_args()
+    return parser.parse_args(argv)


### PR DESCRIPTION
Instead of using sys.argv implicitly, which is inconvenient for testing.

Signed-off-by: Loic Dachary <loic@dachary.org>