### PR TITLE
misc: do not trace children with valgrind

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1098,8 +1098,9 @@ def get_valgrind_args(testdir, name, preamble, v):
     val_path = '/var/log/ceph/valgrind'.format(tdir=testdir)
     if '--tool=memcheck' in v or '--tool=helgrind' in v:
         extra_args = [
-
             'valgrind',
+            '--trace-children=no',
+            '--child-silent-after-fork=yes',
             '--num-callers=50',
             '--suppressions={tdir}/valgrind.supp'.format(tdir=testdir),
             '--xml=yes',
@@ -1109,6 +1110,8 @@ def get_valgrind_args(testdir, name, preamble, v):
     else:
         extra_args = [
             'valgrind',
+            '--trace-children=no',
+            '--child-silent-after-fork=yes',
             '--suppressions={tdir}/valgrind.supp'.format(tdir=testdir),
             '--log-file={vdir}/{n}.log'.format(vdir=val_path, n=name),
             '--time-stamp=yes',


### PR DESCRIPTION
This fixes errors we get from ceph-mon when it spawns crushtool to test new
maps.

Fixes: #13251
Signed-off-by: Sage Weil <sage@redhat.com>