### PR TITLE
ceph.conf: mon osd reporter subtree level = osd

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -53,6 +53,7 @@
 	debug paxos = 20
 	mon data avail warn = 5
 	mon reweight min pgs per osd = 4
+	mon osd reporter subtree level = osd
 
 [mds]
         mds debug scatterstat = true


### PR DESCRIPTION
Teuthology puts everything under one host, and many tests run on one host.

Signed-off-by: Sage Weil <sage@redhat.com>