### PR TITLE
internal: move buildpackages before install task

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -208,6 +208,7 @@ def get_initial_tasks(lock, config, machine_type):
         {'internal.sudo': None},
         {'internal.syslog': None},
         {'internal.timer': None},
+        {'internal.buildpackages_prep': None},
         {'selinux': None},
     ])
 

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -234,6 +234,12 @@ def check_packages(ctx, config):
 
     If there are missing packages, fail the job.
     """
+    for task in ctx.config['tasks']:
+        if task.keys()[0] == 'buildpackages':
+            log.info("Checking packages skipped because "
+                     "the task buildpackages was found.")
+            return
+
     log.info("Checking packages...")
     os_type = ctx.config.get("os_type")
     sha1 = ctx.config.get("sha1")

--- a/teuthology/test/task/test_internal.py
+++ b/teuthology/test/task/test_internal.py
@@ -1,0 +1,53 @@
+from teuthology.config import FakeNamespace
+from teuthology.task import internal
+
+
+class TestInternal(object):
+    def setup(self):
+        self.ctx = FakeNamespace()
+        self.ctx.config = dict()
+
+    def test_buildpackages_prep(self):
+        #
+        # no buildpackages nor install tasks
+        #
+        self.ctx.config = { 'tasks': [] }
+        assert internal.buildpackages_prep(self.ctx,
+                                      self.ctx.config) == internal.BUILDPACKAGES_NOTHING
+        #
+        # move the buildpackages tasks before the install task
+        #
+        self.ctx.config = {
+            'tasks': [ { 'atask': None },
+                       { 'install': None },
+                       { 'buildpackages': None } ],
+        }
+        assert internal.buildpackages_prep(self.ctx,
+                                      self.ctx.config) == internal.BUILDPACKAGES_SWAPPED
+        assert self.ctx.config == {
+            'tasks': [ { 'atask': None },
+                       { 'buildpackages': None },
+                       { 'install': None } ],
+        }
+        #
+        # the buildpackages task already is before the install task
+        #
+        assert internal.buildpackages_prep(self.ctx,
+                                      self.ctx.config) == internal.BUILDPACKAGES_OK
+        #
+        # no buildpackages task
+        #
+        self.ctx.config = {
+            'tasks': [ { 'install': None } ],
+        }
+        assert internal.buildpackages_prep(self.ctx,
+                                      self.ctx.config) == internal.BUILDPACKAGES_NOTHING
+        #
+        # no install task: the buildpackages task must be removed
+        #
+        self.ctx.config = {
+            'tasks': [ { 'buildpackages': None } ],
+        }
+        assert internal.buildpackages_prep(self.ctx,
+                                      self.ctx.config) == internal.BUILDPACKAGES_REMOVED
+        assert self.ctx.config == {'tasks': []}

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -105,6 +105,7 @@ class TestRun(object):
         assert {"kernel": "the_kernel"} in result
         # added because use_existing_cluster == False
         assert {'internal.vm_setup': None} in result
+        assert {'internal.buildpackages_prep': None} in result
 
     @patch("teuthology.run.fetch_qa_suite")
     def test_fetch_tasks_if_needed(self, m_fetch_qa_suite):


### PR DESCRIPTION
If a buildpackages task is found, ensure it is always before the install
task because it is intended to produce the packages that will be used by
the install task.

http://tracker.ceph.com/issues/13031 Refs: #13031

Signed-off-by: Loic Dachary <loic@dachary.org>