### PR TITLE
openstack: support CentOS 7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
          'archive-key.pub',
          'openstack-centos-6.5-user-data.txt',
          'openstack-centos-7.0-user-data.txt',
+         'openstack-centos-7.1-user-data.txt',
          'openstack-debian-8.0-user-data.txt',
          'openstack-opensuse-user-data.txt',
          'openstack-teuthology.cron',

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -182,6 +182,7 @@ class OpenStack(object):
     image2url = {
         'centos-6.5': 'http://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud-1508.qcow2',
         'centos-7.0': 'http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1508.qcow2',
+        'centos-7.1': 'http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1508.qcow2',
         'ubuntu-12.04': 'https://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-amd64-disk1.img',
         'ubuntu-14.04': 'https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-disk1.img',
         'debian-8.0': 'http://cdimage.debian.org/cdimage/openstack/current/debian-8.2.0-openstack-amd64.qcow2',

--- a/teuthology/openstack/openstack-centos-7.1-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.1-user-data.txt
@@ -1,0 +1,21 @@
+#cloud-config
+bootcmd:
+ - echo nameserver {nameserver} | tee /etc/resolv.conf
+ - echo search {lab_domain} | tee -a /etc/resolv.conf
+ - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-eth0
+ - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
+ - hostname $(cat /etc/hostname)
+ - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config
+# See https://github.com/ceph/ceph-cm-ansible/blob/master/roles/cobbler/templates/snippets/cephlab_user
+ - ( echo 'Defaults !requiretty' ; echo 'Defaults visiblepw' ) | tee /etc/sudoers.d/cephlab_sudo ; chmod 0440 /etc/sudoers.d/cephlab_sudo
+preserve_hostname: true
+system_info:
+  default_user:
+    name: {username}
+packages:
+ - python
+ - wget
+ - git
+ - ntp
+ - redhat-lsb-core
+final_message: "{up}, after $UPTIME seconds"


### PR DESCRIPTION
It uses the same cloud image as centos-7.0 because it already was 7.1
anyway, only misnamed 7.0 because changing it is inconvenient.

Signed-off-by: Loic Dachary <loic@dachary.org>