### PR TITLE
use modern paramiko

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
                       'configobj',
                       'six',
                       'httplib2',
-                      'paramiko < 1.8',
+                      'paramiko >= 1.15.1',
                       'pexpect',
                       'requests >= 2.3.0',
                       'raven',


### PR DESCRIPTION
We need >= 1.15 to connect to newer OpenSSH, such as the version used by
debian jessie.

Signed-off-by: Sage Weil <sage@redhat.com>