### PR TITLE
openstack: throttling helps the instance running the cluster

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -410,11 +410,11 @@ ssh access   : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/html
             'ram': 1024, # MB
             'cpus': 1,
         }
-        if self.args.simultaneous_jobs > 25:
+        if self.args.simultaneous_jobs > 100:
             hint['ram'] = 30000 # MB
-        elif self.args.simultaneous_jobs > 10:
+        elif self.args.simultaneous_jobs > 25:
             hint['ram'] = 7000 # MB
-        elif self.args.simultaneous_jobs > 3:
+        elif self.args.simultaneous_jobs > 10:
             hint['ram'] = 4000 # MB
 
         select = None


### PR DESCRIPTION
The instance throttling (not launching more than X instances per minute)
helps the instance running the teuthology cluster when running multiple
workers. The workload does not spike when launching a suite and that
allows to run more workers on a machine with the same hardware configuration.

Signed-off-by: Loic Dachary <loic@dachary.org>