### PR TITLE
os-client-config is fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
                       'pyopenssl>=0.13',
                       'ndg-httpsclient',
                       'pyasn1',
-                      'os-client-config == 1.6.3', # https://bugs.launchpad.net/os-client-config/+bug/1496624
                       'python-openstackclient',
                       ],
 


### PR DESCRIPTION
No need to pin 1.6.3 since 1.7.3 has been released and fixes the
regression.

https://bugs.launchpad.net/python-openstackclient/+bug/1496689

Signed-off-by: Loic Dachary <loic@dachary.org>