### PR TITLE
openstack: poll every 30 seconds instead of 2

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -205,7 +205,7 @@ class OpenStack(object):
         if self.key_filename:
             log.debug("using key " + self.key_filename)
             client_args['key_filename'] = self.key_filename
-        with safe_while(sleep=2, tries=600,
+        with safe_while(sleep=30, tries=100,
                         action="cloud_init_wait " + name_or_ip) as proceed:
             success = False
             # CentOS 6.6 logs in /var/log/clout-init-output.log


### PR DESCRIPTION
No cloud provider boots an instance within 30 seconds, no need to poll
aggressively. Also wait more than a total of 1200 seconds (3000 seconds)
because some providers may take more than 20 minutes to complete the
boot sequence.

Signed-off-by: Loic Dachary <ldachary@redhat.com>