### PR TITLE
openstack: run one job at a time by default

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -51,7 +51,7 @@ and analyze results.
         '--simultaneous-jobs',
         help='maximum number of jobs running in parallel',
         type=int,
-        default=2,
+        default=1,
     )
     parser.add_argument(
         '--teardown',


### PR DESCRIPTION
Most jobs in rados/thrash allocate six volumes. The default tenant on
OVH has ten volumes, that's just not enough for two jobs to run in parallel.

Signed-off-by: Loic Dachary <loic@dachary.org>