### PR TITLE
lock.py: is_vpm should test is_vm

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -17,7 +17,9 @@ from .lockstatus import get_status
 
 log = logging.getLogger(__name__)
 
-is_vpm = lambda name: 'vpm' in name
+
+def is_vm(name):
+    return get_status(name)['is_vm']
 
 
 def get_distro_from_downburst():
@@ -311,7 +313,7 @@ def main(ctx):
         if ctx.owner is None and user is None:
             user = misc.get_user()
         # If none of them are vpm, do them all in one shot
-        if not filter(is_vpm, machines):
+        if not filter(is_vm, machines):
             res = unlock_many(machines, user)
             return 0 if res else 1
         for machine in machines:


### PR DESCRIPTION
Testing the name of a machine to figure out if it is a virtual machine
is unreliable. Use the is_vm field of get_status instead.

Signed-off-by: Loic Dachary <loic@dachary.org>