### PR TITLE
openstack: reset the gitbuilder_host on stop

### DIFF
--- a/teuthology/openstack/openstack-teuthology.init
+++ b/teuthology/openstack/openstack-teuthology.init
@@ -80,6 +80,7 @@ case $1 in
                     while read uuid ; do
                     eval openstack volume delete $uuid
                 done
+                perl -pi -e 's/.*gitbuilder_host.*/gitbuilder_host: gitbuilder.ceph.com/' /home/$user/.teuthology.yaml
                 rm -fr /home/$user/src/* /tmp/stampsdir
                 ;;
         restart)


### PR DESCRIPTION
The package-repository instance is destroyed and requests to it will
timeout which takes time. Reverting to the default gitbuilder.ceph.com
is quicker and easier.

Signed-off-by: Loic Dachary <ldachary@redhat.com>