### PR TITLE
openstack: support glance disk-format raw

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -27,7 +27,7 @@ Linux)
         #   C) Adding "Precise" conditionals somewhere, eg. conditionalizing
         #   this bootstrap script to only use the python-libvirt package on
         #   Ubuntu Precise.
-        for package in python-dev libssl-dev python-pip python-virtualenv libevent-dev python-libvirt libmysqlclient-dev libffi-dev libyaml-dev ; do
+        for package in qemu-utils python-dev libssl-dev python-pip python-virtualenv libevent-dev python-libvirt libmysqlclient-dev libffi-dev libyaml-dev ; do
             if [ "$(dpkg --status -- $package|sed -n 's/^Status: //p')" != "install ok installed" ]; then
                 # add a space after old values
                 missing="${missing:+$missing }$package"

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -128,12 +128,20 @@ class OpenStack(object):
 
     def image_create(self, name):
         """
-        Upload an image into OpenStack with glance. The image has to be qcow2.
+        Upload an image into OpenStack with glance.
         """
         misc.sh("wget -c -O " + name + ".qcow2 " + self.image2url[name])
+        self.set_provider()
+        if self.provider == 'dreamhost':
+            image = name + ".raw"
+            disk_format = 'raw'
+            misc.sh("qemu-img convert " + name + ".qcow2 " + image)
+        else:
+            image = name + ".qcow2"
+            disk_format = 'qcow2'
         misc.sh("glance image-create --property ownedby=teuthology " +
-                " --disk-format=qcow2 --container-format=bare " +
-                " --file " + name + ".qcow2 --name " + self.image_name(name))
+                " --disk-format=" + disk_format + " --container-format=bare " +
+                " --file " + image + " --name " + self.image_name(name))
 
     def image(self, os_type, os_version):
         """


### PR DESCRIPTION
For providers such as dreamcompute that only support the glance image
format raw, convert the qcow2 image to raw prior to uploading.

Signed-off-by: Loic Dachary <ldachary@redhat.com>