### PR TITLE
openstack: keep image private

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -266,6 +266,7 @@ class OpenStack(object):
             disk_format = 'qcow2'
         misc.sh("glance image-create --property ownedby=teuthology " +
                 " --disk-format=" + disk_format + " --container-format=bare " +
+                " --visibility private" +
                 " --file " + image + " --name " + self.image_name(name))
 
     def image(self, os_type, os_version):


### PR DESCRIPTION
Ensure a newly created image is private to this tenant by default,
regardless of whatever the openstack defaults are.

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>