### PR TITLE
schedule.py: make main() argv as an argument

### DIFF
--- a/scripts/schedule.py
+++ b/scripts/schedule.py
@@ -2,6 +2,7 @@ import docopt
 
 import teuthology.misc
 import teuthology.schedule
+import sys
 
 doc = """
 usage: teuthology-schedule -h
@@ -39,6 +40,6 @@ optional arguments:
 """
 
 
-def main():
-    args = docopt.docopt(doc)
+def main(argv=sys.argv[1:]):
+    args = docopt.docopt(doc, argv=argv)
     teuthology.schedule.main(args)


### PR DESCRIPTION
Instead of using sys.argv implicitly, which is inconvenient for testing.

Signed-off-by: Loic Dachary <loic@dachary.org>