### PR TITLE
openstack: increase ssh timeout to 240 (part 2)

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -199,7 +199,7 @@ class OpenStack(object):
         log.debug('cloud_init_wait ' + name_or_ip)
         client_args = {
             'user_at_host': '@'.join((self.username, name_or_ip)),
-            'timeout': 10,
+            'timeout': 240,
             'retry': False,
         }
         if self.key_filename:


### PR DESCRIPTION
When the connectivity is not great, this is required.

Signed-off-by: Loic Dachary <ldachary@redhat.com>