### PR TITLE
openstack: implement OpenStack.set_provider

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -68,6 +68,19 @@ class OpenStack(object):
         self.up_string = "UNKNOWN"
         self.teuthology_suite = 'teuthology-suite'
 
+    def set_provider(self):
+        if 'OS_AUTH_URL' not in os.environ:
+            raise Exception('no OS_AUTH_URL environment variable')
+        providers = (('cloud.ovh.net', 'ovh'),
+                     ('entercloudsuite.com', 'entercloudsuite'),
+                     ('rackspacecloud.com', 'rackspace'))
+        self.provider = None
+        for (pattern, provider) in providers:
+            if pattern in os.environ['OS_AUTH_URL']:
+                self.provider = provider
+                break
+        return self.provider
+
     @staticmethod
     def get_value(result, field):
         """
@@ -412,16 +425,7 @@ ssh access   : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/html
         except subprocess.CalledProcessError:
             log.exception("openstack server list")
             raise Exception("verify openrc.sh has been sourced")
-        if 'OS_AUTH_URL' not in os.environ:
-            raise Exception('no OS_AUTH_URL environment variable')
-        providers = (('cloud.ovh.net', 'ovh'),
-                     ('entercloudsuite.com', 'entercloudsuite'),
-                     ('rackspacecloud.com', 'rackspace'))
-        self.provider = None
-        for (pattern, provider) in providers:
-            if pattern in os.environ['OS_AUTH_URL']:
-                self.provider = provider
-                break
+        self.set_provider()
 
     def flavor(self):
         """

--- a/teuthology/openstack/test/test_openstack.py
+++ b/teuthology/openstack/test/test_openstack.py
@@ -86,6 +86,14 @@ class TestOpenStack(object):
         }
         assert defaults == OpenStack().interpret_hints(defaults, None)
 
+    def test_set_provider(self):
+        auth = os.environ.get('OS_AUTH_URL', None)
+        os.environ['OS_AUTH_URL'] = 'cloud.ovh.net'
+        assert OpenStack().set_provider() == 'ovh'
+        if auth != None:
+            os.environ['OS_AUTH_URL'] = auth
+        else:
+            del os.environ['OS_AUTH_URL']
 
 class TestTeuthologyOpenStack(object):
 


### PR DESCRIPTION
Setting the provider name depending on the OS_AUTH_URL content is
generally useful and moved to the OpenStack base class. There is a need
to cope with public OpenStack providers special cases, even if
temporarily (i.e. no volumes on OVH, no security group on RackSpace
etc.).

Signed-off-by: Loic Dachary <ldachary@redhat.com>