### PR TITLE
ansible: decode('utf-8', 'ignore') before logging

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -29,7 +29,7 @@ class LoggerFile(object):
         self.level = level
 
     def write(self, string):
-        self.logger.log(self.level, string.decode('utf-8'))
+        self.logger.log(self.level, string.decode('utf-8', 'ignore'))
 
     def flush(self):
         pass


### PR DESCRIPTION
b834dd6660a77379b2c693a36487352941a8e52d added decode('utf-8') which
breaks when a substring inadevertendly cuts in the middle of a valid
utf-8 sequence. Add the 'ignore' so the offending sequence is discarded
instead of raising an error.

Signed-off-by: Loic Dachary <loic@dachary.org>