### PR TITLE
do not run the kernel task unless there is a flavor

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -194,7 +194,7 @@ def get_initial_tasks(lock, config, machine_type):
             {'internal.vm_setup': None},
         ])
 
-    if 'kernel' in config:
+    if 'kernel' in config and config['kernel'].get('flavor'):
         init_tasks.append({'kernel': config['kernel']})
 
     init_tasks.extend([

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -92,10 +92,10 @@ class TestRun(object):
             run.get_initial_tasks(True, {"targets": "can't be here"}, "machine_type")
 
     def test_get_inital_tasks(self):
-        config = {"roles": range(2), "kernel": "the_kernel", "use_existing_cluster": False}
+        config = {"roles": range(2), "kernel": {"flavor": "basic"}, "use_existing_cluster": False}
         result = run.get_initial_tasks(True, config, "machine_type")
         assert {"internal.lock_machines": (2, "machine_type")} in result
-        assert {"kernel": "the_kernel"} in result
+        assert {"kernel": {"flavor": "basic"}} in result
         # added because use_existing_cluster == False
         assert {'internal.vm_setup': None} in result
 


### PR DESCRIPTION
The kernel task imposes requirements on virtual machines that can be
bypassed when no specific kernel is required.

Signed-off-by: Loic Dachary <loic@dachary.org>