### PR TITLE
ssh_keyscan_wait: blocking version of ssh_keysscan

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1147,6 +1147,23 @@ def ssh_keyscan(hostnames):
     return keys_dict
 
 
+def ssh_keyscan_wait(hostname):
+    """
+    Run ssh-keyscan against a host, return True if it succeeds,
+    False otherwise. Try again if ssh-keyscan timesout.
+    :param hostname: on which ssh-keyscan is run
+    """
+    with safe_while(sleep=6, tries=100,
+                    action="ssh_keyscan_wait " + hostname) as proceed:
+        success = False
+        while proceed():
+            keys_dict = ssh_keyscan([hostname])
+            if len(keys_dict) == 1:
+                success = True
+                break
+            log.info("try ssh_keyscan again for " + str(hostname))
+        return success
+
 def stop_daemons_of_type(ctx, type_):
     """
     :param type_: type of daemons to be stopped.


### PR DESCRIPTION
ssh_keyscan is designed to return almost immediately if there is no
connection (the timeout is 1 second). ssh_keyscan_wait will wait up to
10 minutes and report progress every 6 seconds.

Signed-off-by: Loic Dachary <loic@dachary.org>