### PR TITLE
Block requests==2.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ setup(
                       'httplib2',
                       'paramiko < 1.8',
                       'pexpect',
-                      'requests >= 2.3.0',
+                      # We have to block requests 2.9.0 because of:
+                      # https://bugs.launchpad.net/nova/+bug/1526413
+                      'requests >= 2.3.0, != 2.9.0',
                       'raven',
                       'web.py',
                       'docopt',


### PR DESCRIPTION
Because of https://bugs.launchpad.net/nova/+bug/1526413

Signed-off-by: Zack Cerza <zack@redhat.com>