### PR TITLE
misc: truncating shell output to 1024 per line

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1282,7 +1282,7 @@ def is_in_dict(searchkey, searchval, d):
         return searchval == val
 
 
-def sh(command, log_limit=128):
+def sh(command, log_limit=1024):
     """
     Run the shell command and return the output in ascii (stderr and
     stdout).  If the command fails, raise an exception. The command


### PR DESCRIPTION
Truncating by default to 128 frequently trims useful debug
information. Set the default to 1024: the intent is to avoid huge logs
when a json output is repeatedly returning large (>10k) payloads.

Signed-off-by: Loic Dachary <loic@dachary.org>