### PR TITLE
suite.py: make main() argv as an argument

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -1,4 +1,5 @@
 import docopt
+import sys
 
 import teuthology.suite
 from teuthology.config import config
@@ -81,6 +82,6 @@ Scheduler arguments:
            default_results_timeout=config.results_timeout)
 
 
-def main():
-    args = docopt.docopt(doc)
+def main(argv=sys.argv[1:]):
+    args = docopt.docopt(doc, argv=argv)
     teuthology.suite.main(args)


### PR DESCRIPTION
Instead of using sys.argv implicitly, which is inconvenient for testing.

Signed-off-by: Loic Dachary <loic@dachary.org>