### PR TITLE
openstack: server show returns a dict or an array

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -81,8 +81,11 @@ class OpenStack(object):
         :param field:   The name of the field whose value to retrieve. Case is
                         ignored.
         """
-        filter_func = lambda v: v['Field'].lower() == field.lower()
-        return filter(filter_func, result)[0]['Value']
+        if type(result) is types.ListType:
+            filter_func = lambda v: v['Field'].lower() == field.lower()
+            return filter(filter_func, result)[0]['Value']
+        else:
+            return result[field.lower()]
 
     def image_exists(self, image):
         """


### PR DESCRIPTION
The returned json from server show may either be an array of
'Field'/'Value' or a dictionary, depending.

Signed-off-by: Loic Dachary <ldachary@redhat.com>