### PR TITLE
suite: do not cancel --dry-run if double --verbose

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -20,9 +20,7 @@ runs the dumpling-x facet of the upgrade suite.
 Miscellaneous arguments:
   -h, --help                  Show this help message and exit
   -v, --verbose               Be more verbose
-  --dry-run                   Do a dry run; do not schedule anything. In
-                              combination with -vv, also call
-                              teuthology-schedule with --dry-run.
+  --dry-run                   Do a dry run; do not schedule anything.
 
 Standard arguments:
   <config_yaml>               Optional extra job yaml to include

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -670,11 +670,8 @@ def teuthology_schedule(args, verbose, dry_run, log_prefix=''):
     """
     Run teuthology-schedule to schedule individual jobs.
 
-    If --dry-run has been passed but --verbose has been passed just once, don't
-    actually run the command - only print what would be executed.
-
-    If --dry-run has been passed and --verbose has been passed multiple times,
-    do both.
+    If --dry-run has been passed don't actually run the
+    command - only print what would be executed.
     """
     exec_path = os.path.join(
         os.path.dirname(sys.argv[0]),
@@ -693,7 +690,7 @@ def teuthology_schedule(args, verbose, dry_run, log_prefix=''):
             log_prefix,
             ' '.join(printable_args),
         ))
-    if not dry_run or (dry_run and verbose > 1):
+    if not dry_run:
         subprocess.check_call(args=args)
 
 


### PR DESCRIPTION
This behavior is confusing and will lead to unexpected suite scheduling
if the --verbose flag is in the command line twice by accident.

http://tracker.ceph.com/issues/13854 Fixes: #13854

Signed-off-by: Loic Dachary <loic@dachary.org>