### PR TITLE
Introduces teuthology.packaging.GitbuilderProject

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -28,6 +28,7 @@ from teuthology.exceptions import (CommandCrashedError, CommandFailedError,
 from .orchestra import run
 from .config import config
 from .contextutil import safe_while
+from .packaging import DEFAULT_OS_VERSION
 
 log = logging.getLogger(__name__)
 
@@ -1236,22 +1237,13 @@ def get_distro_version(ctx):
     """
     Get the verstion of the distro that we are using (release number).
     """
-    default_os_version = dict(
-        ubuntu="14.04",
-        fedora="20",
-        centos="7.0",
-        opensuse="12.2",
-        sles="11-sp2",
-        rhel="7.0",
-        debian='7.0'
-    )
     distro = get_distro(ctx)
     if ctx.os_version is not None:
         return ctx.os_version
     try:
-        os_version = ctx.config.get('os_version', default_os_version[distro])
+        os_version = ctx.config.get('os_version', DEFAULT_OS_VERSION[distro])
     except AttributeError:
-        os_version = default_os_version[distro]
+        os_version = DEFAULT_OS_VERSION[distro]
     return os_version
 
 

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -502,8 +502,20 @@ class GitbuilderProject(object):
         return self._get_base_url()
 
     @property
-    def uri(self):
-        return self._get_uri()
+    def uri_reference(self):
+        """
+        The URI reference that identifies what build of the project
+        we'd like to use.
+
+        For example, the following could be returned::
+
+            ref/<branch>
+            sha1/<sha1>
+            ref/<tag>
+
+        :returns: The uri_reference as a string.
+        """
+        return self._get_uri_reference()
 
     def _parse_version(self, version):
         """
@@ -594,10 +606,10 @@ class GitbuilderProject(object):
 
         return version
 
-    def _get_uri(self):
+    def _get_uri_reference(self):
         """
-        Returns the URI that identifies what build of the project we'd like
-        to use.
+        Returns the URI reference that identifies what build of the project
+        we'd like to use.
 
         If a remote is given, it will attempt to read the config for the given
         remote to find either a tag, branch or sha1 defined. If there is no
@@ -644,7 +656,7 @@ class GitbuilderProject(object):
             arch=self.arch,
             dist=self.distro,
             flavor=self.flavor,
-            uri=self.uri,
+            uri=self.uri_reference,
         )
         return base_url
 

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -5,7 +5,6 @@ import requests
 
 from cStringIO import StringIO
 
-from teuthology import misc
 from .config import config
 
 log = logging.getLogger(__name__)
@@ -53,7 +52,7 @@ def get_package_name(pkg, rem):
     """
     Find the remote-specific name of the generic 'pkg'
     """
-    flavor = misc.get_system_type(rem)
+    flavor = rem.os.package_type
 
     try:
         return _PACKAGE_MAP[pkg][flavor]
@@ -65,7 +64,7 @@ def get_service_name(service, rem):
     """
     Find the remote-specific name of the generic 'service'
     """
-    flavor = misc.get_system_type(rem)
+    flavor = rem.os.package_type
     try:
         return _SERVICE_MAP[service][flavor]
     except KeyError:
@@ -78,7 +77,7 @@ def install_package(package, remote):
     Assumes repo has already been set up (perhaps with install_repo)
     """
     log.info('Installing package %s on %s', package, remote)
-    flavor = misc.get_system_type(remote)
+    flavor = remote.os.package_type
     if flavor == 'deb':
         pkgcmd = ['DEBIAN_FRONTEND=noninteractive',
                   'sudo',
@@ -103,7 +102,7 @@ def remove_package(package, remote):
     """
     Remove package from remote
     """
-    flavor = misc.get_system_type(remote)
+    flavor = remote.os.package_type
     if flavor == 'deb':
         pkgcmd = ['DEBIAN_FRONTEND=noninteractive',
                   'sudo',

--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -150,7 +150,7 @@ def _get_baseurlinfo_and_dist(ctx, remote, config):
         distro=distro,
         version=version,
     )
-    # this is used when contructing the rpm name
+    # this is used when constructing the rpm name
     result["dist_release"] = dist_release
 
     # branch/tag/sha1 flavor
@@ -173,7 +173,7 @@ def _get_gitbuilder_version(version):
 
     Minor version numbers are ignored if they end in a zero. If they do
     not end in a zero the minor version number is included with a dash as
-    the separtor instead of a period.
+    the separator instead of a period.
     """
     version_tokens = version.split(".")
     include_minor_version = (
@@ -181,7 +181,7 @@ def _get_gitbuilder_version(version):
         version_tokens[1] != "0"
     )
     if include_minor_version:
