### PR TITLE
DNM: Initial work on docker task for teuthology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,11 @@
 *.pyc
 *.pyo
 .tox
+/dist
 
 /*.egg-info
 /virtualenv
+/venv
 /build
 /*.yaml
 docs/build

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(
                       'pyopenssl>=0.13',
                       'ndg-httpsclient',
                       'pyasn1',
-                      ],
+                      'maestro-ng >= 0.2.6.2'
+                     ],
     tests_require=['nose >=1.0.0', 'fudge >=1.0.3'],
 
 

--- a/teuthology/task/docker.py
+++ b/teuthology/task/docker.py
@@ -1,0 +1,266 @@
+from . import Task
+
+from teuthology.exceptions import ConfigError
+
+from maestro.__main__ import create_parser
+from maestro.maestro import Conductor
+import shlex
+
+
+class Docker(Task):
+    """
+    A task to execute maestro-ng commands. The main assumption is that every
+    host provided in "targets" is running a docker daemon.
+
+    Required configuration parameters:
+        command:    Required; List of commands. Any of "pull", "stop"
+                    or "start". Commands are separated by space and are executed
+                    in the given list-order.
+        services:   The service(s) that are being operated on. This has the same
+                    format as `maestro-ng`'s for describing services. The only
+                    thing to notice is that the value of the `ship` option
+                    (where a service runs) has to take values that come from one
+                    of the hosts specified in teuthology's `targets` option.
+        roles:      Create services from roles specified in teuthology's config.
+                    These should correspond to the roles specified in
+                    teuthology's `roles` option. An optional `tag` config
+                    specifies the corresponding image's version to execute
+                    (defaults to `latest`). Also, a registry other than 'ceph'
+                    (the default) can be specified with the `registry_repo`
+                    option.
+    Optional configuration parameters:
+        port:       TCP port where the docker daemon is listening (defaults to
+                    '2375'). This should be enabled on every node.
+
+    Examples:
+
+    tasks:
+    - docker:
+        command: ["start"]
+        services:
+          paddles:
+            image: ceph/paddles:latest
+            paddles.0:
+              ship: host1
+              ports: { front: 8081 }
+          pulpito:
+            image: ceph/pulpito:latest
+            requires: [ paddles ]
+            pulpito.0:
+              ship: host1
+              ports: { front: 8080 }
+          teuthology:
+            image: ceph/teuthology:latest
+            requires: [ pulpito ]
+            teuthology.0:
+              ship: host2
+              ports: { queue: 11300 }
+              env:
+                LAB_DOMAIN: example.com
+                LOCK_SERVER: http://pulpito.example.com:8080
+                RESULTS_SERVER: http://pulpito.example.com:8080
+                QUEUE_HOST: localhost
+                QUEUE_PORT: 11300
+                RESULTS_EMAIL: you@example.com
+                ARCHIVE_BASE: /teuthworker/archive
+
+    tasks:
+    - docker:
+        command: ["stop"]
+        roles:
+        port: 4653
+
+    tasks:
+    - docker:
+        command: ["stop", "start"]
+        roles:
+          tag: hammer
+          registry_repo: otherthanceph
+    """
+
+    def __init__(self, ctx, config):
+        super(Docker, self).__init__(ctx, config)
+
+    def setup(self):
+        """"
+        Validates the given config
+        """
+        if 'command' not in self.config:
+            raise ConfigError("Expecting 'command' in task configuration")
+        if 'services' not in self.config and 'roles' not in self.config:
+            raise ConfigError("Expecting 'services' or 'roles' (or both)")
+
+        if len(self.config['command']) == 0:
+            raise ConfigError("Expecting at least 1 command")
+        for c in self.config['command']:
+            if (c != "start" and c != "pull" and c != "stop"):
+                raise ConfigError("Unknown command '" + c + "'")
+
+    def begin(self):
+        """"
+        Invokes maestro-ng with the given commands and arguments.
+        """
+        self.generate_maestro_conf()
+
+        for cmd in self.config['command']:
+            try:
+                opts = create_parser().parse_args(shlex.split(cmd))
+                c = Conductor(self.maestro_config)
+                opts.things = [s.name for s in c.services.values()]
+                getattr(c, opts.command)(**vars(opts))
+            except:
+                raise
+
+    def generate_maestro_conf(self):
+        """
+        Obtain config to pass to maestro. For example, given the following
+        teuthology configuration:
+
+        ```yaml
+
+        roles:
+        -  [mon.0, mds.0, osd.0]
+        -  [mon.1, osd.1]
+        -  [mon.2, client.0]
+
+        tasks:
+        - docker:
+            command: ["start"]
+            services:
+              foo:
+                image: foo:latest
+                instances:
+                  foo1:
+                    ship: host1
+            roles:
+              tag: hammer
+        - radosbench:
+            clients: [client.0]
+            time: 360
+        - interactive:
+
+        targets:
+          ubuntu@host1: ssh-rsa host1_key
+          ubuntu@host2: ssh-rsa host2_key
+          ubuntu@host3: ssh-rsa host3_key
+        ```
+
+        The generated maestro configuration is:
+
+        ```yaml
+
+        name: teuthology
+
+        docker_defaults:
+          port: 2375
+
+        ships:
+          host1: { ip: <host1> }
+          host2: { ip: <host2> }
+          host3: { ip: <host3> }
+
+        services:
+          foo:
+            image: foo:latest
+            instances:
+              foo1:
+                ship: host1
+          mon:
+            image: ceph/mon:hammer
+            net: host
+            env:
+               MON_IP_AUTO_DETECT: 1
+            instances:
+              mon.0:
+                ship: host1
+              mon.1:
+                ship: host2
+              mon.2:
+                ship: host3
+          osd:
+            image: ceph/osd:hammer
+            requires: [ mon ]
+            instances:
+              osd.0:
+                ship: host1
+              osd.1:
+                ship: host2
+          mds:
+            image: ceph/mds:hammer
+            requires: [ osd ]
+            instances:
+              mds.0:
+                ship: host1
+          client:
+            image: ceph/client:hammer
+            requires: [ osd ]
+            instances:
+              client.0:
+                ship: host3
+        ```
+        """
+
+        self.maestro_config = {}
+        self.maestro_config['name'] = 'teuthology'
+        self.maestro_config['docker_defaults'] = {
+            'port': self.config['port'] if 'port' in self.config else 2375
+        }
+
+        # ships
+        self.maestro_config['ships'] = {}
+
+        remotes = sorted(
+            self.ctx.cluster.remotes.iterkeys(), key=lambda rem: rem.name)
+        for remote in remotes:
+            self.maestro_config['ships'].update({
+                remote.name: {
+                    'ip': remote.name
+                }
+            })
+
+        # services
+        self.maestro_config['services'] = {}
+
+        if 'services' in self.config:
+            self.maestro_config['services'].update(self.config['services'])
+
+        if 'roles' in self.config:
+            from_roles = get_services_for_roles(self.ctx, self.config['roles'])
+            self.maestro_config['services'].update(from_roles)
+
+
+def get_services_for_roles(ctx, config):
+    services = {}
+
+    repo = config['registry_repo'] if 'registry_repo' in config else 'ceph'
+    tag = config['tag'] if 'tag' in config else 'latest'
+
+    for role_category in ['mon', 'osd', 'mds', 'client']:
+        services[role_category] = {
+            'image': repo + '/' + role_category + ':' + tag,
+        }
+
+        services[role_category]['instances'] = {}
+
+        if role_category is 'mon':
+            services[role_category].update({
+                'net': 'host',
+                'env': {
+                    'MON_IP_AUTO_DETECT': 1
+                }
+            })
+
+        if role_category is 'osd':
+            services[role_category].update({'requires': ['mon']})
+
+        if role_category is 'mds' or role_category is 'client':
+            services[role_category].update({'requires': ['osd']})
+
+        for remote in ctx.cluster.remotes:
+            for role in ctx.cluster.remotes[remote]:
+                if role.startswith(role_category):
+                    services[role_category]['instances'][role] = {
+                        'ship': remote.name
+                    }
+
+    return services

--- a/teuthology/test/task/test_docker.py
+++ b/teuthology/test/task/test_docker.py
@@ -1,0 +1,196 @@
+from pytest import raises
+from teuthology.config import FakeNamespace
+from teuthology.exceptions import ConfigError
+from teuthology.orchestra.cluster import Cluster
+from teuthology.orchestra.remote import Remote
+from teuthology.task.docker import Docker
+
+from . import TestTask
+
+import socket
+
+
+class TestDockerTask(TestTask):
+    klass = Docker
+    task_name = 'docker'
+
+    def setup(self):
+        self.ctx = FakeNamespace()
+        self.ctx.cluster = Cluster()
+        self.ctx.cluster.add(Remote('host0'), ['mon.0', 'osd.0'])
+        self.ctx.cluster.add(Remote('host1'), ['mon.1', 'osd.1'])
+        self.ctx.cluster.add(Remote('host2'), ['mon.2', 'client.0'])
+        self.ctx.config = {}
+        self.task_config = {'command': ['start'], 'services': ''}
+
+    def test_setup(self):
+        # test with an empty config
+        task_config = {}
+        task = Docker(self.ctx, task_config)
+        with raises(ConfigError) as excinfo:
+            task.setup()
+        assert excinfo.value.message.startswith("Expecting 'command'")
+
+        # with empty command
+        task_config = {'command': [], 'roles': ''}
+        task = Docker(self.ctx, task_config)
+        with raises(ConfigError) as excinfo:
+            task.setup()
+        assert excinfo.value.message.startswith("Expecting at least")
+
+        # with incorrect command
+        task_config = {'command': ['foo'], 'roles': ''}
+        task = Docker(self.ctx, task_config)
+        with raises(ConfigError) as excinfo:
+            task.setup()
+        assert excinfo.value.message.startswith("Unknown command")
+
+        # missing roles or services
+        task_config = {'command': ['start']}
+        task = Docker(self.ctx, task_config)
+        with raises(ConfigError) as excinfo:
+            task.setup()
+        assert excinfo.value.message.startswith("Expecting 'services'")
+
+        # with correct values
+        task_config = {'command': ['start'], 'roles': ''}
+        task = Docker(self.ctx, task_config)
+        task.setup()
+        task_config = {'command': ['start', 'pull', 'stop'], 'services': ''}
+        task = Docker(self.ctx, task_config)
+        task.setup()
+
+    def test_make_conf_with_services(self):
+        task_config = {
+            'services': {
+                'foo': {
+                    'image': 'bar/foo:latest',
+                    'instances': {
+                        'foo.1': {
+                            'ship': 'host0'
+                        }
+                    }
+                }
+            }
+        }
+        task = Docker(self.ctx, task_config)
+        task.generate_maestro_conf()
+
+        c = task.maestro_config
+
+        assert isinstance(c, dict)
+        assert len(c.items()) != 0
+
+        assert c['name'] == 'teuthology'
+        assert c['docker_defaults']['port'] == 2375
+
+        ships = c['ships']
+        assert ships['host0']['ip'] == 'host0'
+        assert ships['host1']['ip'] == 'host1'
+        assert ships['host2']['ip'] == 'host2'
+
+        assert c['services'] == task_config['services']
+
+    def test_make_conf_with_roles_and_defaults(self):
+        task_config = {'roles': {}}
+
+        task = Docker(self.ctx, task_config)
+        task.generate_maestro_conf()
+
+        c = task.maestro_config
+
+        assert isinstance(c, dict)
+        assert len(c.items()) != 0
+
+        assert c['name'] == 'teuthology'
+        assert c['docker_defaults']['port'] == 2375
+
+        ships = c['ships']
+        assert ships['host0']['ip'] == 'host0'
+        assert ships['host1']['ip'] == 'host1'
+        assert ships['host2']['ip'] == 'host2'
+
+        service = c['services']
+
+        assert 'mon' in service
+        assert 'image' in service['mon']
+        assert 'net' in service['mon']
+        assert 'env' in service['mon']
+        assert 'instances' in service['mon']
+        assert 'mon.0' in service['mon']['instances']
+        assert 'mon.1' in service['mon']['instances']
+        assert 'mon.2' in service['mon']['instances']
+        assert 'ship' in service['mon']['instances']['mon.0']
+        assert 'ship' in service['mon']['instances']['mon.1']
+        assert 'ship' in service['mon']['instances']['mon.2']
+        assert service['mon']['image'] == 'ceph/mon:latest'
+        assert service['mon']['net'] == 'host'
+        assert service['mon']['env']['MON_IP_AUTO_DETECT'] == 1
+        assert service['mon']['instances']['mon.0']['ship'] == 'host0'
+        assert service['mon']['instances']['mon.1']['ship'] == 'host1'
+        assert service['mon']['instances']['mon.2']['ship'] == 'host2'
+
+        assert 'osd' in service
+        assert 'image' in service['osd']
+        assert 'instances' in service['osd']
+        assert 'osd.0' in service['osd']['instances']
+        assert 'osd.1' in service['osd']['instances']
+        assert 'ship' in service['osd']['instances']['osd.0']
+        assert 'ship' in service['osd']['instances']['osd.1']
+        assert service['osd']['image'] == 'ceph/osd:latest'
+        assert service['osd']['instances']['osd.0']['ship'] == 'host0'
+        assert service['osd']['instances']['osd.1']['ship'] == 'host1'
+
+        assert 'client' in service
+        assert 'image' in service['client']
+        assert 'instances' in service['client']
+        assert 'client.0' in service['client']['instances']
+        assert 'ship' in service['client']['instances']['client.0']
+        assert service['client']['image'] == 'ceph/client:latest'
+        assert service['client']['instances']['client.0']['ship'] == 'host2'
+
+    def test_make_conf_with_roles_and_no_defaults(self):
+        task_config = {
+            'port': 2345,
+            'roles': {
+                'tag': 'hammer',
+                'registry_repo': 'foo'
+            }
+        }
+
+        task = Docker(self.ctx, task_config)
+        task.generate_maestro_conf()
+
+        c = task.maestro_config
+
+        assert isinstance(c, dict)
+        assert len(c.items()) != 0
+
+        assert c['docker_defaults']['port'] == 2345
+
+        service = c['services']
+        assert 'osd' in service
+        assert service['osd']['image'] == 'foo/osd:hammer'
+
+    def test_begin(self):
+        if port_open('localhost', 2375):
+            ctx = FakeNamespace()
+            ctx.cluster = Cluster()
+            ctx.cluster.add(Remote('localhost'), ['osd.0'])
+            ctx.config = {}
+            task_config = {
+                'command': ['pull'],
+                'roles': {
+                }
+            }
+            task = Docker(ctx, task_config)
+            task.begin()
+
+
+def port_open(host, port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result = sock.connect_ex((host, port))
+    if result == 0:
+        return True
+    else:
+        return False


### PR DESCRIPTION
Introduces a 'docker' task that leverages maestro-ng to deploy a docker-based ceph cluster. In a nutshell, it maps the teuthology configuration (roles and targets) to a maestro-ng configuration and passes that to maestro-ng to execute commands.

Supported maestro-ng commands are start, stop and pull. It also adds tests for this task. A new dependency is added to setup.py (maestro-ng).

Follow-up items:
- add support for [`execute` command](https://github.com/signalfuse/maestro-ng/issues/136). This allows other tasks (e.g. radosbench) that rely on Remote's SSH connection to be able to execute inside a container.
- (optional) test using [docker-py's API mocks](https://github.com/docker/docker-py/blob/master/tests/fake_api.py). Currently, we check if there's a docker daemon running locally. If there isn't one, the `test_begin` doesn't execute.
