### PR TITLE
openstack: resources hint is the max of all hints

### DIFF
--- a/teuthology/openstack/test/test_openstack.py
+++ b/teuthology/openstack/test/test_openstack.py
@@ -29,8 +29,63 @@ import tempfile
 
 import teuthology
 from teuthology import misc
-from teuthology.openstack import TeuthologyOpenStack
+from teuthology.openstack import TeuthologyOpenStack, OpenStack
 import scripts.openstack
+
+class TestOpenStack(object):
+
+    def test_interpret_hints(self):
+        defaults = {
+            'machine': {
+                'ram': 0,
+                'disk': 0,
+                'cpus': 0,
+            },
+            'volumes': {
+                'count': 0,
+                'size': 0,
+            },
+        }
+        expected_disk = 10 # first hint larger than the second
+        expected_ram = 20 # second hint larger than the first
+        expected_cpus = 0 # not set, hence zero by default
+        expected_count = 30 # second hint larger than the first
+        expected_size = 40 # does not exist in the first hint
+        hints = [
+            {
+                'machine': {
+                    'ram': 2,
+                    'disk': expected_disk,
+                },
+                'volumes': {
+                    'count': 9,
+                    'size': expected_size,
+                },
+            },
+            {
+                'machine': {
+                    'ram': expected_ram,
+                    'disk': 3,
+                },
+                'volumes': {
+                    'count': expected_count,
+                },
+            },
+        ]
+        hint = OpenStack().interpret_hints(defaults, hints)
+        assert hint == {
+            'machine': {
+                'ram': expected_ram,
+                'disk': expected_disk,
+                'cpus': expected_cpus,
+            },
+            'volumes': {
+                'count': expected_count,
+                'size': expected_size,
+            }
+        }
+        assert defaults == OpenStack().interpret_hints(defaults, None)
+
 
 class TestTeuthologyOpenStack(object):
 


### PR DESCRIPTION
Exactly one OpenStack resources hint can be included in a given job, as
part of an existing facet. It is error prone because it is sometimes not
trivial to figure out how a given job is composed and if two resources
hint are included only one of them will be taken into account which can
lead to problems difficult to diagnose. Another undesirable side effect
is to artificially increase resources usage. It is easier and more
reliable (from the test maintainer point of view) to increase the
resources of all jobs when a few need more RAM or disk rather than
trying to figure where to write the hints so that they are used by these
jobs and these jobs only.

Instead of being a fixed hint for a given job, the max of all hints
found in each facet is used. For instance, rados/thrash can have a facet
requiring that all jobs are given 3 devices.

cat rados/thrash/cluster/openstack.yaml
  openstack:
    - volumes:
        count: 3

If one task in rados/thrash needs 16GB RAM instead of the default of 8GB
RAM, it can have:

cat rados/thrash/tasks/bigworkunit.yaml

  task:
    - workunit: highmemoryusage.sh
  openstack:
    - machine:
        ram: 16 # GB

And a job composed of rados/thrash/{cluster/openstack.yaml
tasks/bigworkunit.yaml} is aggregated as the max of all resources,
including the default, that is:

  task:
    - workunit: highmemoryusage.sh
  openstack:
    - machine:
        disk: 20 # GB
        ram: 16 # GB
        cpu: 1
      volumes:
        count: 3
        size: 1 # GB

Signed-off-by: Loic Dachary <ldachary@redhat.com>