### PR TITLE
task.ansible: set the ansible_failure.yaml file mode to 0664

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -288,6 +288,7 @@ class Ansible(Task):
             self.failure_log.name,
             archive_path
         )
+        os.chmod(archive_path, 0664)
 
     def _build_args(self):
         """


### PR DESCRIPTION
Without the permissions set correctly apache will not serve this file

Signed-off-by: Andrew Schoen <aschoen@redhat.com>