### PR TITLE
ansible: read the ansible failure log and raise a more meaningful error

### DIFF
--- a/teuthology/exceptions.py
+++ b/teuthology/exceptions.py
@@ -52,6 +52,20 @@ class CommandFailedError(Exception):
             )
 
 
+class AnsibleFailedError(Exception):
+
+    """
+    Exception thrown when an ansible playbook fails
+    """
+    def __init__(self, failures):
+        self.failures = failures
+
+    def __str__(self):
+        return "{failures}".format(
+            failures=self.failures,
+        )
+
+
 class CommandCrashedError(Exception):
 
     """


### PR DESCRIPTION
This works with a custom ansible callback plugin that intercepts task
failures and writes them to a log file (in yaml format) provided by the
ansible task as an environment variable. If the playbook fails, teuthology
reads that failure log and raises an AnsibleFailedError with the actual
output from the failed ansible task.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>