### PR TITLE
task/install: rm {proj}.list is idempotent

### DIFF
--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -695,7 +695,7 @@ def _remove_sources_list_deb(remote, proj):
     """
     remote.run(
         args=[
-            'sudo', 'rm', '/etc/apt/sources.list.d/{proj}.list'.format(
+            'sudo', 'rm', '-f', '/etc/apt/sources.list.d/{proj}.list'.format(
                 proj=proj),
             run.Raw('&&'),
             'sudo', 'apt-get', 'update',


### PR DESCRIPTION
It does not matter if the {proj}.list file can't be removed because it
does not exist.

Signed-off-by: Loic Dachary <loic@dachary.org>