### PR TITLE
Adds option to override the default SSH port

### DIFF
--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -38,7 +38,7 @@ def create_key(keytype, key):
 
 
 def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,
-            _SSHClient=None, _create_key=None):
+            _SSHClient=None, _create_key=None, port=22):
     """
     ssh connection routine.
 
@@ -74,7 +74,8 @@ def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,
     connect_args = dict(
         hostname=host,
         username=user,
-        timeout=timeout
+        timeout=timeout,
+        port=port
     )
 
     ssh_config_path = os.path.expanduser("~/.ssh/config")

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -35,7 +35,7 @@ class Remote(object):
     _runner = staticmethod(run.run)
 
     def __init__(self, name, ssh=None, shortname=None, console=None,
-                 host_key=None, keep_alive=True, ssh_port=22):
+                 host_key=None, keep_alive=True, port=22):
         self.name = name
         if '@' in name:
             (self.user, hostname) = name.split('@')
@@ -52,7 +52,7 @@ class Remote(object):
         self.keep_alive = keep_alive
         self.console = console
         self.ssh = ssh
-        self.ssh_port = ssh_port
+        self.ssh_port = port
 
     def connect(self, timeout=None):
         args = dict(user_at_host=self.name, host_key=self._host_key,

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -35,7 +35,7 @@ class Remote(object):
     _runner = staticmethod(run.run)
 
     def __init__(self, name, ssh=None, shortname=None, console=None,
-                 host_key=None, keep_alive=True):
+                 host_key=None, keep_alive=True, ssh_port=22):
         self.name = name
         if '@' in name:
             (self.user, hostname) = name.split('@')
@@ -52,10 +52,11 @@ class Remote(object):
         self.keep_alive = keep_alive
         self.console = console
         self.ssh = ssh
+        self.ssh_port = ssh_port
 
     def connect(self, timeout=None):
         args = dict(user_at_host=self.name, host_key=self._host_key,
-                    keep_alive=self.keep_alive)
+                    keep_alive=self.keep_alive,port=self.ssh_port)
         if timeout:
             args['timeout'] = timeout
 

--- a/teuthology/orchestra/test/test_connection.py
+++ b/teuthology/orchestra/test/test_connection.py
@@ -40,6 +40,7 @@ class TestConnection(object):
             hostname='orchestra.test.newdream.net.invalid',
             username='jdoe',
             timeout=60,
+            port=22
         )
         transport = ssh.expects('get_transport').with_args().returns_fake()
         transport.remember_order()
@@ -62,6 +63,7 @@ class TestConnection(object):
             hostname='orchestra.test.newdream.net.invalid',
             username='jdoe',
             timeout=60,
+            port=22
         )
         transport = ssh.expects('get_transport').with_args().returns_fake()
         transport.remember_order()
@@ -90,6 +92,7 @@ class TestConnection(object):
             hostname='orchestra.test.newdream.net.invalid',
             username='jdoe',
             timeout=60,
+            port=22
             )
         transport = ssh.expects('get_transport').with_args().returns_fake()
         transport.remember_order()

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -296,6 +296,7 @@ def add_remotes(ctx, config):
     """
     remotes = []
     machs = []
+    ssh_port = ctx.config.get('ssh_port', 22)
     for name in ctx.config['targets'].iterkeys():
         machs.append(name)
     for t, key in ctx.config['targets'].iteritems():
@@ -305,7 +306,8 @@ def add_remotes(ctx, config):
                 key = None
         except (AttributeError, KeyError):
             pass
-        rem = remote.Remote(name=t, host_key=key, keep_alive=True)
+        rem = remote.Remote(name=t, host_key=key,
+                            keep_alive=True, ssh_port=ssh_port)
         remotes.append(rem)
     ctx.cluster = cluster.Cluster()
     if 'roles' in ctx.config:
@@ -361,6 +363,7 @@ def check_ceph_data(ctx, config):
     Check for old /var/lib/ceph directories and detect staleness.
     """
     log.info('Checking for old /var/lib/ceph...')
+
     processes = ctx.cluster.run(
         args=['test', '!', '-e', '/var/lib/ceph'],
         wait=False,

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -296,18 +296,20 @@ def add_remotes(ctx, config):
     """
     remotes = []
     machs = []
-    ssh_port = ctx.config.get('ssh_port', 22)
     for name in ctx.config['targets'].iterkeys():
         machs.append(name)
     for t, key in ctx.config['targets'].iteritems():
+        port = 22
+        if ':' in t:
+            port = int(t.split(':')[1])
+            t = t.split(':')[0]
         t = misc.canonicalize_hostname(t)
         try:
             if ctx.config['sshkeys'] == 'ignore':
                 key = None
         except (AttributeError, KeyError):
             pass
-        rem = remote.Remote(name=t, host_key=key,
-                            keep_alive=True, ssh_port=ssh_port)
+        rem = remote.Remote(name=t, host_key=key, keep_alive=True, port=port)
         remotes.append(rem)
     ctx.cluster = cluster.Cluster()
     if 'roles' in ctx.config:


### PR DESCRIPTION
Currently, if a test node's `sshd` binds to another port, it is not possible to configure teuthology so that it communicates via this port (22 is "hard-coded"). This PR add support for alternate ports by specifying them in `targets`, for example:

``` yaml
targets:
  'ubuntu@localhost:2222': ssh-dss sshkeytolocalhost
```
