### PR TITLE
Fix misc.sh() tests on MacOS

### DIFF
--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -11,24 +11,29 @@ import pytest
 class FakeRemote(object):
     pass
 
+
 def test_sh_normal(caplog):
-    assert misc.sh("echo ABC") == "ABC\n"
+    assert misc.sh("/bin/echo ABC") == "ABC\n"
     assert "truncated" not in caplog.text()
 
+
 def test_sh_truncate(caplog):
-    assert misc.sh("echo -n AB ; echo C", 2) == "ABC\n"
+    assert misc.sh("/bin/echo -n AB ; /bin/echo C", 2) == "ABC\n"
     assert "truncated" in caplog.text()
     assert "ABC" not in caplog.text()
 
+
 def test_sh_fail(caplog):
     with pytest.raises(Exception) as excinfo:
-        misc.sh("echo -n AB ; echo C ; exit 111", 2) == "ABC\n"
+        misc.sh("/bin/echo -n AB ; /bin/echo C ; exit 111", 2) == "ABC\n"
     assert excinfo.value.returncode == 111
     assert "failed with ABC" in caplog.text()
+
 
 def test_wait_until_osds_up():
     ctx = argparse.Namespace()
     remote = FakeRemote()
+
     class r():
         class o:
             def getvalue(self):
@@ -46,6 +51,7 @@ def test_wait_until_osds_up():
             get_testdir=lambda ctx: "TESTDIR",
     ):
         misc.wait_until_osds_up(ctx, ctx.cluster, remote)
+
 
 def test_get_clients_simple():
     ctx = argparse.Namespace()


### PR DESCRIPTION
It needs to be specifically told to use /bin/echo. Also add some
newlines to make the linter happy.

Signed-off-by: Zack Cerza <zack@redhat.com>