### PR TITLE
Remote: only submit X.Y for os_version

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -357,7 +357,7 @@ class Remote(object):
         node['user'] = self.user
         node['arch'] = self.arch
         node['os_type'] = self.os.name
-        node['os_version'] = self.os.version
+        node['os_version'] = '.'.join(self.os.version.split('.')[:2])
         node['ssh_pub_key'] = self.host_key
         node['up'] = True
         return node

--- a/teuthology/orchestra/test/test_remote.py
+++ b/teuthology/orchestra/test/test_remote.py
@@ -5,6 +5,7 @@ from pytest import skip
 from cStringIO import StringIO, OutputType
 
 from .. import remote
+from .. import opsys
 from ..run import RemoteProcess
 
 
@@ -137,3 +138,18 @@ class TestRemote(object):
         key.expects('get_base64').returns('test ssh key')
         r = remote.Remote(name='jdoe@xyzzy.example.com', ssh=ssh)
         assert r.host_key == 'key_type test ssh key'
+
+    def test_inventory_info(self):
+        r = remote.Remote('user@host', host_key='host_key')
+        r._arch = 'arch'
+        r._os = opsys.OS(name='os_name', version='1.2.3', codename='code')
+        inv_info = r.inventory_info
+        assert inv_info == dict(
+            name='host',
+            user='user',
+            arch='arch',
+            os_type='os_name',
+            os_version='1.2',
+            ssh_pub_key='host_key',
+            up=True,
+        )


### PR DESCRIPTION
The opsys.OS class passes the operating system's version according to
the actual host; in some cases e.g. CentOS is reporting things like
'7.1.1503'. In these cases, let's make
Remote.inventory_info['os_version'] only use the '7.1' - since we don't
care about the rest. This will allow us to continue scheduling against
CentOS smoothly.

Signed-off-by: Zack Cerza <zack@redhat.com>