### PR TITLE
openstack: explicitly set gitbuilder_host default

### DIFF
--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -53,6 +53,7 @@ $archive_upload
 archive_upload_key: teuthology/openstack/archive-key
 lock_server: http://localhost:8080/
 results_server: http://localhost:8080/
+gitbuilder_host: gitbuilder.ceph.com
 queue_port: 11300
 queue_host: localhost
 lab_domain: $labdomain


### PR DESCRIPTION
So that it is easier to replace because there is no need to verify if
it's already present or not.

Signed-off-by: Loic Dachary <loic@dachary.org>