### PR TITLE
openstack: global server creation lock

### DIFF
--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -310,7 +310,7 @@ class ProvisionOpenStack(OpenStack):
             net = ''
         flavor = self.flavor(resources_hint['machine'],
                              config['openstack'].get('flavor-select-regexp'))
-        misc.sh("openstack server create" +
+        misc.sh("flock --close /tmp/teuthology-server-create.lock openstack server create" +
                 " " + config['openstack'].get('server-create', '') +
                 " -f json " +
                 " --image '" + str(image) + "'" +


### PR DESCRIPTION
An attempt to reduce the instance error rate on OVH. When all workers
are on the same machine, it makes them wait for an instance creation is
complete before running another one. If not, it is possible for 200
workers to run 200 server creation simultaneously. While this should be
throttled by OVH, these bursts may be the cause for occasional instance
creation errors: few tenants are likely to have such a pattern.

Signed-off-by: Loic Dachary <ldachary@redhat.com>