### PR TITLE
Pin os-client-config to 1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
                       # is resolved
                       'cliff-tablib', # required to get a Field/Value output from openstack server show
                       'python-openstackclient',
+                      'os-client-config==1.9.0',
                       ],
 
 


### PR DESCRIPTION
This is to fix 'openstack image list --json' acting as if --debug were
passed. This was breaking things.

https://bugs.launchpad.net/os-client-config/+bug/1513919

Signed-off-by: Zack Cerza <zack@redhat.com>