### PR TITLE
bootstrap: fixes for openSUSE

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -66,9 +66,11 @@ Linux)
 	fi
 	;;
     "openSUSE project"|"SUSE LINUX")
-        for package in python-pip python-virtualenv libev-devel libvirt-python libmysqlclient-devel libffi-devel; do
+        for package in python-pip python-devel python-virtualenv libev-devel libvirt-python libmysqlclient-devel libffi-devel; do
             if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
-                missing="${missing:+$missing }$package"
+                if [ "$(rpm -q --whatprovides $package)" == "no package provides $package" ]; then
+                    missing="${missing:+$missing }$package"
+                fi
             fi
         done
         if [ -n "$missing" ]; then


### PR DESCRIPTION
When a package is found not to exist, we need to also check if there
is another package installed that provides a capability of the same
name.

Also, the python-devel package must be installed, or the pip phase
fails.

http://tracker.ceph.com/issues/14002 Fixes: #14002

Signed-off-by: Nathan Cutler <ncutler@suse.com>