### PR TITLE
openstack: cleanup leftovers every 30 minutes

### DIFF
--- a/teuthology/openstack/openstack-teuthology.cron
+++ b/teuthology/openstack/openstack-teuthology.cron
@@ -1,0 +1,2 @@
+SHELL=/bin/bash
+*/30 * * * * ( date ; source $HOME/openrc.sh ; time timeout 900 $HOME/teuthology/virtualenv/bin/teuthology-nuke --stale-openstack ) >> $HOME/cron.log 2>&1

--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -275,6 +275,15 @@ function setup_bootscript() {
     echo "CREATED init script /etc/init.d/teuthology"
 }
 
+function setup_crontab() {
+    local where=$(dirname $0)
+    crontab $where/openstack-teuthology.cron
+}
+
+function remove_crontab() {
+    crontab -r
+}
+
 function get_or_create_keypair() {
     local keypair=$1
     local key_file=$HOME/.ssh/id_rsa
@@ -556,6 +565,7 @@ function main() {
         setup_authorized_keys || return 1
         setup_bashrc || return 1
         setup_bootscript $nworkers || return 1
+        setup_crontab || return 1
     fi
 
     if $do_setup_keypair ; then
@@ -586,6 +596,7 @@ function main() {
         teardown_pulpito || return 1
         teardown_ansible || return 1
         remove_images || return 1
+        remove_crontab || return 1
     fi
 }
 


### PR DESCRIPTION
Resources are billed by the hour, it makes a difference to cleanup
leftovers once every hour. Provide a crontab that runs

  teuthology-nuke --stale-openstack

every 30 minutes.

Signed-off-by: Loic Dachary <loic@dachary.org>