### PR TITLE
ansible: do not use colors in the teuthology log

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -226,6 +226,7 @@ class Ansible(Task):
         environ = os.environ
         environ['ANSIBLE_SSH_PIPELINING'] = '1'
         environ['ANSIBLE_ROLES_PATH'] = "%s/roles" % self.repo_path
+        environ['ANSIBLE_NOCOLOR'] = '1'
         args = self._build_args()
         command = ' '.join(args)
         log.debug("Running %s", command)


### PR DESCRIPTION
I tested this locally and the environment variable does work.