### PR TITLE
refactor the install task to use packaging.GitbuilderProject

### DIFF
--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -7,45 +7,25 @@ from teuthology.task import install
 
 class TestInstall(object):
 
-    @patch("teuthology.task.install.teuth_config")
-    @patch("teuthology.task.install._get_baseurlinfo_and_dist")
-    def test_get_baseurl(self, m_get_baseurlinfo_and_dist, m_config):
-        m_config.gitbuilder_host = 'FQDN'
-        config = {'project': 'CEPH'}
-        remote = Mock()
-        remote.system_type = 'rpm'
-        m_config.baseurl_template = (
-            'OVERRIDE: {host}/{proj}-{pkg_type}-{dist}-{arch}-{flavor}/{uri}')
-        baseurlinfo_and_dist = {
-            'dist': 'centos7',
-            'arch': 'i386',
-            'flavor': 'notcmalloc',
-            'uri': 'ref/master',
-        }
-        m_get_baseurlinfo_and_dist.return_value = baseurlinfo_and_dist
-        expected = m_config.baseurl_template.format(
-            host=m_config.gitbuilder_host,
-            proj=config['project'],
-            pkg_type=remote.system_type,
-            **baseurlinfo_and_dist)
-        actual = install._get_baseurl(Mock(), remote, config)
-        assert expected == actual
-
-    @patch("teuthology.task.install._get_baseurl")
-    @patch("teuthology.task.install._block_looking_for_package_version")
+    @patch("teuthology.task.install._get_gitbuilder_project")
     @patch("teuthology.task.install.packaging.get_package_version")
-    def test_verify_ceph_version_success(self, m_get_package_version, m_block,
-                                         m_get_baseurl):
-        m_block.return_value = "0.89.0"
+    def test_verify_ceph_version_success(self, m_get_package_version,
+                                         m_gitbuilder_project):
+        gb = Mock()
+        gb.version = "0.89.0"
+        gb.project = "ceph"
+        m_gitbuilder_project.return_value = gb
         m_get_package_version.return_value = "0.89.0"
         install.verify_package_version(Mock(), Mock(), Mock())
 
-    @patch("teuthology.task.install._get_baseurl")
-    @patch("teuthology.task.install._block_looking_for_package_version")
+    @patch("teuthology.task.install._get_gitbuilder_project")
     @patch("teuthology.task.install.packaging.get_package_version")
-    def test_verify_ceph_version_failed(self, m_get_package_version, m_block,
-                                        m_get_baseurl):
-        m_block.return_value = "0.89.0"
+    def test_verify_ceph_version_failed(self, m_get_package_version,
+                                        m_gitbuilder_project):
+        gb = Mock()
+        gb.version = "0.89.0"
+        gb.project = "ceph"
+        m_gitbuilder_project.return_value = gb
         m_get_package_version.return_value = "0.89.1"
         config = Mock()
         # when it looks for config.get('extras') it won't find it
@@ -53,12 +33,14 @@ class TestInstall(object):
         with pytest.raises(RuntimeError):
             install.verify_package_version(Mock(), config, Mock())
 
-    @patch("teuthology.task.install._get_baseurl")
-    @patch("teuthology.task.install._block_looking_for_package_version")
+    @patch("teuthology.task.install._get_gitbuilder_project")
     @patch("teuthology.task.install.packaging.get_package_version")
-    def test_skip_when_using_ceph_deploy(self, m_get_package_version, m_block,
-                                         m_get_baseurl):
-        m_block.return_value = "0.89.0"
+    def test_skip_when_using_ceph_deploy(self, m_get_package_version,
+                                         m_gitbuilder_project):
+        gb = Mock()
+        gb.version = "0.89.0"
+        gb.project = "ceph"
+        m_gitbuilder_project.return_value = gb
         # ceph isn't installed because ceph-deploy would install it
         m_get_package_version.return_value = None
         config = Mock()
@@ -80,84 +62,3 @@ class TestInstall(object):
             valgrind=True
         )
         assert install.get_flavor(config) == 'notcmalloc'
