### PR TITLE
test_execute_playbook(): patch Remote.reconnect()

### DIFF
--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -257,7 +257,9 @@ class TestAnsibleTask(TestTask):
         logger = StringIO()
         with patch.object(ansible.pexpect, 'run') as m_run:
             m_run.return_value = ('', 0)
-            task.execute_playbook(_logfile=logger)
+            with patch.object(Remote, 'reconnect') as m_reconnect:
+                m_reconnect.return_value = True
+                task.execute_playbook(_logfile=logger)
             m_run.assert_called_once_with(
                 ' '.join(args),
                 logfile=logger,


### PR DESCRIPTION
Speeds up that unit test greatly.

Signed-off-by: Zack Cerza <zack@redhat.com>