### PR TITLE
suite: ceph-deploy now is similar to install

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -1047,9 +1047,7 @@ dict_templ = {
             'sha1': Placeholder('ceph_hash'),
         },
         'ceph-deploy': {
-            'branch': {
-                'dev-commit': Placeholder('ceph_hash'),
-            },
+            'sha1': Placeholder('ceph_hash'),
             'conf': {
                 'client': {
                     'log file': '/var/log/ceph/ceph-$name.$pid.log'


### PR DESCRIPTION
The ceph-deploy task interprets its config in the same way the install
task does: tag, branch and sha1 have priority.

http://tracker.ceph.com/issues/13526 Refs: #13526

Signed-off-by: Loic Dachary <ldachary@redhat.com>