### PR TITLE
a worker --verbose calls run --verbose

### DIFF
--- a/teuthology/test/test_worker.py
+++ b/teuthology/test/test_worker.py
@@ -73,7 +73,7 @@ class TestWorker(object):
         m_p.returncode = 0
         m_popen.return_value = m_p
         m_t_config.results_server = True
-        worker.run_job(config, "teuth/bin/path")
+        worker.run_job(config, "teuth/bin/path", verbose=False)
         m_run_watchdog.assert_called_with(m_p, config)
         expected_args = [
             'teuth/bin/path/teuthology',
@@ -120,7 +120,7 @@ class TestWorker(object):
         m_p.returncode = 1
         m_popen.return_value = m_p
         m_t_config.results_server = False
-        worker.run_job(config, "teuth/bin/path")
+        worker.run_job(config, "teuth/bin/path", verbose=False)
         m_symlink_log.assert_called_with(config["worker_log"], config["archive_path"])
 
     @patch("teuthology.worker.report.try_push_job_info")

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -162,7 +162,7 @@ def main(ctx):
             log.info('Creating archive dir %s', archive_path_full)
             safepath.makedirs(ctx.archive_dir, safe_archive)
             log.info('Running job %d', job.jid)
-            run_job(job_config, teuth_bin_path)
+            run_job(job_config, teuth_bin_path, ctx.verbose)
         job.delete()
 
 
@@ -222,7 +222,7 @@ def run_with_watchdog(process, job_config):
         report.try_push_job_info(job_info, dict(status='dead'))
 
 
-def run_job(job_config, teuth_bin_path):
+def run_job(job_config, teuth_bin_path, verbose):
     suite_path = job_config['suite_path']
     arg = [
         os.path.join(teuth_bin_path, 'teuthology'),
@@ -238,7 +238,7 @@ def run_job(job_config, teuth_bin_path):
         else:
             job_config.update(inner_config)
 
-    if job_config['verbose']:
+    if verbose or job_config['verbose']:
         arg.append('-v')
 
     arg.extend([


### PR DESCRIPTION
When a worker runs with --verbose, it also runs the jobs with --verbose.

Signed-off-by: Loic Dachary <loic@dachary.org>