### PR TITLE
suite: pass dev-commit: <sha1> to ceph-deploy

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -1006,7 +1006,7 @@ dict_templ = {
         },
         'ceph-deploy': {
             'branch': {
-                'dev': Placeholder('ceph_branch'),
+                'dev-commit': Placeholder('ceph_hash'),
             },
             'conf': {
                 'client': {


### PR DESCRIPTION
Use the new ceph-deploy install --dev-commit <sha1> option to inform the
install.

Signed-off-by: Sage Weil <sage@redhat.com>