### PR TITLE
openstack: enforce hints as an array

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -189,9 +189,7 @@ class OpenStack(object):
         if not hints:
             return result
         if type(hints) is types.DictType:
-            hints = [hints]
-            # TODO: raise after converting all ceph-qa-suite to only use arrays (oct 2015)
-            # raise Exception("openstack: " + str(hints) + " must be an array, not a dict")
+            raise Exception("openstack: " + str(hints) + " must be an array, not a dict")
         for hint in hints:
             for resource in ('machine', 'volumes'):
                 if resource in hint:


### PR DESCRIPTION
All OpenStack hints have been converted to arrays (hammer, infernalis,
master), raise an error if a hint is added old style to avoid mixing
style.

http://tracker.ceph.com/issues/13581 Fixes: #13581

Signed-off-by: Loic Dachary <loic@dachary.org>