### PR TITLE
Fix results-email-job scheduling

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -319,7 +319,6 @@ def prepare_and_schedule(job_config, suite_repo_path, base_yaml_paths, limit,
             arg.extend(['--timeout', timeout])
         if dry_run:
             log.info('dry-run: %s' % ' '.join(arg))
-        else:
             teuthology_schedule(
                 args=arg,
                 dry_run=dry_run,

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -317,14 +317,12 @@ def prepare_and_schedule(job_config, suite_repo_path, base_yaml_paths, limit,
         arg.extend(['--email', job_config.email])
         if timeout:
             arg.extend(['--timeout', timeout])
-        if dry_run:
-            log.info('dry-run: %s' % ' '.join(arg))
-            teuthology_schedule(
-                args=arg,
-                dry_run=dry_run,
-                verbose=verbose,
-                log_prefix="Results email: ",
-            )
+        teuthology_schedule(
+            args=arg,
+            dry_run=dry_run,
+            verbose=verbose,
+            log_prefix="Results email: ",
+        )
         results_url = get_results_url(job_config.name)
         if results_url:
             log.info("Test results viewable at %s", results_url)


### PR DESCRIPTION
Sample output:
```
(virtualenv)13:40:20 zack@zwork.local teuthology master ? teuthology-suite -vv --owner zack@zqork --suite teuthology --limit 1 --priority 1 --filter vps --filter-out rgw --dry-run
2015-09-21 13:40:39,040.040 DEBUG:teuthology.suite:Defaults for machine_type magna distro None: arch=x86_64, release=centos7, pkg_type=rpm
2015-09-21 13:40:39,040.040 DEBUG:teuthology.suite:Gitbuilder URL: http://gitbuilder.ceph.redhat.com/ceph-rpm-centos7-x86_64-basic/ref/master/sha1
2015-09-21 13:40:39,457.457 INFO:teuthology.suite:ceph sha1: 0bfefdf5b6becba0a395c6316b126fd7f3addc8b
2015-09-21 13:40:39,457.457 DEBUG:teuthology.suite:Defaults for machine_type magna distro None: arch=x86_64, release=centos7, pkg_type=rpm
2015-09-21 13:40:39,457.457 DEBUG:teuthology.suite:Looking for packages at http://gitbuilder.ceph.redhat.com/ceph-rpm-centos7-x86_64-basic/sha1/0bfefdf5b6becba0a395c6316b126fd7f3addc8b/version
2015-09-21 13:40:39,824.824 INFO:teuthology.suite:ceph version: v9.0.3-1760.g0bfefdf
2015-09-21 13:40:39,824.824 INFO:teuthology.suite:teuthology branch: master
2015-09-21 13:40:40,342.342 INFO:teuthology.suite:ceph-qa-suite branch: master
2015-09-21 13:40:40,343.343 INFO:teuthology.repo_utils:Fetching from upstream into /Users/zack/src/ceph-qa-suite_master
2015-09-21 13:40:41,373.373 INFO:teuthology.repo_utils:Resetting repo at /Users/zack/src/ceph-qa-suite_master to branch master
2015-09-21 13:40:41,425.425 DEBUG:teuthology.suite:Base job config:
branch: master
email: zack@redhat.com
machine_type: magna
name: zack-2015-09-21_13:40:39-teuthology-master---basic-magna
nuke-on-error: true
overrides:
  admin_socket:
    branch: master
  ceph:
    conf:
      mon:
        debug mon: 20
        debug ms: 1
        debug paxos: 20
      osd:
        debug filestore: 20
        debug journal: 20
        debug ms: 1
        debug osd: 20
    log-whitelist:
    - slow request
    sha1: 0bfefdf5b6becba0a395c6316b126fd7f3addc8b
  ceph-deploy:
    branch:
      dev-commit: 0bfefdf5b6becba0a395c6316b126fd7f3addc8b
    conf:
      client:
        log file: /var/log/ceph/ceph-$name.$pid.log
      mon:
        debug mon: 1
        debug ms: 20
        debug paxos: 20
        osd default pool size: 2
  install:
    ceph:
      sha1: 0bfefdf5b6becba0a395c6316b126fd7f3addc8b
  workunit:
    sha1: 0bfefdf5b6becba0a395c6316b126fd7f3addc8b
owner: zack@zqork
priority: 1
sha1: 0bfefdf5b6becba0a395c6316b126fd7f3addc8b
suite: teuthology
suite_branch: master
tasks:
- ansible.cephlab: null
- clock.check: null
teuthology_branch: master
2015-09-21 13:40:41,994.994 DEBUG:teuthology.suite:Suite teuthology in /Users/zack/src/ceph-qa-suite_master/suites/teuthology
2015-09-21 13:40:41,997.997 INFO:teuthology.suite:Suite teuthology in /Users/zack/src/ceph-qa-suite_master/suites/teuthology generated 26 jobs (not yet filtered)
2015-09-21 13:40:42,000.000 DEBUG:teuthology.suite:Defaults for machine_type plana distro None: arch=x86_64, release=centos7, pkg_type=rpm
2015-09-21 13:40:42,000.000 DEBUG:teuthology.suite:Looking for packages at http://gitbuilder.ceph.redhat.com/ceph-rpm-centos7-x86_64-basic/sha1/0bfefdf5b6becba0a395c6316b126fd7f3addc8b/version
2015-09-21 13:40:42,367.367 INFO:teuthology.suite:Stopped after 1 jobs due to --limit=1
2015-09-21 13:40:42,367.367 INFO:teuthology.suite:Scheduling teuthology/no-ceph/{clusters/single.yaml distros/vps.yaml tasks/teuthology.yaml}
2015-09-21 13:40:42,367.367 INFO:teuthology.suite:/Users/zack/inkdev/teuthology/virtualenv/bin/teuthology-schedule --name zack-2015-09-21_13:40:39-teuthology-master---basic-magna --num 1 --worker magna --dry-run --priority 1 -v --owner zack@zqork --description 'teuthology/no-ceph/{clusters/single.yaml distros/vps.yaml tasks/teuthology.yaml}' -- /var/folders/lh/723f8c417xz2n8dfzjqnmk3c0000gn/T/schedule_suite_RWMzt6 /Users/zack/src/ceph-qa-suite_master/suites/teuthology/no-ceph/clusters/single.yaml /Users/zack/src/ceph-qa-suite_master/suites/teuthology/no-ceph/distros/vps.yaml /Users/zack/src/ceph-qa-suite_master/suites/teuthology/no-ceph/tasks/teuthology.yaml
{'branch': 'master',
 'description': 'teuthology/no-ceph/{clusters/single.yaml distros/vps.yaml tasks/teuthology.yaml}',
 'email': 'zack@redhat.com',
 'last_in_suite': False,
 'machine_type': 'vps',
 'name': 'zack-2015-09-21_13:40:39-teuthology-master---basic-magna',
 'nuke-on-error': True,
 'overrides': {'admin_socket': {'branch': 'master'},
               'ceph': {'conf': {'mon': {'debug mon': 20,
                                         'debug ms': 1,
                                         'debug paxos': 20},
                                 'osd': {'debug filestore': 20,
                                         'debug journal': 20,
                                         'debug ms': 1,
                                         'debug osd': 20}},
                        'log-whitelist': ['slow request'],
                        'sha1': '0bfefdf5b6becba0a395c6316b126fd7f3addc8b'},
               'ceph-deploy': {'branch': {'dev-commit': '0bfefdf5b6becba0a395c6316b126fd7f3addc8b'},
                               'conf': {'client': {'log file': '/var/log/ceph/ceph-$name.$pid.log'},
                                        'mon': {'debug mon': 1,
                                                'debug ms': 20,
                                                'debug paxos': 20,
                                                'osd default pool size': 2}}},
               'install': {'ceph': {'sha1': '0bfefdf5b6becba0a395c6316b126fd7f3addc8b'}},
               'workunit': {'sha1': '0bfefdf5b6becba0a395c6316b126fd7f3addc8b'}},
 'owner': 'zack@zqork',
 'priority': 1,
 'roles': [['mon.0', 'client.0']],
 'sha1': '0bfefdf5b6becba0a395c6316b126fd7f3addc8b',
 'suite': 'teuthology',
 'suite_branch': 'master',
 'tasks': [{'ansible.cephlab': None}, {'clock.check': None}, {'tests': None}],
 'teuthology_branch': 'master',
 'tube': 'magna',
 'verbose': True}
2015-09-21 13:40:42,742.742 INFO:teuthology.suite:Suite teuthology in /Users/zack/src/ceph-qa-suite_master/suites/teuthology scheduled 1 jobs.
2015-09-21 13:40:42,743.743 INFO:teuthology.suite:Suite teuthology in /Users/zack/src/ceph-qa-suite_master/suites/teuthology -- 25 jobs were filtered out.
2015-09-21 13:40:42,743.743 INFO:teuthology.suite:Suite teuthology in /Users/zack/src/ceph-qa-suite_master/suites/teuthology scheduled 0 jobs with missing packages.
2015-09-21 13:40:42,743.743 INFO:teuthology.suite:Results email: /Users/zack/inkdev/teuthology/virtualenv/bin/teuthology-schedule --name zack-2015-09-21_13:40:39-teuthology-master---basic-magna --num 1 --worker magna --dry-run --priority 1 -v --owner zack@zqork --last-in-suite --email zack@redhat.com --timeout 43200
{'description': None,
 'email': 'zack@redhat.com',
 'last_in_suite': True,
 'machine_type': 'magna',
 'name': 'zack-2015-09-21_13:40:39-teuthology-master---basic-magna',
 'owner': 'zack@zqork',
 'priority': 1,
 'results_timeout': '43200',
 'tube': 'magna',
 'verbose': True}
2015-09-21 13:40:43,079.079 INFO:teuthology.suite:Test results viewable at http://pulpito.ceph.com/zack-2015-09-21_13:40:39-teuthology-master---basic-magna/
```