### PR TITLE
openstack: remove bugous static IP regexp

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -144,8 +144,7 @@ class OpenStackInstance(object):
         if not self.ip:
             self.ip = self.get_floating_ip()
             if not self.ip:
-                self.ip = re.findall('([\d.]+)$',
-                                     self.get_addresses())[0]
+                self.ip = self.get_ip('')
         return self.ip
 
     def destroy(self):


### PR DESCRIPTION
Instead of duplicating a bugous static IP regexp, use the get_ip()
method.

Signed-off-by: Loic Dachary <loic@dachary.org>