### PR TITLE
packaging: ignore minor version numbers in gitbuilder urls

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -521,20 +521,9 @@ class GitbuilderProject(object):
         Parses a distro version string and returns a modified string
         that matches the format needed for the gitbuilder url.
 
-        Minor version numbers are ignored if they end in a zero. If they do
-        not end in a zero the minor version number is included with an
-        underscore as the separator instead of a period.
+        Minor version numbers are ignored.
         """
-        version_tokens = version.split(".")
-        include_minor_version = (
-            len(version_tokens) > 1 and
-            version_tokens[1] != "0"
-        )
-        if include_minor_version:
-            return "_".join(version_tokens)
-
-        # return only the major version
-        return version_tokens[0]
+        return version.split(".")[0]
 
     def _get_distro(self, distro=None, version=None, codename=None):
         """

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -352,7 +352,9 @@ class TestGitbuilderProject(object):
 
     GITBUILDER_DISTRO_MATRIX = [
         ('rhel', '7.0', None, 'centos7'),
-        ('centos', '6.5', None, 'centos6_5'),
+        ('centos', '6.5', None, 'centos6'),
+        ('centos', '7.0', None, 'centos7'),
+        ('centos', '7.1', None, 'centos7'),
         ('fedora', '20', None, 'fc20'),
         ('ubuntu', '14.04', 'trusty', 'trusty'),
         ('ubuntu', '14.04', None, 'trusty'),


### PR DESCRIPTION
We don't care about minor version numbers anymore for gitbuilder.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>