### PR TITLE
task/install: rest-bench has been removed

### DIFF
--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -56,7 +56,6 @@ PACKAGES['ceph']['rpm'] = [
     'ceph',
     'ceph-fuse',
     'cephfs-java',
-    'rest-bench',
     'libcephfs_jni1',
     'libcephfs1',
     'librados2',


### PR DESCRIPTION
Removed this tool from upstream.  Don't install (or remove) it any more!

Signed-off-by: Sage Weil <sage@redhat.com>