### PR TITLE
openstack: a failure to rename a volume is not fatal

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -167,7 +167,7 @@ class OpenStackInstance(object):
         misc.sh("openstack server delete --wait " + self['id'] +
                 " || true")
         for volume in volumes:
-            misc.sh("openstack volume set --name REMOVE-ME " + volume)
+            misc.sh("openstack volume set --name REMOVE-ME " + volume + " || true")
             misc.sh("openstack volume delete " + volume + " || true")
         return True
 


### PR DESCRIPTION
It will be cleaned up by nuke --stale-openstack

Signed-off-by: Loic Dachary <loic@dachary.org>