### PR TITLE
openstack: cleanup the src directory when stopping the cluster

### DIFF
--- a/teuthology/openstack/openstack-teuthology.init
+++ b/teuthology/openstack/openstack-teuthology.init
@@ -73,6 +73,7 @@ case $1 in
                     while read uuid ; do
                     eval openstack server delete $uuid
                 done
+                rm -fr /home/$user/src/*
                 ;;
         restart)
                 $0 stop


### PR DESCRIPTION
So that there is no leftover from the ceph-qa-suite clones.

Signed-off-by: Loic Dachary <loic@dachary.org>