### PR TITLE
misc: wait_until_osds_up must verify 'up' in state

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -910,7 +910,7 @@ def wait_until_osds_up(ctx, cluster, remote):
         )
         out = r.stdout.getvalue()
         j = json.loads('\n'.join(out.split('\n')[1:]))
-        up = len(j['osds'])
+        up = len(filter(lambda o: 'up' in o['state'], j['osds']))
         log.debug('%d of %d OSDs are up' % (up, num_osds))
         if up == num_osds:
             break

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -12,6 +12,27 @@ class FakeRemote(object):
     pass
 
 
+def test_wait_until_osds_up():
+    ctx = argparse.Namespace()
+    remote = FakeRemote()
+    class r():
+        class o:
+            def getvalue(self):
+                return 'IGNORED\n{"osds":[{"state":["up"]}]}'
+        stdout = o()
+
+    remote.run = lambda **kwargs: r()
+    ctx.cluster = cluster.Cluster(
+        remotes=[
+            (remote, ['osd.0', 'client.1'])
+        ],
+    )
+    with patch.multiple(
+            misc,
+            get_testdir=lambda ctx: "TESTDIR",
+    ):
+        misc.wait_until_osds_up(ctx, ctx.cluster, remote)
+
 def test_get_clients_simple():
     ctx = argparse.Namespace()
     remote = FakeRemote()


### PR DESCRIPTION
It is not enough to count the number of entries in the osds
array, wait_until_osds_up must count which one are actually up by
checking if the string "up" is in the "state" array.

http://tracker.ceph.com/issues/13363 Fixes: #13363

Signed-off-by: Loic Dachary <loic@dachary.org>