### PR TITLE
Pass a targets var when using the Ansible task

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -57,7 +57,9 @@ class Ansible(Task):
                     --inventory-file flag; useful for playbooks that also have
                     vars they need access to. If this is not set, we check for
                     /etc/ansible/hosts and use that if it exists. If it does
-                    not, we generate a temporary file to use.
+                    not, we generate a temporary file to use. If an inventory
+                    is generated for you all hosts will be added to a group
+                    called 'testnodes'.
         tags:       A string including any (comma-separated) tags to be passed
                     directly to ansible-playbook.
         vars:       A dict of vars to be passed to ansible-playbook via the
@@ -177,7 +179,9 @@ class Ansible(Task):
         hosts = self.cluster.remotes.keys()
         hostnames = [remote.hostname for remote in hosts]
         hostnames.sort()
-        hosts_str = '\n'.join(hostnames + [''])
+        inventory = ['[testnodes]']
+        inventory.extend(hostnames + [''])
+        hosts_str = '\n'.join(inventory)
         hosts_file = NamedTemporaryFile(prefix="teuth_ansible_hosts_",
                                         delete=False)
         hosts_file.write(hosts_str)

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -240,7 +240,10 @@ class Ansible(Task):
         fqdns = [r.hostname for r in self.cluster.remotes.keys()]
         # Assume all remotes use the same username
         user = self.cluster.remotes.keys()[0].user
-        extra_vars = dict(ansible_ssh_user=user)
+        extra_vars = dict(
+            ansible_ssh_user=user,
+            targets='all',
+        )
         extra_vars.update(self.config.get('vars', dict()))
         args = [
             'ansible-playbook', '-v',

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -303,7 +303,8 @@ class TestAnsibleTask(TestTask):
         assert args.count('--extra-vars') == 1
         vars_str = args[args.index('--extra-vars') + 1].strip("'")
         extra_vars = json.loads(vars_str)
-        assert extra_vars.keys() == ['ansible_ssh_user']
+        assert 'ansible_ssh_user' in extra_vars
+        assert 'targets' in extra_vars
 
     def test_build_args_vars(self):
         extra_vars = dict(

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -208,7 +208,11 @@ class TestAnsibleTask(TestTask):
         assert task.generated_inventory is True
         assert task.inventory == hosts_file_path
         hosts_file_obj.seek(0)
-        assert hosts_file_obj.readlines() == ['remote1\n', 'remote2\n']
+        assert hosts_file_obj.readlines() == [
+            '[testnodes]\n',
+            'remote1\n',
+            'remote2\n',
+        ]
 
     def test_generate_playbook(self):
         playbook = [


### PR DESCRIPTION
Passing targets will allow playbooks to use that var
in the 'hosts' declaration.  This way teuthology
does not need to somehow look at the playbook being used
and parse it to figure out what group to assign hosts to
when creating a dynamic inventory.

In the ansible playbook, you can do something like this to
utilize this targets var:

  - hosts: "{{ targets | default('a_group') }}"

Signed-off-by: Andrew Schoen <aschoen@redhat.com>