### PR TITLE
run: do not lock machines if there are no roles

### DIFF
--- a/scripts/test/script.py
+++ b/scripts/test/script.py
@@ -11,6 +11,6 @@ class Script(object):
         assert out.startswith('usage')
 
     def test_invalid(self):
-        args = (self.script_name, 'INVALID')
+        args = (self.script_name, '--invalid-option')
         with raises(subprocess.CalledProcessError):
             subprocess.check_call(args)

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -174,24 +174,28 @@ def validate_tasks(config):
 
 def get_initial_tasks(lock, config, machine_type):
     init_tasks = [{'internal.check_packages': None}]
-    if lock:
+    if 'roles' in config and lock:
         msg = ('You cannot specify targets in a config file when using the ' +
                '--lock option')
         assert 'targets' not in config, msg
         init_tasks.append({'internal.lock_machines': (
             len(config['roles']), machine_type)})
 
-    init_tasks.extend([
-        {'internal.save_config': None},
-        {'internal.check_lock': None},
-        {'internal.add_remotes': None},
-        {'internal.connect': None},
-        {'internal.push_inventory': None},
-        {'internal.serialize_remote_roles': None},
-        {'internal.check_conflict': None},
-    ])
 
-    if not config.get('use_existing_cluster', False):
+    init_tasks.append({'internal.save_config': None})
+
+    if 'roles' in config:
+        init_tasks.extend([
+            {'internal.check_lock': None},
+            {'internal.add_remotes': None},
+            {'internal.connect': None},
+            {'internal.push_inventory': None},
+            {'internal.serialize_remote_roles': None},
+            {'internal.check_conflict': None},
+        ])
+
+    if ('roles' in config and
+        not config.get('use_existing_cluster', False)):
         init_tasks.extend([
             {'internal.check_ceph_data': None},
             {'internal.vm_setup': None},
@@ -200,17 +204,27 @@ def get_initial_tasks(lock, config, machine_type):
     if 'kernel' in config:
         init_tasks.append({'kernel': config['kernel']})
 
+    if 'roles' in config:
+        init_tasks.append({'internal.base': None})
+    init_tasks.append({'internal.archive_upload': None})
+    if 'roles' in config:
+        init_tasks.extend([
+            {'internal.archive': None},
+            {'internal.coredump': None},
+            {'internal.sudo': None},
+            {'internal.syslog': None},
+        ])
     init_tasks.extend([
-        {'internal.base': None},
-        {'internal.archive_upload': None},
-        {'internal.archive': None},
-        {'internal.coredump': None},
-        {'internal.sudo': None},
-        {'internal.syslog': None},
         {'internal.timer': None},
         {'internal.buildpackages_prep': None},
-        {'selinux': None},
     ])
+
+    if 'roles' in config:
+        init_tasks.extend([
+            {'selinux': None},
+            {'ansible.cephlab': None},
+            {'clock.check': None}
+        ])
 
     return init_tasks
 

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -1103,8 +1103,5 @@ dict_templ = {
     'suite': Placeholder('suite'),
     'suite_branch': Placeholder('suite_branch'),
     'suite_sha1': Placeholder('suite_hash'),
-    'tasks': [
-        {'ansible.cephlab': None},
-        {'clock.check': None}
-    ],
+    'tasks': [],
 }

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -95,7 +95,8 @@ class TestRun(object):
 
     def test_get_initial_tasks_invalid(self):
         with pytest.raises(AssertionError) as excinfo:
-            run.get_initial_tasks(True, {"targets": "can't be here"}, "machine_type")
+            run.get_initial_tasks(True, {"targets": "can't be here",
+                                         "roles": "roles" }, "machine_type")
         assert excinfo.value.message.startswith("You cannot")
 
     def test_get_inital_tasks(self):


### PR DESCRIPTION
The worker runs the job, even if there are no roles: it is legitimate to
run a job that does not need machines.

Run only locks machines if there are roles and init_tasks is only
populated with tasks that make sense depending on the presence of roles
or not.

Move the internal task added in suite.py to run.py : there is no reason
to not have them with teuthology-run or teuthology-schedule (ansible +
clock).

Signed-off-by: Loic Dachary <ldachary@redhat.com>