### PR TITLE
tests: openstack-integration is too agressive

### DIFF
--- a/teuthology/openstack/test/openstack-integration.py
+++ b/teuthology/openstack/test/openstack-integration.py
@@ -57,14 +57,11 @@ class Integration(object):
         # INTERNALERROR> IndexError: list index out of range
         # move that to def tearDown for debug and when it works move it
         # back in tearDownClass so it is not called on every test
+        ownedby = "ownedby='" + teuth_config.openstack['ip']
         all_instances = teuthology.misc.sh("openstack server list -f json --long")
         for instance in json.loads(all_instances):
-            if 'teuthology=' in instance['Properties']:
+            if ownedby in instance['Properties']:
                 teuthology.misc.sh("openstack server delete --wait " + instance['ID'])
-        teuthology.misc.sh("""
-teuthology/openstack/setup-openstack.sh \
-  --populate-paddles
-        """)
 
     def setup_worker(self):
         self.logs = self.d + "/log"


### PR DESCRIPTION
It will wipe out all targets in the tenant which can be devastating and
unexpected when multiple teuthology clusters use the same tenant. Filter
the deletion using the ownedby property to limit the destruction to the
targets owned by the cluster in which the integration tests are run.

Signed-off-by: Loic Dachary <loic@dachary.org>