### PR TITLE
suite: honor suite_verify_ceph_hash on --dry-run

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -613,7 +613,7 @@ def schedule_suite(job_config,
             args=arg
         )
 
-        if dry_run:
+        if dry_run and config.suite_verify_ceph_hash:
             full_job_config = dict()
             deep_merge(full_job_config, job_config.to_dict())
             deep_merge(full_job_config, parsed_yaml)


### PR DESCRIPTION
When running dry-run, an attempt is made to figure out if the hash of
the job is already present in the gitbuilder. This must not be done
if suite_verify_ceph_hash is false.

Signed-off-by: Loic Dachary <loic@dachary.org>