### PR TITLE
ansible: decode('utf-8') before logging

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -29,7 +29,7 @@ class LoggerFile(object):
         self.level = level
 
     def write(self, string):
-        self.logger.log(self.level, string)
+        self.logger.log(self.level, string.decode('utf-8'))
 
     def flush(self):
         pass


### PR DESCRIPTION
Otherwise it may fail if LC_ALL=C

Signed-off-by: Loic Dachary <loic@dachary.org>