### PR TITLE
Pins mock to 1.0.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ passenv = HOME
 sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt
-  mock
+  mock==1.0.1
   fudge
   nose
   pytest-cov==1.6
@@ -19,7 +19,7 @@ passenv = HOME
 sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt
-  mock
+  mock==1.0.1
   fudge
   nose
   pytest-cov==1.6


### PR DESCRIPTION
[`mock`](https://pypi.python.org/pypi/mock) was updated on 07/10/15 and it seems that the update introduced an issue I'm experiencing in https://github.com/ceph/teuthology/pull/567. Reverting to previous version (`mock==1.0.1`) fixes the issue. In order to avoid this type of issues in the future, I propose we pin dependencies to specific versions we know are working OK.

