### PR TITLE
suite: --wait to block until the suite finishes

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -28,6 +28,7 @@ Standard arguments:
   <config_yaml>               Optional extra job yaml to include
   -s <suite>, --suite <suite>
                               The suite to schedule
+  --wait                      Block until the suite is finished
   -c <ceph>, --ceph <ceph>    The ceph branch to run against
                               [default: master]
   -k <kernel>, --kernel <kernel>


### PR DESCRIPTION
After all jobs in the suite are scheduled, wait for it to complete by
checking the result server every five minutes. The polling delay is
large but almost all suites take significantly longer than five minutes.

The list of remaining jobs is displayed every five minutes in verbose
mode.

The suite is considered stale if the list of unfinished jobs does not
change within config.max_job_time seconds (plus 30 minutes to avoid
border cases). It can happen when a worker dies, the machine running the
worker reboots etc.

http://tracker.ceph.com/issues/13884 Fixes: 13884

Signed-off-by: Loic Dachary <loic@dachary.org>