-
-    @patch("teuthology.task.install._get_config_value_for_remote")
-    def test_get_baseurlinfo_and_dist_rhel(self, m_get_config_value_for_remote):
-        remote = Mock()
-        remote.os.name = "rhel"
-        remote.os.version = "7.0"
-        remote.arch = "x86_64"
-        m_get_config_value_for_remote.return_value = "tag"
-        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
-        expected = dict(
-            dist="centos7",
-            arch="x86_64",
-            flavor="basic",
-            uri="ref/tag",
-            dist_release="el7"
-        )
-        assert result == expected
-
-    @patch("teuthology.task.install._get_config_value_for_remote")
-    def test_get_baseurlinfo_and_dist_minor_version_allowed(self, m_get_config_value_for_remote):
-        remote = Mock()
-        remote.os.name = "centos"
-        remote.os.version = "6.5"
-        remote.arch = "x86_64"
-        m_get_config_value_for_remote.return_value = "tag"
-        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
-        expected = dict(
-            dist="centos6",
-            arch="x86_64",
-            flavor="basic",
-            uri="ref/tag",
-            dist_release="el6",
-        )
-        assert result == expected
-
-    @patch("teuthology.task.install._get_config_value_for_remote")
-    def test_get_baseurlinfo_and_dist_fedora(self, m_get_config_value_for_remote):
-        remote = Mock()
-        remote.os.name = "fedora"
-        remote.os.version = "20"
-        remote.arch = "x86_64"
-        m_get_config_value_for_remote.return_value = "tag"
-        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
-        expected = dict(
-            dist="fc20",
-            arch="x86_64",
-            flavor="basic",
-            uri="ref/tag",
-            dist_release="fc20",
-        )
-        assert result == expected
-
-    @patch("teuthology.task.install._get_config_value_for_remote")
-    def test_get_baseurlinfo_and_dist_ubuntu(self, m_get_config_value_for_remote):
-        remote = Mock()
-        remote.os.name = "ubuntu"
-        remote.os.version = "14.04"
-        remote.os.codename = "trusty"
-        remote.arch = "x86_64"
-        m_get_config_value_for_remote.return_value = "tag"
-        result = install._get_baseurlinfo_and_dist(Mock(), remote, dict())
-        expected = dict(
-            dist="trusty",
-            arch="x86_64",
-            flavor="basic",
-            uri="ref/tag",
-            dist_release="trusty",
-        )
-        assert result == expected
-
-    def test_get_uri_tag(self):
-        assert "ref/thetag" == install._get_uri("thetag", None, None)
-
-    def test_get_uri_branch(self):
-        assert "ref/thebranch" == install._get_uri(None, "thebranch", None)
-
-    def test_get_uri_sha1(self):
-        assert "sha1/thesha1" == install._get_uri(None, None, "thesha1")
-
-    def test_get_uri_default(self):
-        assert "ref/master" == install._get_uri(None, None, None)

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -407,3 +407,27 @@ class TestGitbuilderProject(object):
         )
         gp = packaging.GitbuilderProject("ceph", config)
         assert gp.distro == expected
+
+    GITBUILDER_DIST_RELEASE_MATRIX = [
+        ('rhel', '7.0', None, 'el7'),
+        ('centos', '6.5', None, 'el6'),
+        ('centos', '7.0', None, 'el7'),
+        ('centos', '7.1', None, 'el7'),
+        ('fedora', '20', None, 'fc20'),
+        ('debian', '7.0', None, 'debian'),
+        ('debian', '7', None, 'debian'),
+        ('debian', '7.1', None, 'debian'),
+        ('ubuntu', '12.04', None, 'ubuntu'),
+        ('ubuntu', '14.04', None, 'ubuntu'),
+    ]
+
+    @pytest.mark.parametrize(
+        "distro, version, codename, expected",
+        GITBUILDER_DIST_RELEASE_MATRIX
+    )
+    def test_get_dist_release(self, distro, version, codename, expected):
+        rem = self._get_remote(distro=distro, version=version,
+                               codename=codename)
+        ctx = dict(foo="bar")
+        gp = packaging.GitbuilderProject("ceph", {}, ctx=ctx, remote=rem)
+        assert gp.dist_release == expected

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -360,6 +360,7 @@ class TestGitbuilderProject(object):
         ('ubuntu', '14.04', None, 'trusty'),
         ('debian', '7.0', None, 'wheezy'),
         ('debian', '7', None, 'wheezy'),
+        ('debian', '7.1', None, 'wheezy'),
         ('ubuntu', '12.04', None, 'precise'),
         ('ubuntu', '14.04', None, 'trusty'),
     ]

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -304,6 +304,20 @@ class TestGitbuilderProject(object):
         assert result == expected
 
     @patch("teuthology.packaging.config")
+    @patch("teuthology.packaging._get_config_value_for_remote")
+    def test_init_from_remote_base_url_debian(self, m_get_config_value, m_config):
+        m_config.baseurl_template = 'http://{host}/{proj}-{pkg_type}-{dist}-{arch}-{flavor}/{uri}'
+        m_config.gitbuilder_host = "gitbuilder.ceph.com"
+        m_get_config_value.return_value = None
+        # remote.os.codename returns and empty string on debian
+        rem = self._get_remote(distro="debian", codename='', version="7.1")
+        ctx = dict(foo="bar")
+        gp = packaging.GitbuilderProject("ceph", {}, ctx=ctx, remote=rem)
+        result = gp.base_url
+        expected = "http://gitbuilder.ceph.com/ceph-deb-wheezy-x86_64-basic/ref/master"
+        assert result == expected
+
+    @patch("teuthology.packaging.config")
     def test_init_from_config_base_url(self, m_config):
         m_config.baseurl_template = 'http://{host}/{proj}-{pkg_type}-{dist}-{arch}-{flavor}/{uri}'
         m_config.gitbuilder_host = "gitbuilder.ceph.com"


### PR DESCRIPTION
I've tested this on Ubuntu, Debian and Centos.  It might be smart to run an upgrade suite with this branch before merging just to be safe though.

This should fix: http://tracker.ceph.com/issues/12668