### PR TITLE
Removes test_require from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
                       'ndg-httpsclient',
                       'pyasn1',
                       ],
-    tests_require=['nose >=1.0.0', 'fudge >=1.0.3'],
 
 
     # to find the code associated with entry point


### PR DESCRIPTION
setuptools doesn't install dependencies found in `tests_require`, so there's no need to have this option in `setup.py`. Since this options doesn't have an effect on the outcome of tests, we run the risk of getting out of sync to what we actually use, which is specified in `tox.ini`.

alternatively, we can set `tests_require` to what `tox.ini` has.

The former seemed more straightforward.