-        return "-".join(version_tokens)
+        return "_".join(version_tokens)
 
     # return only the major version
     return version_tokens[0]

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -80,3 +80,84 @@ class TestInstall(object):
             valgrind=True
         )
         assert install.get_flavor(config) == 'notcmalloc'
+
+    @patch("teuthology.task.install._get_config_value_for_remote")
+    def test_get_baseurlinfo_and_dist_rhel(self, m_get_config_value_for_remote):
+        remote = Mock()
+        remote.os.name = "rhel"
+        remote.os.version = "7.0"
+        remote.arch = "x86_64"
+        m_get_config_value_for_remote.return_value = "tag"
+        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
+        expected = dict(
+            dist="centos7",
+            arch="x86_64",
+            flavor="basic",
+            uri="ref/tag",
+            dist_release="el7"
+        )
+        assert result == expected
+
+    @patch("teuthology.task.install._get_config_value_for_remote")
+    def test_get_baseurlinfo_and_dist_minor_version_allowed(self, m_get_config_value_for_remote):
+        remote = Mock()
+        remote.os.name = "centos"
+        remote.os.version = "6.5"
+        remote.arch = "x86_64"
+        m_get_config_value_for_remote.return_value = "tag"
+        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
+        expected = dict(
+            dist="centos6-5",
+            arch="x86_64",
+            flavor="basic",
+            uri="ref/tag",
+            dist_release="el6-5",
+        )
+        assert result == expected
+
+    @patch("teuthology.task.install._get_config_value_for_remote")
+    def test_get_baseurlinfo_and_dist_fedora(self, m_get_config_value_for_remote):
+        remote = Mock()
+        remote.os.name = "fedora"
+        remote.os.version = "20"
+        remote.arch = "x86_64"
+        m_get_config_value_for_remote.return_value = "tag"
+        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
+        expected = dict(
+            dist="fc20",
+            arch="x86_64",
+            flavor="basic",
+            uri="ref/tag",
+            dist_release="fc20",
+        )
+        assert result == expected
+
+    @patch("teuthology.task.install._get_config_value_for_remote")
+    def test_get_baseurlinfo_and_dist_ubuntu(self, m_get_config_value_for_remote):
+        remote = Mock()
+        remote.os.name = "ubuntu"
+        remote.os.version = "14.04"
+        remote.os.codename = "trusty"
+        remote.arch = "x86_64"
+        m_get_config_value_for_remote.return_value = "tag"
+        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
+        expected = dict(
+            dist="trusty",
+            arch="x86_64",
+            flavor="basic",
+            uri="ref/tag",
+            dist_release="trusty",
+        )
+        assert result == expected
+
+    def test_get_uri_tag(self):
+        assert "ref/thetag" == install._get_uri("thetag", None, None)
+
+    def test_get_uri_branch(self):
+        assert "ref/thebranch" == install._get_uri(None, "thebranch", None)
+
+    def test_get_uri_sha1(self):
+        assert "sha1/thesha1" == install._get_uri(None, None, "thesha1")
+
+    def test_get_uri_default(self):
+        assert "ref/master" == install._get_uri(None, None, None)

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -107,11 +107,11 @@ class TestInstall(object):
         m_get_config_value_for_remote.return_value = "tag"
         result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
         expected = dict(
-            dist="centos6-5",
+            dist="centos6_5",
             arch="x86_64",
             flavor="basic",
             uri="ref/tag",
-            dist_release="el6-5",
+            dist_release="el6_5",
         )
         assert result == expected
 

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -28,40 +28,39 @@ KOJI_TASK_RPMS = [rpm[0] for rpm in KOJI_TASK_RPMS_MATRIX]
 
 class TestPackaging(object):
 
-    @patch("teuthology.packaging.misc")
-    def test_get_package_name_deb(self, m_misc):
-        m_misc.get_system_type.return_value = "deb"
-        assert packaging.get_package_name('sqlite', Mock()) == "sqlite3"
+    def test_get_package_name_deb(self):
+        remote = Mock()
+        remote.os.package_type = "deb"
+        assert packaging.get_package_name('sqlite', remote) == "sqlite3"
 
