### PR TITLE
Remove buggy error checking in lock_machines()

### DIFF
--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -117,8 +117,6 @@ def lock_machines(ctx, config):
 
         newly_locked = lock.lock_many(ctx, how_many, machine_type, ctx.owner,
                                       ctx.archive, os_type, os_version, arch)
-        if not newly_locked and not isinstance(newly_locked, list):
-            raise RuntimeError('Invalid parameters specified')
         all_locked.update(newly_locked)
         if len(all_locked) == how_many:
             vmlist = []


### PR DESCRIPTION
http://tracker.ceph.com/issues/12462

If lock_many() fails to create any VMs, it returns an empty dict, which
was causing an exception to be raised. The existing error reporting in
lock_many() should be adequate here.

Signed-off-by: Zack Cerza <zack@redhat.com>