### PR TITLE
suite: add the ceph-qa-suite hash to the job config

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -248,11 +248,16 @@ def create_initial_config(suite, suite_branch, ceph_branch, teuthology_branch,
             log.info("branch {0} not in ceph-qa-suite.git; will use master for"
                      " ceph-qa-suite".format(ceph_branch))
             suite_branch = 'master'
-    log.info("ceph-qa-suite branch: %s", suite_branch)
+    suite_hash = git_ls_remote('ceph-qa-suite', suite_branch)
+    if not suite_hash:
+        exc = BranchNotFoundError(suite_branch, 'ceph-qa-suite.git')
+        schedule_fail(message=str(exc), name=name)
+    log.info("ceph-qa-suite branch: %s %s", suite_branch, suite_hash)
 
     config_input = dict(
         suite=suite,
         suite_branch=suite_branch,
+        suite_hash=suite_hash,
         ceph_branch=ceph_branch,
         ceph_hash=ceph_hash,
         teuthology_branch=teuthology_branch,
@@ -1097,6 +1102,7 @@ dict_templ = {
     },
     'suite': Placeholder('suite'),
     'suite_branch': Placeholder('suite_branch'),
+    'suite_sha1': Placeholder('suite_hash'),
     'tasks': [
         {'ansible.cephlab': None},
         {'clock.check': None}

--- a/teuthology/test/test_suite.py
+++ b/teuthology/test/test_suite.py
@@ -54,9 +54,11 @@ class TestSuiteOffline(object):
                                         'basic') == ref_url
 
     def test_substitute_placeholders(self):
+        suite_hash = 'suite_hash'
         input_dict = dict(
             suite='suite',
             suite_branch='suite_branch',
+            suite_hash=suite_hash,
             ceph_branch='ceph_branch',
             ceph_hash='ceph_hash',
             teuthology_branch='teuthology_branch',
@@ -68,6 +70,7 @@ class TestSuiteOffline(object):
         output_dict = suite.substitute_placeholders(suite.dict_templ,
                                                     input_dict)
         assert output_dict['suite'] == 'suite'
+        assert output_dict['suite_sha1'] == suite_hash
         assert isinstance(suite.dict_templ['suite'], suite.Placeholder)
         assert isinstance(
             suite.dict_templ['overrides']['admin_socket']['branch'],
@@ -77,6 +80,7 @@ class TestSuiteOffline(object):
         input_dict = dict(
             suite='suite',
             suite_branch='suite_branch',
+            suite_hash='suite_hash',
             ceph_branch='ceph_branch',
             ceph_hash='ceph_hash',
             teuthology_branch='teuthology_branch',


### PR DESCRIPTION
To be able to re-run a job we need:

* the ceph repository and hash
* the ceph-qa-suite repository and hash
* the job description

When reading the job log from the archive directory, we currently only
have the ceph-qa-suite branch name. If and when the branch name moves
on, the job description may cease to be valid and re-running the job
may no longer be possible.

Signed-off-by: Loic Dachary <ldachary@redhat.com>