### PR TITLE
openstack: tests: look in caplog

### DIFF
--- a/teuthology/openstack/test/test_openstack.py
+++ b/teuthology/openstack/test/test_openstack.py
@@ -131,7 +131,7 @@ openstack keypair delete {key_name} || true
         """.format(key_name=self.key_name,
                    name=self.name))
 
-    def test_create(self, capsys):
+    def test_create(self, caplog):
         teuthology_argv = [
             '--suite', 'upgrade/hammer',
             '--dry-run',
@@ -168,8 +168,7 @@ openstack keypair delete {key_name} || true
         assert "clone=git clone" in variables
         assert os.environ['OS_AUTH_URL'] in variables
 
-        out, err = capsys.readouterr()
-        assert " ".join(teuthology_argv) in out
+        assert " ".join(teuthology_argv) in caplog.text()
 
         if self.can_create_floating_ips:
             ip = teuthology.get_floating_ip(self.name)

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt
   mock
+  pytest-capturelog
 
 commands=py.test -v {posargs:teuthology/openstack/test/test_openstack.py}
 basepython=python2.7


### PR DESCRIPTION
The output is now logged, use caplog instead of capsys and add it as a
test dependency.

Signed-off-by: Loic Dachary <ldachary@redhat.com>