### PR TITLE
install: ignore minor version when building a gitbuilder url

### DIFF
--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -171,20 +171,10 @@ def _get_gitbuilder_version(version):
     Parses a distro version string and returns a modified string
     that matches the format needed for the gitbuilder url.
 
-    Minor version numbers are ignored if they end in a zero. If they do
-    not end in a zero the minor version number is included with a dash as
-    the separator instead of a period.
+    Minor version numbers are ignored.
     """
-    version_tokens = version.split(".")
-    include_minor_version = (
-        len(version_tokens) > 1 and
-        version_tokens[1] != "0"
-    )
-    if include_minor_version:
-        return "_".join(version_tokens)
-
     # return only the major version
-    return version_tokens[0]
+    return version.split(".")[0]
 
 
 def _get_baseurl(ctx, remote, config):

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -107,11 +107,11 @@ class TestInstall(object):
         m_get_config_value_for_remote.return_value = "tag"
         result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
         expected = dict(
-            dist="centos6_5",
+            dist="centos6",
             arch="x86_64",
             flavor="basic",
             uri="ref/tag",
-            dist_release="el6_5",
+            dist_release="el6",
         )
         assert result == expected
 


### PR DESCRIPTION
We don't care about minor version in gitbuilder anymore.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>