### PR TITLE
Remove epel packages during downstream testing if present on the node

### DIFF
--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -760,6 +760,8 @@ def rh_install_pkgs(ctx, remote, installed_version):
     """
     pkgs = ['ceph-deploy']
     rh_version_check = {'0.94.1': '1.3.0', '0.94.3': '1.3.1'}
+    log.info("Remove any epel packages installed on node %s", remote.shortname)
+    remote.run(args=['sudo', 'yum', 'remove', run.Raw("leveldb xmlstarlet fcgi"), '-y'],check_status=False)
     for pkg in pkgs:
         log.info("Check if ceph-deploy is already installed on node %s", remote.shortname)
         remote.run(args=['sudo', 'yum', 'clean', 'metadata'])


### PR DESCRIPTION
Remove epel packages during downstream testing if present on the node and install these packages using the downstream repo

Dependent on https://github.com/ceph/ceph-cm-ansible/pull/167

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>