### PR TITLE
teuthology-results: Be aware of all job statuses

### DIFF
--- a/scripts/results.py
+++ b/scripts/results.py
@@ -8,8 +8,8 @@ optional arguments:
   -v, --verbose      be more verbose
   --dry-run          Instead of sending the email, just print it
   --email EMAIL      address to email test failures to
-  --timeout TIMEOUT  how many seconds to wait for all tests to finish (default
-                     no wait)
+  --timeout TIMEOUT  how many seconds to wait for all tests to finish
+                     [default: 0]
   --archive-dir DIR  path under which results for the suite are stored
   --name NAME        name of the suite
 """

--- a/teuthology/results.py
+++ b/teuthology/results.py
@@ -175,7 +175,7 @@ def format_job(run_name, job):
     job_id = job['job_id']
     status = job['status']
     description = job['description']
-    duration = int(job['duration'] or 0)
+    duration = seconds_to_hms(int(job['duration'] or 0))
 
     # Every job gets a link to e.g. pulpito's pages
     info_url = misc.get_results_url(run_name, job_id)
@@ -239,6 +239,12 @@ def format_job(run_name, job):
         return email_templates['fail_templ'].format(**format_args)
 
 
+def seconds_to_hms(seconds):
+    (minutes, seconds) = divmod(seconds, 60)
+    (hours, minutes) = divmod(minutes, 60)
+    return "%02d:%02d:%02d" % (hours, minutes, seconds)
+
+
 email_templates = {
     'body_templ': dedent("""\
         Test Run: {name}
