### PR TITLE
make a colored version of teuthology.log

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
                       'pyopenssl>=0.13',
                       'ndg-httpsclient',
                       'pyasn1',
+                      'ansi2html',
                       ],
 
 

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -5,6 +5,7 @@ import contextlib
 import sys
 import logging
 from traceback import format_tb
+from ansi2html import Ansi2HTMLConverter
 
 import teuthology
 from . import report
@@ -243,11 +244,24 @@ def report_outcome(config, archive, summary, fake_ctx):
 
     report.try_push_job_info(config, summary)
 
+    teuth_log = os.path.join(archive, 'teuthology.log')
     if passed:
         log.info(status)
+        make_html_log(teuth_log)
     else:
         log.info(str(status).upper())
+        make_html_log(teuth_log)
         sys.exit(1)
+
+
+def make_html_log(teuth_log):
+    with open(teuth_log, 'r') as output:
+        conv = Ansi2HTMLConverter()
+        html = conv.convert(output.read())
+
+    if html:
+        with open("{0}.html".format(teuth_log), "w") as html_log:
+            html_log.write(html)
 
 
 def get_teuthology_command(args):

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -119,9 +119,10 @@ class TestRun(object):
     @patch("yaml.safe_dump")
     @patch("teuthology.report.try_push_job_info")
     @patch("teuthology.run.email_results")
+    @patch("teuthology.run.make_html_log")
     @patch("__builtin__.file")
     @patch("sys.exit")
-    def test_report_outcome(self, m_sys_exit, m_file, m_email_results, m_try_push_job_info, m_safe_dump, m_nuke, m_get_status):
+    def test_report_outcome(self, m_sys_exit, m_file, m_email_results, m_make_html_log, m_try_push_job_info, m_safe_dump, m_nuke, m_get_status):
         config = {"nuke-on-error": True, "email-on-error": True}
         m_get_status.return_value = "fail"
         fake_ctx = Mock()
@@ -133,6 +134,7 @@ class TestRun(object):
         assert m_email_results.called
         assert m_file.called
         assert m_sys_exit.called
+        assert m_make_html_log.called
 
     @patch("teuthology.run.set_up_logging")
     @patch("teuthology.run.setup_config")


### PR DESCRIPTION
This uses ansi2html to convert the teuthology.log to an html file that
shows the ansi colors.

See an example here: 

http://qa-proxy.ceph.com/teuthology/ubuntu-2015-08-05_13:51:24-teuthology-master---basic-multi/1001742/teuthology.log.html
