### PR TITLE
openstack: server show must always return array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ setup(
                       'pyopenssl>=0.13',
                       'ndg-httpsclient',
                       'pyasn1',
+                      # the following may be removed when
+                      # https://bugs.launchpad.net/python-openstackclient/+bug/1510546
+                      # is resolved
+                      'cliff-tablib', # required to get a Field/Value output from openstack server show
                       'python-openstackclient',
                       ],
 


### PR DESCRIPTION
If cliff-tablib is not present, the output of openstack server show is a
dictionary, otherwise it is a list of Field/Value pairs. Since
cliff-tablib is not a required dependency of python-openstack client,
the output format of openstack server show may vary. Add cliff-tablib as
a dependency so that the output format is always the same.

https://bugs.launchpad.net/python-openstackclient/+bug/1510546

Signed-off-by: Loic Dachary <ldachary@redhat.com>