### PR TITLE
openstack: do not rely on gitbuilder.ceph.com by default

### DIFF
--- a/teuthology/openstack/test/openstack.yaml
+++ b/teuthology/openstack/test/openstack.yaml
@@ -1,13 +1,19 @@
-overrides:                                                                                                                                                 
-  ceph:                                                                                                                                                    
-    conf:                                                                                                                                                  
-      global:                                                                                                                                              
-        osd heartbeat grace: 100                                                                                                                           
-        # this line to address issue #1017                                                                                                                 
-        mon lease: 15                                                                                                                                      
-        mon lease ack timeout: 25                                                                                                                          
-  rgw:                                                                                                                                                     
-    default_idle_timeout: 1200                                                                                                                             
-  s3tests:                                                                                                                                                 
-    idle_timeout: 1200                                                                                                                                     
+overrides:
+  ceph:
+    conf:
+      global:
+        osd heartbeat grace: 100
+        # this line to address issue #1017
+        mon lease: 15
+        mon lease ack timeout: 25
+  rgw:
+    default_idle_timeout: 1200
+  s3tests:
+    idle_timeout: 1200
 archive-on-error: true
+tasks:
+    - buildpackages:
+        machine:
+          disk: 40 # GB
+          ram: 15000 # MB
+          cpus: 16


### PR DESCRIPTION
Make it so the default when using the OpenStack backend is to build the
packages transparently using the OpenStack cluster instead of relying on
http://ceph.com/gitbuilder.cgi.

Signed-off-by: Loic Dachary <loic@dachary.org>