### PR TITLE
openstack: ensure HOME environment variable

### DIFF
--- a/teuthology/openstack/openstack-teuthology.init
+++ b/teuthology/openstack/openstack-teuthology.init
@@ -37,6 +37,8 @@ source /etc/default/teuthology
 
 user=${TEUTHOLOGY_USERNAME:-ubuntu}
 
+export HOME=/home/$user
+
 case $1 in
         start)
                 /etc/init.d/beanstalkd start


### PR DESCRIPTION
Make it so even after a reboot and run from root, the HOME is set to the
user directory where the scripts are expected to be.

Signed-off-by: Loic Dachary <loic@dachary.org>