-    @patch("teuthology.packaging.misc")
-    def test_get_package_name_rpm(self, m_misc):
-        m_misc.get_system_type.return_value = "rpm"
-        assert packaging.get_package_name('sqlite', Mock()) is None
+    def test_get_package_name_rpm(self):
+        remote = Mock()
+        remote.os.package_type = "rpm"
+        assert packaging.get_package_name('sqlite', remote) is None
 
-    @patch("teuthology.packaging.misc")
-    def test_get_package_name_not_found(self, m_misc):
-        m_misc.get_system_type.return_value = "rpm"
-        assert packaging.get_package_name('notthere', Mock()) is None
+    def test_get_package_name_not_found(self):
+        remote = Mock()
+        remote.os.package_type = "rpm"
+        assert packaging.get_package_name('notthere', remote) is None
 
-    @patch("teuthology.packaging.misc")
-    def test_get_service_name_deb(self, m_misc):
-        m_misc.get_system_type.return_value = "deb"
-        assert packaging.get_service_name('httpd', Mock()) == 'apache2'
+    def test_get_service_name_deb(self):
+        remote = Mock()
+        remote.os.package_type = "deb"
+        assert packaging.get_service_name('httpd', remote) == 'apache2'
 
-    @patch("teuthology.packaging.misc")
-    def test_get_service_name_rpm(self, m_misc):
-        m_misc.get_system_type.return_value = "rpm"
-        assert packaging.get_service_name('httpd', Mock()) == 'httpd'
+    def test_get_service_name_rpm(self):
+        remote = Mock()
+        remote.os.package_type = "rpm"
+        assert packaging.get_service_name('httpd', remote) == 'httpd'
 
-    @patch("teuthology.packaging.misc")
-    def test_get_service_name_not_found(self, m_misc):
-        m_misc.get_system_type.return_value = "rpm"
-        assert packaging.get_service_name('notthere', Mock()) is None
+    def test_get_service_name_not_found(self):
+        remote = Mock()
+        remote.os.package_type = "rpm"
+        assert packaging.get_service_name('notthere', remote) is None
 
-    @patch("teuthology.packaging.misc")
-    def test_install_package_deb(self, m_misc):
-        m_misc.get_system_type.return_value = "deb"
+    def test_install_package_deb(self):
         m_remote = Mock()
+        m_remote.os.package_type = "deb"
         expected = [
             'DEBIAN_FRONTEND=noninteractive',
             'sudo',
@@ -74,10 +73,9 @@ class TestPackaging(object):
         packaging.install_package('apache2', m_remote)
         m_remote.run.assert_called_with(args=expected)
 
-    @patch("teuthology.packaging.misc")
-    def test_install_package_rpm(self, m_misc):
-        m_misc.get_system_type.return_value = "rpm"
+    def test_install_package_rpm(self):
         m_remote = Mock()
+        m_remote.os.package_type = "rpm"
         expected = [
             'sudo',
             'yum',
@@ -88,10 +86,9 @@ class TestPackaging(object):
         packaging.install_package('httpd', m_remote)
         m_remote.run.assert_called_with(args=expected)
 
-    @patch("teuthology.packaging.misc")
-    def test_remove_package_deb(self, m_misc):
-        m_misc.get_system_type.return_value = "deb"
+    def test_remove_package_deb(self):
         m_remote = Mock()
+        m_remote.os.package_type = "deb"
         expected = [
             'DEBIAN_FRONTEND=noninteractive',
             'sudo',
@@ -104,10 +101,9 @@ class TestPackaging(object):
         packaging.remove_package('apache2', m_remote)
         m_remote.run.assert_called_with(args=expected)
 
-    @patch("teuthology.packaging.misc")
-    def test_remove_package_rpm(self, m_misc):
-        m_misc.get_system_type.return_value = "rpm"
+    def test_remove_package_rpm(self):
         m_remote = Mock()
+        m_remote.os.package_type = "rpm"
         expected = [
             'sudo',
             'yum',


### PR DESCRIPTION
teuthology.suite, teuthology.task.install and teuthology.task.internal.check_packages all use different methods to check for packages in gitbuilder.  This provides a standard interface that all places in teuthology should be able to use to interact with packages on gitbuilder.

I'm looking for feedback on the class and the approach.  I've implemented it's usage in teuthology.task.internal.check_packages and that tests out with manual teuthology runs.  I've scheduled a suite, but it hasn't completed yet.

I'm hoping we can agree on  the approach and usage in check_packages in this PR and then submit others to use this in suite and install.

I've also done a bit of refactoring and testing to install here as well.