### PR TITLE
amendment misunderstood lock server and results server address

### DIFF
--- a/docs/LAB_SETUP.rst
+++ b/docs/LAB_SETUP.rst
@@ -60,8 +60,8 @@ Teuthology Node
 Create an ``/etc/teuthology.yaml`` that looks like::
 
     lab_domain: example.com
-    lock_server: http://pulpito.example.com:8080
-    results_server: http://pulpito.example.com:8080
+    lock_server: http://paddles.example.com:8080
+    results_server: http://paddles.example.com:8080
     queue_host: localhost
     queue_port: 11300
     results_email: you@example.com


### PR DESCRIPTION
In fact, results server and lock server are function of the paddles, written pulpito is misleading, although pulpito and paddles always installed on one machine.
