### PR TITLE
openstack: tests: use new resources hint style

### DIFF
--- a/teuthology/openstack/test/resources_hint.yaml
+++ b/teuthology/openstack/test/resources_hint.yaml
@@ -1,13 +1,13 @@
 stop_worker: true
 machine_type: openstack
 openstack:
-  machine:
-    disk: 10 # GB
-    ram: 1024 # MB
-    cpus: 1
-  volumes:
-    count: 1
-    size: 2 # GB
+  - machine:
+     disk: 10 # GB
+     ram: 10000 # MB
+     cpus: 1
+    volumes:
+     count: 1
+     size: 2 # GB
 os_type: ubuntu
 os_version: "14.04"
 roles:
@@ -16,7 +16,7 @@ roles:
 tasks:
 - exec:
     mon.a:
-      - test $(sed -n -e 's/MemTotal.* \([0-9][0-9]*\).*/\1/p' < /proc/meminfo) -lt 4000000 && echo "RAM" "size" "ok"
+      - test $(sed -n -e 's/MemTotal.* \([0-9][0-9]*\).*/\1/p' < /proc/meminfo) -ge 10000000 && echo "RAM" "size" "ok"
       - cat /proc/meminfo
 # wait for the attached volume to show up
       - for delay in 1 2 4 8 16 32 64 128 256 512 ; do if test -e /sys/block/vdb/size ; then break ; else sleep $delay ; fi ; done

--- a/teuthology/openstack/test/resources_hint_no_cinder.yaml
+++ b/teuthology/openstack/test/resources_hint_no_cinder.yaml
@@ -1,13 +1,13 @@
 stop_worker: true
 machine_type: openstack
 openstack:
-  machine:
-    disk: 10 # GB
-    ram: 1024 # MB
-    cpus: 1
-  volumes:
-    count: 0
-    size: 2 # GB
+  - machine:
+     disk: 10 # GB
+     ram: 10000 # MB
+     cpus: 1
+    volumes:
+     count: 0
+     size: 2 # GB
 os_type: ubuntu
 os_version: "14.04"
 roles:
@@ -17,4 +17,4 @@ tasks:
 - exec:
     mon.a:
       - cat /proc/meminfo
-      - test $(sed -n -e 's/MemTotal.* \([0-9][0-9]*\).*/\1/p' < /proc/meminfo) -lt 4000000 && echo "RAM" "size" "ok"
+      - test $(sed -n -e 's/MemTotal.* \([0-9][0-9]*\).*/\1/p' < /proc/meminfo) -ge 10000000 && echo "RAM" "size" "ok"


### PR DESCRIPTION
The memory cannot be lowered by the hint: test that it increases to 10GB
instead of testing that it was lowered under a given limit.

Signed-off-by: Loic Dachary <ldachary@redhat.com>