### PR TITLE
Allows other users besides ubuntu (2nd round)

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -39,41 +39,33 @@ is_vm = lambda x: x.startswith('vpm') or x.startswith('ubuntu@vpm')
 is_arm = lambda x: x.startswith('tala') or x.startswith(
     'ubuntu@tala') or x.startswith('saya') or x.startswith('ubuntu@saya')
 
-hostname_expr_templ = '(?P<user>.*@)?(?P<shortname>.*)\.{lab_domain}'
-
 
 def canonicalize_hostname(hostname, user='ubuntu'):
-    hostname_expr = hostname_expr_templ.format(
-        lab_domain=config.lab_domain.replace('.', '\.'))
-    match = re.match(hostname_expr, hostname)
-    if match:
-        match_d = match.groupdict()
-        shortname = match_d['shortname']
-        if user is None:
-            user_ = user
-        else:
-            user_ = match_d.get('user') or user
-    else:
-        shortname = hostname.split('.')[0]
-        user_ = user
+    userhost = hostname.split('@')
 
-    user_at = user_.strip('@') + '@' if user_ else ''
+    both_given = len(userhost) == 2
 
-    ret = '{user_at}{short}.{lab_domain}'.format(
-        user_at=user_at,
-        short=shortname,
-        lab_domain=config.lab_domain,
-    )
-    return ret
+    usr = '' if user is None else userhost[0] if both_given else user
+    hst = userhost[1] if both_given else userhost[0]
+    lab = config.lab_domain
+
+    user_at = (usr + "@") if usr else ''
+    domain = hst if lab in hst else (hst + '.' + lab) if lab else hst
+
+    return user_at + domain
 
 
 def decanonicalize_hostname(hostname):
-    hostname_expr = hostname_expr_templ.format(
-        lab_domain=config.lab_domain.replace('.', '\.'))
-    match = re.match(hostname_expr, hostname)
-    if match:
-        hostname = match.groupdict()['shortname']
-    return hostname
+    userhost = hostname.split('@')
+
+    both_given = len(userhost) == 2
+
+    host = userhost[1] if both_given else userhost[0]
+
+    if config.lab_domain:
+        return host.split('.')[0]
+    else:
+        return host
 
 
 def config_file(string):

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -76,6 +76,11 @@ class TestHostnames(object):
         result = misc.canonicalize_hostname(host_base, user=None)
         assert result == 'box1.front.sepia.ceph.com'
 
+    def test_canonicalize_hostname_nouserarg_withuserat(self):
+        host_base = 'ubuntu@box1'
+        result = misc.canonicalize_hostname(host_base, user=None)
+        assert result == 'box1.front.sepia.ceph.com'
+
     def test_decanonicalize_hostname_nouser(self):
         host = 'box1.front.sepia.ceph.com'
         result = misc.decanonicalize_hostname(host)
@@ -93,6 +98,40 @@ class TestHostnames(object):
         result = misc.decanonicalize_hostname(host)
         assert result == 'box1'
 
+    def test_canonicalize_hostname_otheruser(self):
+        host_base = 'foo@box1'
+        result = misc.canonicalize_hostname(host_base)
+        assert result == 'foo@box1.front.sepia.ceph.com'
+
+    def test_canonicalize_hostname_nolab_ip(self):
+        config.lab_domain = ''
+        host_base = 'foo@192.168.0.1'
+        result = misc.canonicalize_hostname(host_base)
+        assert result == 'foo@192.168.0.1'
+
+    def test_canonicalize_hostname_nolab_domainname(self):
+        config.lab_domain = ''
+        host_base = 'foo@full.domain.org'
+        result = misc.canonicalize_hostname(host_base)
+        assert result == 'foo@full.domain.org'
+
+    def test_decanonicalize_hostname_nolab_ip(self):
+        config.lab_domain = ''
+        host_base = 'foo@192.168.0.1'
+        result = misc.decanonicalize_hostname(host_base)
+        assert result == '192.168.0.1'
+
+    def test_decanonicalize_hostname_nolab_domainname(self):
+        config.lab_domain = ''
+        host_base = 'foo@full.domain.org'
+        result = misc.decanonicalize_hostname(host_base)
+        assert result == 'full.domain.org'
+
+    def test_canonicalize_hostname_repeateddomain(self):
+        config.lab_domain = 'ceph.com'
+        host_base = 'foo@bar.ceph.com'
+        result = misc.canonicalize_hostname(host_base)
+        assert result == 'foo@bar.ceph.com'
 
 class TestMergeConfigs(object):
     """ Tests merge_config and deep_merge in teuthology.misc """


### PR DESCRIPTION
[1st attempt](https://github.com/ceph/teuthology/pull/563) to address [this](http://tracker.ceph.com/issues/10086) was reverted due to a buggy commit.

I think I managed to capture with a test the use case that observed the buggy behavior. If you have time @zmc and @andrewschoen , could you please point me to other use cases in teuthology or ceph-qa-suite that are not covered by the unit tests?
