### PR TITLE
list_locks must use 1 / 0 for True / False

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -503,6 +503,11 @@ def unlock_one(ctx, name, user, description=None):
 
 def list_locks(keyed_by_name=False, **kwargs):
     uri = os.path.join(config.lock_server, 'nodes', '')
+    for key, value in kwargs.iteritems():
+        if kwargs[key] is False:
+            kwargs[key] = '0'
+        if kwargs[key] is True:
+            kwargs[key] = '1'
     if kwargs:
         if 'machine_type' in kwargs:
             kwargs['machine_type'] = kwargs['machine_type'].replace(',','|')


### PR DESCRIPTION
Depending on the backend being used (sqlite or another), paddles won't
interpret locked=false as being the same as locked=0 (see
http://tracker.ceph.com/issues/12183 for more context).

Convert True to 1 and False to 0 to always get the same behavior from
paddles, regardless of the backend.

Signed-off-by: Loic Dachary <loic@dachary.org>