### PR TITLE
Unpin os-client-config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
                       # is resolved
                       'cliff-tablib', # required to get a Field/Value output from openstack server show
                       'python-openstackclient',
-                      'os-client-config==1.9.0',
                       ],
 
 


### PR DESCRIPTION
The bug found in 1.10.1 was fixed and version 1.10.2 is now current.

https://bugs.launchpad.net/os-client-config/+bug/1513919

Signed-off-by: Loic Dachary <loic@dachary.org>