### PR TITLE
openstack: update ~/.teuthology with --git-ceph{,qa-suite}-url

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -166,5 +166,13 @@ and analyze results.
         type=int,
         default=15,
     )
+    parser.add_argument(
+        '--ceph-git-url',
+        help=("git clone url for Ceph"),
+    )
+    parser.add_argument(
+        '--ceph-qa-suite-git-url',
+        help=("git clone url for ceph-qa-suite"),
+    )
 
     return parser.parse_args(argv)

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -419,13 +419,22 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
                                     '--archive-upload',
                                     '--key-name',
                                     '--key-filename',
-                                    '--simultaneous-jobs'):
+                                    '--simultaneous-jobs',
+                                    '--ceph-git-url',
+                                    '--ceph-qa-suite-git-url'):
                 del original_argv[0:2]
             elif original_argv[0] in ('--teardown',
                                       '--upload'):
                 del original_argv[0]
             else:
                 argv.append(original_argv.pop(0))
+        for arg in ('ceph_git_url', 'ceph_qa_suite_git_url'):
+            if getattr(self.args, arg):
+                command = (
+                    "perl -pi -e 's|.*{arg}.*|{arg}: {value}|'"
+                    " ~/.teuthology.yaml"
+                ).format(arg=arg, value=getattr(self.args, arg))
+                self.ssh(command)
         argv.append('/home/' + self.username +
                     '/teuthology/teuthology/openstack/test/openstack.yaml')
         command = (
@@ -433,7 +442,7 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
             " --machine-type openstack " +
             " ".join(map(lambda x: "'" + x + "'", argv))
         )
-        print self.ssh(command)
+        self.ssh(command)
 
     def setup(self):
         """

--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -55,6 +55,8 @@ lock_server: http://localhost:8080/
 results_server: http://localhost:8080/
 gitbuilder_host: gitbuilder.ceph.com
 check_package_signatures: false
+ceph_git_url: https://github.com/ceph/ceph.git
+ceph_qa_suite_git_url: https://github.com/ceph/ceph-qa-suite.git
 queue_port: 11300
 suite_verify_ceph_hash: false
 queue_host: localhost


### PR DESCRIPTION
The teuthology-openstack cli has two arguments to override the
git_ceph_url and git_ceph_qa_suite_url configuration values in the
~/.teuthology.yaml file of the teuthology cluster.

Signed-off-by: Loic Dachary <loic@dachary.org>