### PR TITLE
run: upload must happen after archive

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -202,9 +202,9 @@ def get_initial_tasks(lock, config, machine_type):
 
     init_tasks.extend([
         {'internal.base': None},
+        {'internal.archive_upload': None},
         {'internal.archive': None},
         {'internal.coredump': None},
-        {'internal.archive_upload': None},
         {'internal.sudo': None},
         {'internal.syslog': None},
         {'internal.timer': None},


### PR DESCRIPTION
The unwinding order is in reverse: internal.archive must be after
archive_upload so that it actually happens *before*.

Signed-off-by: Loic Dachary <ldachary@redhat.com>