### PR TITLE
config: add ceph_git_url and ceph_qa_suite_git_url

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -54,6 +54,12 @@ Here is a sample configuration with many of the options set and documented::
     # Where all git repos are considered to reside.
     ceph_git_base_url: https://github.com/ceph/
 
+    # Where the ceph git repo is considered to reside.
+    ceph_git_url: https://github.com/ceph/ceph.git
+
+    # Where the ceph-qa-suite git repo is considered to reside.
+    ceph_qa_suite_git_url: https://github.com/ceph/ceph-qa-suite.git
+
     # Where teuthology and ceph-qa-suite repos should be stored locally
     src_base_path: /home/foo/src
 

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -131,6 +131,8 @@ class TeuthologyConfig(YamlConfig):
         'automated_scheduling': False,
         'reserve_machines': 5,
         'ceph_git_base_url': 'https://github.com/ceph/',
+        'ceph_git_url': None,
+        'ceph_qa_suite_git_url': None,
         'gitbuilder_host': 'gitbuilder.ceph.com',
         'lab_domain': 'front.sepia.ceph.com',
         'lock_server': 'http://paddles.front.sepia.ceph.com/',
@@ -166,6 +168,13 @@ class TeuthologyConfig(YamlConfig):
     def __init__(self, yaml_path=None):
         super(TeuthologyConfig, self).__init__(yaml_path or self.yaml_path)
 
+    def get_ceph_qa_suite_git_url(self):
+        return (self.ceph_qa_suite_git_url or
+                self.ceph_git_base_url + 'ceph-qa-suite.git')
+
+    def get_ceph_git_url(self):
+        return (self.ceph_git_url or
+                self.ceph_git_base_url + 'ceph.git')
 
 class JobConfig(YamlConfig):
     pass

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -199,8 +199,8 @@ def fetch_qa_suite(branch, lock=True):
     :param branch: The branch to fetch
     :returns:      The destination path
     """
-    url = config.ceph_git_base_url + 'ceph-qa-suite.git'
-    return fetch_repo(url, branch, lock=lock)
+    return fetch_repo(config.get_ceph_qa_suite_git_url(),
+                      branch, lock=lock)
 
 
 def fetch_teuthology(branch, lock=True):


### PR DESCRIPTION
The ~/.teuthology.yaml ceph_git_base_url configuration does not allow to
modify the URL of the Ceph repository without also modifying the URL of
the teuthology repository. Although it is frequently needed to point to
an alternate ceph or ceph-qa-suite repository, it is rarely necessary to
point to an alternate teuthology repository.

This is not a blocker: it is enough to mirror the teuthology,
ceph-cm-ansible, ceph-deploy and maybe a few other repositories to
satisfy this requirement. This is however inconvenient because the
exact list of repositories that need to be mirrored is not easily
accessible. In addition, unless the user is careful about updating the
mirrors prior to running teuthology, there is a good chance that an
obsolete version of the repository will be used and this may lead to
problems difficult to diagnose.

The git_ceph_url and git_ceph_qa_suite_url configuration variables are
added to specify the URL of the ceph and ceph-qa-suite repositories
without modifying the git_ceph_base_url value so that all other
repositories retain their default location.

For easier consumption within teuthology and ceph-qa-suite, the
get_git_ceph_url() and get_git_ceph_qa_suite_url() accessors are added
to the config class. They use the user provided value, if available, and
otherwise fallback to constructing the URL with git_ceph_base_url which
is the legacy behavior.

http://tracker.ceph.com/issues/11883 Fixes: #11883

Signed-off-by: Loic Dachary <loic@dachary.org>