### PR TITLE
fix ansible error reporting

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -4,6 +4,7 @@ import requests
 import os
 import pexpect
 import yaml
+import shutil
 
 from cStringIO import StringIO
 from tempfile import NamedTemporaryFile
@@ -266,7 +267,11 @@ class Ansible(Task):
             try:
                 failures = yaml.safe_load(log)
             except yaml.parser.ParserError:
-                log.exception("Failed to load failure log...")
+                log.exception(
+                    "Failed to parse ansible failure log: {0}".format(
+                        self.failure_log.name,
+                    )
+                )
 
         if failures:
             if self.ctx.archive:
@@ -275,9 +280,13 @@ class Ansible(Task):
         raise CommandFailedError(command, status)
 
     def _archive_failures(self):
-        os.rename(
+        archive_path = "{0}/ansible_failures.yaml".format(self.ctx.archive)
+        log.info("Archiving ansible failure log at: {0}".format(
+            archive_path,
+        ))
+        shutil.move(
             self.failure_log.name,
-            "{0}/ansible_failures.yaml".format(self.ctx.archive)
+            archive_path
         )
 
     def _build_args(self):

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -263,7 +263,10 @@ class Ansible(Task):
     def _handle_failure(self, command, status):
         failures = None
         with open(self.failure_log.name, 'r') as log:
-            failures = yaml.safe_load(log)
+            try:
+                failures = yaml.safe_load(log)
+            except yaml.parser.ParserError:
+                log.exception("Failed to load failure log...")
 
         if failures:
             if self.ctx.archive:


### PR DESCRIPTION
When moving the error log between file systems of two different types os.rename will throw an error while shutil.move correctly handles that case.  See: http://tracker.ceph.com/issues/12656

I've also added some exception handling incase we fail to parse the error log.  All it does is fail silently and log the exception so that we can inspect the log after the fact. See: http://tracker.ceph.com/issues/12675