### PR TITLE
openstack: clear the buildpackages directory on stop

### DIFF
--- a/teuthology/openstack/openstack-teuthology.init
+++ b/teuthology/openstack/openstack-teuthology.init
@@ -73,7 +73,7 @@ case $1 in
                     while read uuid ; do
                     eval openstack server delete $uuid
                 done
-                rm -fr /home/$user/src/*
+                rm -fr /home/$user/src/* /tmp/stampsdir
                 ;;
         restart)
                 $0 stop


### PR DESCRIPTION
When running /etc/init.d/teuthology stop, all OpenStack resources are
destroyed, including the instance hosting the repository where the
buildpackages task artefacts are archived. Remove /tmp/stampsdir so that
everything gets rebuilt.

Signed-off-by: Loic Dachary <loic@dachary.org>