### PR TITLE
get_latest_image_version_deb(): run apt-get update

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -941,6 +941,7 @@ def get_latest_image_version_deb(remote, ostype):
     Round-about way to get the newest kernel uname -r compliant version string
     from the virtual package which is the newest kenel for debian/ubuntu.
     """
+    remote.run(args=['sudo', 'apt-get', 'update'])
     output = StringIO()
     newest = ''
     # Depend of virtual package has uname -r output in package name. Grab that.


### PR DESCRIPTION
When we were still using Chef, we accidentally ran it twice on downburst
VMs during scheduled jobs. Now that we're not, VMs are showing up with
stale apt caches. This will make all deb-based systems update their
cache before attempting to install a kernel.

Signed-off-by: Zack Cerza <zack@redhat.com>