### PR TITLE
openstack: revert to zero volumes default

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -185,7 +185,7 @@ Here is a sample configuration with many of the options set and documented::
 
         # The number of volumes
         #
-        count: 3
+        count: 0
         
         # The size of each volume, in GB
         #

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -160,8 +160,8 @@ class TeuthologyConfig(YamlConfig):
                 'cpus': 1,
             },
             'volumes': {
-                'count': 3,
-                'size': 10,
+                'count': 0,
+                'size': 1,
             },
         },
     }


### PR DESCRIPTION
Volumes are rarely needed, having no volumes by default is sane.

Signed-off-by: Loic Dachary <ldachary@redhat.com>