### PR TITLE
Fix cleanup-and-unlock.sh

### DIFF
--- a/cleanup-and-unlock.sh
+++ b/cleanup-and-unlock.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -ex
 
-bin/teuthology-nuke -t $1 -r --owner $2
-bin/teuthology-lock --unlock -t $1 --owner $2
+teuthology-nuke -t $1 -r --owner $2
+teuthology-lock --unlock -t $1 --owner $2


### PR DESCRIPTION
The bin dir does not exist in the source code tree

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>