@@ -262,7 +268,7 @@ email_templates = {
     'fail_templ': dedent("""\
         [{job_id}]  {desc}
         -----------------------------------------------------------------
-        time:   {time}s{info_line}{log_line}{sentry_line}{reason_lines}
+        time:   {time}{info_line}{log_line}{sentry_line}{reason_lines}
 
         """),
     'info_url_templ': "\ninfo:   {info}",
@@ -274,7 +280,7 @@ email_templates = {
         """),
     'pass_templ': dedent("""\
         [{job_id}] {desc}
-        time:   {time}s{info_line}
+        time:   {time}{info_line}
 
         """),
 }

--- a/teuthology/results.py
+++ b/teuthology/results.py
@@ -53,7 +53,7 @@ def results(archive_dir, name, email, timeout, dry_run):
         if not unfinished_jobs:
             log.info('Tests finished! gathering results...')
             break
-        time.sleep(10)
+        time.sleep(60)
 
     (subject, body) = build_email_body(name)
 

--- a/teuthology/results.py
+++ b/teuthology/results.py
@@ -223,7 +223,7 @@ def format_job(run_name, job):
             reason = \
                 '\n'.join(('    ') + line for line in reason.splitlines())
             reason_lines = email_templates['fail_reason_templ'].format(
-                reason=reason)
+                reason=reason).rstrip()
         else:
             reason_lines = ''
 
@@ -261,6 +261,7 @@ email_templates = {
         {fail_sect}{dead_sect}{running_sect}{waiting_sect}{queued_sect}{pass_sect}
         """),
     'sect_templ': dedent("""\
+
         {title}
         =================================================================
         {jobs}
@@ -277,6 +278,7 @@ email_templates = {
     'fail_reason_templ': "\n\n{reason}\n",
     'running_templ': dedent("""\
         [{job_id}] {desc}{info_line}
+
         """),
     'pass_templ': dedent("""\
         [{job_id}] {desc}

--- a/teuthology/results.py
+++ b/teuthology/results.py
@@ -3,6 +3,7 @@ import sys
 import time
 import logging
 import subprocess
+from collections import OrderedDict
 from textwrap import dedent
 from textwrap import fill
 
@@ -113,12 +114,14 @@ def email_results(subject, from_, to, body):
 
 
 def build_email_body(name, _reporter=None):
-    failed = {}
-    dead = {}
-    running = {}
-    waiting = {}
-    queued = {}
-    passed = {}
+    stanzas = OrderedDict([
+        ('fail', dict()),
+        ('dead', dict()),
+        ('running', dict()),
+        ('waiting', dict()),
+        ('queued', dict()),
+        ('pass', dict()),
+    ])
     reporter = _reporter or ResultsReporter()
     fields = ('job_id', 'status', 'description', 'duration', 'failure_reason',
               'sentry_event', 'log_href')
@@ -126,146 +129,20 @@ def build_email_body(name, _reporter=None):
     jobs.sort(key=lambda job: job['job_id'])
 
     for job in jobs:
-        job_id = job['job_id']
-        status = job['status']
-        description = job['description']
-        duration = int(job['duration'] or 0)
+        job_stanza = format_job(name, job)
+        stanzas[job['status']][job['job_id']] = job_stanza
 
-        # Every job gets a link to e.g. pulpito's pages
-        info_url = misc.get_results_url(name, job_id)
-        if info_url:
-            info_line = email_templates['info_url_templ'].format(info=info_url)
-        else:
-            info_line = ''
-
-        if status in UNFINISHED_STATUSES:
-            format_args = dict(
-                job_id=job_id,
-                desc=description,
-                time=duration,
-                info_line=info_line,
+    sections = OrderedDict.fromkeys(stanzas.keys(), '')
+    subject_fragments = []
+    for status in sections.keys():
+        stanza = stanzas[status]
+        if stanza:
+            subject_fragments.append('%s %s' % (len(stanza), status))
+            sections[status] = email_templates['sect_templ'].format(
+                title=status.title(),
+                jobs=''.join(stanza.values()),
             )
-            if status == 'running':
-                running[job_id] = email_templates['running_templ'].format(
-                    **format_args)
-            elif status == 'waiting':
-                waiting[job_id] = email_templates['running_templ'].format(
-                    **format_args)
-            elif status == 'queued':
-                queued[job_id] = email_templates['running_templ'].format(
-                    **format_args)
-            continue
-
-        if status == 'pass':
-            passed[job_id] = email_templates['pass_templ'].format(
-                job_id=job_id,
-                desc=description,
-                time=duration,
-                info_line=info_line,
-            )
-        else:
-            log_dir_url = job['log_href'].rstrip('teuthology.yaml')
-            if log_dir_url:
-                log_line = email_templates['fail_log_templ'].format(
-                    log=log_dir_url)
-            else:
-                log_line = ''
-            sentry_event = job.get('sentry_event')
-            if sentry_event:
-                sentry_line = email_templates['fail_sentry_templ'].format(
-                    sentry_event=sentry_event)
-            else:
-                sentry_line = ''
-
-            if job['failure_reason']:
-                # 'fill' is from the textwrap module and it collapses a given
-                # string into multiple lines of a maximum width as specified.
-                # We want 75 characters here so that when we indent by 4 on the
-                # next line, we have 79-character exception paragraphs.
-                reason = fill(job['failure_reason'] or '', 75)
-                reason = \
-                    '\n'.join(('    ') + line for line in reason.splitlines())
-                reason_lines = email_templates['fail_reason_templ'].format(
-                    reason=reason)
-            else:
-                reason_lines = ''
-
-            format_args = dict(
-                job_id=job_id,
-                desc=description,
-                time=duration,
-                info_line=info_line,
-                log_line=log_line,
-                sentry_line=sentry_line,
-                reason_lines=reason_lines,
-            )
-            if status == 'fail':
-                failed[job_id] = email_templates['fail_templ'].format(
-                    **format_args)
-            elif status == 'dead':
-                dead[job_id] = email_templates['fail_templ'].format(
-                    **format_args)
-
-    maybe_comma = lambda s: ', ' if s else ' '
-
-    subject = ''
-    fail_sect = ''
-    dead_sect = ''
-    running_sect = ''
-    waiting_sect = ''
-    queued_sect = ''
-    pass_sect = ''
-    if failed:
-        subject += '{num_failed} failed{sep}'.format(
-            num_failed=len(failed),
-            sep=maybe_comma(dead or running or waiting or queued or passed)
-        )
-        fail_sect = email_templates['sect_templ'].format(
-            title='Failed',
-            jobs=''.join(failed.values())
-        )
-    if dead:
-        subject += '{num_dead} dead{sep}'.format(
-            num_dead=len(dead),
-            sep=maybe_comma(running or waiting or queued or passed)
-        )
-        dead_sect = email_templates['sect_templ'].format(
-            title='Dead',
-            jobs=''.join(dead.values()),
-        )
-    if running:
-        subject += '{num_running} running{sep}'.format(
-            num_running=len(running),
-            sep=maybe_comma(waiting or queued or passed)
-        )
-        running_sect = email_templates['sect_templ'].format(
-            title='Running',
-            jobs=''.join(running.values()),
-        )
-    if waiting:
-        subject += '{num_waiting} waiting{sep}'.format(
-            num_waiting=len(waiting),
-            sep=maybe_comma(running or waiting or queued or passed)
-        )
-        waiting_sect = email_templates['sect_templ'].format(
-            title='Waiting',
-            jobs=''.join(waiting.values()),
-        )
-    if queued:
-        subject += '{num_queued} queued{sep}'.format(
-            num_queued=len(queued),
-            sep=maybe_comma(running or waiting or queued or passed)
-        )
-        queued_sect = email_templates['sect_templ'].format(
-            title='Queued',
-            jobs=''.join(queued.values()),
-        )
-    if passed:
-        subject += '%s passed ' % len(passed)
-        pass_sect = email_templates['sect_templ'].format(
-            title='Passed',
-            jobs=''.join(passed.values()),
-        )
+    subject = ', '.join(subject_fragments) + ' '
 
     if config.archive_server:
         log_root = os.path.join(config.archive_server, name, '')
@@ -276,22 +153,91 @@ def build_email_body(name, _reporter=None):
         name=name,
         info_root=misc.get_results_url(name),
         log_root=log_root,
-        fail_count=len(failed),
-        dead_count=len(dead),
-        running_count=len(running),
-        waiting_count=len(waiting),
-        queued_count=len(queued),
-        pass_count=len(passed),
-        fail_sect=fail_sect,
-        dead_sect=dead_sect,
-        running_sect=running_sect,
-        waiting_sect=waiting_sect,
-        queued_sect=queued_sect,
-        pass_sect=pass_sect,
+        fail_count=len(stanzas['fail']),
+        dead_count=len(stanzas['dead']),
+        running_count=len(stanzas['running']),
+        waiting_count=len(stanzas['waiting']),
+        queued_count=len(stanzas['queued']),
+        pass_count=len(stanzas['pass']),
+        fail_sect=sections['fail'],
+        dead_sect=sections['dead'],
+        running_sect=sections['running'],
+        waiting_sect=sections['waiting'],
+        queued_sect=sections['queued'],
+        pass_sect=sections['pass'],
     )
 
     subject += 'in {suite}'.format(suite=name)
     return (subject.strip(), body.strip())
+
+
+def format_job(run_name, job):
+    job_id = job['job_id']
+    status = job['status']
+    description = job['description']
+    duration = int(job['duration'] or 0)
+
+    # Every job gets a link to e.g. pulpito's pages
+    info_url = misc.get_results_url(run_name, job_id)
+    if info_url:
+        info_line = email_templates['info_url_templ'].format(info=info_url)
+    else:
+        info_line = ''
+
+    if status in UNFINISHED_STATUSES:
+        format_args = dict(
+            job_id=job_id,
+            desc=description,
+            time=duration,
+            info_line=info_line,
+        )
+        return email_templates['running_templ'].format(**format_args)
+
+    if status == 'pass':
+        return email_templates['pass_templ'].format(
+            job_id=job_id,
+            desc=description,
+            time=duration,
+            info_line=info_line,
+        )
+    else:
+        log_dir_url = job['log_href'].rstrip('teuthology.yaml')
+        if log_dir_url:
+            log_line = email_templates['fail_log_templ'].format(
+                log=log_dir_url)
+        else:
+            log_line = ''
+        sentry_event = job.get('sentry_event')
+        if sentry_event:
+            sentry_line = email_templates['fail_sentry_templ'].format(
+                sentry_event=sentry_event)
+        else:
+            sentry_line = ''
+
+        if job['failure_reason']:
+            # 'fill' is from the textwrap module and it collapses a given
+            # string into multiple lines of a maximum width as specified.
+            # We want 75 characters here so that when we indent by 4 on the
+            # next line, we have 79-character exception paragraphs.
+            reason = fill(job['failure_reason'] or '', 75)
+            reason = \
+                '\n'.join(('    ') + line for line in reason.splitlines())
+            reason_lines = email_templates['fail_reason_templ'].format(
+                reason=reason)
+        else:
+            reason_lines = ''
+
+        format_args = dict(
+            job_id=job_id,
+            desc=description,
+            time=duration,
+            info_line=info_line,
+            log_line=log_line,
+            sentry_line=sentry_line,
+            reason_lines=reason_lines,
+        )
+        return email_templates['fail_templ'].format(**format_args)
+
 
 email_templates = {
     'body_templ': dedent("""\

--- a/teuthology/test/test_results.py
+++ b/teuthology/test/test_results.py
@@ -84,6 +84,7 @@ class TestResultsEmail(object):
     queued:  1
     passed:  1
 
+
     Fail
     =================================================================
     [88979]  description for job with name test_name
@@ -113,15 +114,21 @@ class TestResultsEmail(object):
     [30481] description for job with name test_name
     info:   http://example.com/test_name/30481/
 
+
+
     Waiting
     =================================================================
     [62965] description for job with name test_name
     info:   http://example.com/test_name/62965/
 
+
+
     Queued
     =================================================================
     [79063] description for job with name test_name
     info:   http://example.com/test_name/79063/
+
+
 
     Pass
     =================================================================

--- a/teuthology/test/test_results.py
+++ b/teuthology/test/test_results.py
@@ -11,15 +11,32 @@ class TestResultsEmail(object):
     reference = {
         'run_name': 'test_name',
         'jobs': [
-            # Hung
+            # Running
             {'description': 'description for job with name test_name',
              'job_id': 30481,
              'name': 'test_name',
              'log_href': 'http://qa-proxy.ceph.com/teuthology/test_name/30481/teuthology.log',  # noqa
              'owner': 'job@owner',
-             'pid': 80399,
              'duration': None,
              'status': 'running',
+             },
+            # Waiting
+            {'description': 'description for job with name test_name',
+             'job_id': 62965,
+             'name': 'test_name',
+             'log_href': 'http://qa-proxy.ceph.com/teuthology/test_name/30481/teuthology.log',  # noqa
+             'owner': 'job@owner',
+             'duration': None,
+             'status': 'waiting',
+             },
+            # Queued
+            {'description': 'description for job with name test_name',
+             'job_id': 79063,
+             'name': 'test_name',
+             'log_href': 'http://qa-proxy.ceph.com/teuthology/test_name/30481/teuthology.log',  # noqa
+             'owner': 'job@owner',
+             'duration': None,
+             'status': 'queued',
              },
             # Failed
             {'description': 'description for job with name test_name',
@@ -27,11 +44,21 @@ class TestResultsEmail(object):
              'name': 'test_name',
              'log_href': 'http://qa-proxy.ceph.com/teuthology/test_name/88979/teuthology.log',  # noqa
              'owner': 'job@owner',
-             'pid': 3903,
              'duration': 35190,
              'success': False,
              'status': 'fail',
              'failure_reason': 'Failure reason!',
+             },
+            # Dead
+            {'description': 'description for job with name test_name',
+             'job_id': 69152,
+             'name': 'test_name',
+             'log_href': 'http://qa-proxy.ceph.com/teuthology/test_name/69152/teuthology.log',  # noqa
+             'owner': 'job@owner',
+             'duration': 5225,
+             'success': False,
+             'status': 'dead',
+             'failure_reason': 'Dead reason!',
              },
             # Passed
             {'description': 'description for job with name test_name',
@@ -39,21 +66,23 @@ class TestResultsEmail(object):
              'name': 'test_name',
              'log_href': 'http://qa-proxy.ceph.com/teuthology/test_name/68369/teuthology.log',  # noqa
              'owner': 'job@owner',
-             'pid': 38524,
              'duration': 33771,
              'success': True,
              'status': 'pass',
              },
         ],
-        'subject': '1 failed, 1 hung, 1 passed in test_name',
+        'subject': '1 failed, 1 dead, 1 running, 1 waiting, 1 queued, 1 passed in test_name',  # noqa
         'body': textwrap.dedent("""
     Test Run: test_name
     =================================================================
-    info:   http://example.com/test_name/
-    logs:   http://qa-proxy.ceph.com/teuthology/test_name/
-    failed: 1
-    hung:   1
-    passed: 1
+    info:    http://example.com/test_name/
+    logs:    http://qa-proxy.ceph.com/teuthology/test_name/
+    failed:  1
+    dead:    1
+    running: 1
+    waiting: 1
+    queued:  1
+    passed:  1
 
     Failed
     =================================================================
@@ -66,10 +95,33 @@ class TestResultsEmail(object):
         Failure reason!
 
 
-    Hung
+
+    Dead
+    =================================================================
+    [69152]  description for job with name test_name
+    -----------------------------------------------------------------
+    time:   5225s
+    info:   http://example.com/test_name/69152/
+    log:    http://qa-proxy.ceph.com/teuthology/test_name/69152/
+
+        Dead reason!
+
+
+
+    Running
     =================================================================
     [30481] description for job with name test_name
     info:   http://example.com/test_name/30481/
+
+    Waiting
+    =================================================================
+    [62965] description for job with name test_name
+    info:   http://example.com/test_name/62965/
+
+    Queued
+    =================================================================
+    [79063] description for job with name test_name
+    info:   http://example.com/test_name/79063/
 
     Passed
     =================================================================

--- a/teuthology/test/test_results.py
+++ b/teuthology/test/test_results.py
@@ -88,7 +88,7 @@ class TestResultsEmail(object):
     =================================================================
     [88979]  description for job with name test_name
     -----------------------------------------------------------------
-    time:   35190s
+    time:   09:46:30
     info:   http://example.com/test_name/88979/
     log:    http://qa-proxy.ceph.com/teuthology/test_name/88979/
 
@@ -100,7 +100,7 @@ class TestResultsEmail(object):
     =================================================================
     [69152]  description for job with name test_name
     -----------------------------------------------------------------
-    time:   5225s
+    time:   01:27:05
     info:   http://example.com/test_name/69152/
     log:    http://qa-proxy.ceph.com/teuthology/test_name/69152/
 
@@ -126,7 +126,7 @@ class TestResultsEmail(object):
     Pass
     =================================================================
     [68369] description for job with name test_name
-    time:   33771s
+    time:   09:22:51
     info:   http://example.com/test_name/68369/
     """).strip(),
     }

--- a/teuthology/test/test_results.py
+++ b/teuthology/test/test_results.py
@@ -71,7 +71,7 @@ class TestResultsEmail(object):
              'status': 'pass',
              },
         ],
-        'subject': '1 failed, 1 dead, 1 running, 1 waiting, 1 queued, 1 passed in test_name',  # noqa
+        'subject': '1 fail, 1 dead, 1 running, 1 waiting, 1 queued, 1 pass in test_name',  # noqa
         'body': textwrap.dedent("""
     Test Run: test_name
     =================================================================
@@ -84,7 +84,7 @@ class TestResultsEmail(object):
     queued:  1
     passed:  1
 
-    Failed
+    Fail
     =================================================================
     [88979]  description for job with name test_name
     -----------------------------------------------------------------
@@ -123,7 +123,7 @@ class TestResultsEmail(object):
     [79063] description for job with name test_name
     info:   http://example.com/test_name/79063/
 
-    Passed
+    Pass
     =================================================================
     [68369] description for job with name test_name
     time:   33771s


### PR DESCRIPTION
We used to claim that every job that didn't pass or fail had 'hung'. That was a holdover from the pre-paddles era.

Now we can report 'dead', 'running', 'waiting', and 'queued'.

``teuthology-results`` will now require a running paddles instance, but then again, so does scheduling jobs in the first place.