### PR TITLE
openstack: get user-data path relative to the sources

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -500,7 +500,12 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
         and a few other values are substituted.
         """
         path = tempfile.mktemp()
-        template = open(self.user_data).read()
+        if self.user_data.startswith('/'):
+            user_data = self.user_data
+        else:
+            user_data = os.path.join(os.path.dirname(__file__),
+                                     '../..', self.user_data)
+        template = open(user_data).read()
         openrc = ''
         for (var, value) in os.environ.iteritems():
             if var.startswith('OS_'):


### PR DESCRIPTION
The user-data files are in the sources, in the teuthology/openstack
directory. By default the template path being used is
teuthology/openstack/openstack-{os_type}-{os_version}-user-data.txt and
assumes teuthology-suite / teuthology-openstack is run from the root of
the source directory.

If the user-data path is relative, make it absolute based on the
directory in which the openstack module is found.

http://tracker.ceph.com/issues/13416 Fixes: #13416

Signed-off-by: Loic Dachary <ldachary@redhat.com>