### PR TITLE
openstack: use flavor list to verify connectivity

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -530,9 +530,9 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
         know already.
         """
         try:
-            misc.sh("openstack server list")
+            misc.sh("openstack flavor list | tail -2")
         except subprocess.CalledProcessError:
-            log.exception("openstack server list")
+            log.exception("openstack flavor list")
             raise Exception("verify openrc.sh has been sourced")
         self.set_provider()
 


### PR DESCRIPTION
Using the server list to verify if the connection to the OpenStack
cluster works may generate too much output if there are many
instances. Use the last two lines of flavor list instead.

Signed-off-by: Loic Dachary <loic@dachary.org>