### PR TITLE
run_tasks.py: fix Sentry URL

### DIFF
--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -96,7 +96,7 @@ def run_tasks(tasks, ctx):
                 tags=tags,
                 extra=extra,
             ))
-            event_url = "{server}/search?q={id}".format(
+            event_url = "{server}/?q={id}".format(
                 server=teuth_config.sentry_server.strip('/'), id=exc_id)
             log.exception(" Sentry event: %s" % event_url)
             ctx.summary['sentry_event'] = event_url


### PR DESCRIPTION
I don't know when or why it changed, but the existing URL format, which
uses '/search?q=<id>', fails; what works, by observing the web UI's URL
submission and by testing, is to omit the 'search' part of the path:
'/?q=<id>'

Signed-off-by: Dan Mick <dan.mick@redhat.com>