### PR TITLE
packaging.GitbuilderProject: support the wait_for_package feature

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -428,7 +428,16 @@ def _get_response(url, wait=False, sleep=15, tries=10):
     with safe_while(sleep=sleep, tries=tries, _raise=False) as proceed:
         while proceed():
             resp = requests.get(url)
-            if resp.ok or not wait:
+            if resp.ok:
+                log.info('Package found...')
+                break
+
+            if not wait:
+                log.info(
+                    'Package is not found at: %s (got HTTP code %s)...',
+                    url,
+                    resp.status_code,
+                )
                 break
 
             log.info(

--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -1263,7 +1263,7 @@ def task(ctx, config):
                 flavor=flavor,
                 extra_packages=config.get('extra_packages', []),
                 extras=config.get('extras', None),
-                wait_for_package=ctx.config.get('wait_for_package', False),
+                wait_for_package=config.get('wait_for_package', False),
                 project=project,
             )),
             lambda: ship_utilities(ctx=ctx, config=None),


### PR DESCRIPTION
This fixes: http://tracker.ceph.com/issues/14125

When trying to fetch a package version, GitbuilderProject will now wait and retry for 2 1/2 minutes if the status_code returned is not a 200 and the config option ``wait_for_package: true`` is set for either the install task or install.upgrade.

The 2 1/2 minute wait time is fairly arbitrary, I'm open to better suggestions there. We could also make it a teuthology config option (in teuthology.yaml) if we wanted to get fancy.