### PR TITLE
internal: ceph-deploy may have ceph-create-keys INFO in syslog

### DIFF
--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -677,6 +677,8 @@ def syslog(ctx, config):
                     run.Raw('|'),
                     'grep', '-v', 'INFO: recovery required on readonly',
                     run.Raw('|'),
+                    'grep', '-v', 'ceph-create-keys: INFO',
+                    run.Raw('|'),
                     'head', '-n', '1',
                 ],
                 stdout=StringIO(),


### PR DESCRIPTION
This is not a concern for error and should be ignored.

Signed-off-by: Loic Dachary <loic@dachary.org>