### PR TITLE
ansible: rename log to fail_log to not conflict with ansible.log

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -263,9 +263,9 @@ class Ansible(Task):
 
     def _handle_failure(self, command, status):
         failures = None
-        with open(self.failure_log.name, 'r') as log:
+        with open(self.failure_log.name, 'r') as fail_log:
             try:
-                failures = yaml.safe_load(log)
+                failures = yaml.safe_load(fail_log)
             except yaml.parser.ParserError:
                 log.exception(
                     "Failed to parse ansible failure log: {0}".format(


### PR DESCRIPTION
Fixing a bug introduced with https://github.com/ceph/teuthology/pull/595.  When I opened the failure_log I gave it the name ``log`` which conflicts with ``ansible.log`` which is what I was really wanting to use with ``log.exception``.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>