### PR TITLE
ansible: include the contents of the failure log in the exception

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -272,7 +272,7 @@ class Ansible(Task):
                         self.failure_log.name,
                     )
                 )
-                failures = fail_log
+                failures = fail_log.read().replace('\n', '')
 
         if failures:
             self._archive_failures()


### PR DESCRIPTION
When parsing of the ansible failure log fails this will actually print
the contents of the malformed log in the raised AnsibleFailedError.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>