### PR TITLE
doc: add descriptive comment at top of hammer.sh script

### DIFF
--- a/hammer.sh
+++ b/hammer.sh
@@ -1,4 +1,7 @@
 #!/bin/sh -ex
+#
+# simple script to repeat a test until it fails
+#
 
 if [ $1 = "-a" ]; then
     shift


### PR DESCRIPTION
This script was added by 303e863d32c077c17cd8a027172af8204434a66b - this
commit takes the description from that commit and places it in a comment at
the top of the script.

Without this descriptive comment, the only thing we have to go on is the
filename, hammer.sh, which is easily confused with Hammer as in version
0.94 of Ceph.

Signed-off-by: Nathan Cutler <ncutler@suse.com>