### PR TITLE
ansible: raise an AnsibleFailedError even when parsing fails

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -267,14 +267,12 @@ class Ansible(Task):
             try:
                 failures = yaml.safe_load(fail_log)
             except yaml.parser.ParserError:
-                log.exception(
+                log.error(
                     "Failed to parse ansible failure log: {0}".format(
                         self.failure_log.name,
                     )
                 )
-                # archive the log anyway so we can see what tripped up
-                # the yaml parsing
-                self._archive_failures()
+                failures = fail_log
 
         if failures:
             self._archive_failures()


### PR DESCRIPTION
If _handle_failures fails to parse the yaml in the ansible error log, it
can still give the contents of the failure log to an AnsibleFailedError
in it's unparsed form.

I also changed the log.exception to log.error when an ParserError occurs
as I think it was confusing some having that extra traceback in the log.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>