### PR TITLE
nuke: gracefully handle zero targets

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -419,6 +419,8 @@ def main(args):
 
 
 def nuke(ctx, should_unlock, sync_clocks=True, reboot_all=True, noipmi=False):
+    if 'targets' not in ctx.config:
+        return
     total_unnuked = {}
     targets = dict(ctx.config['targets'])
     if ctx.name:


### PR DESCRIPTION
If nuke is called with no targets, just do nothing instead of failing
because the target element is not found in the map. This can happen if
the machine fails to be provisioned early in the process.

Signed-off-by: Loic Dachary <loic@dachary.org>