### PR TITLE
Map locking failures to 'dead' status

### DIFF
--- a/teuthology/exceptions.py
+++ b/teuthology/exceptions.py
@@ -138,3 +138,10 @@ class SELinuxError(Exception):
     def __str__(self):
         return "SELinux denials found on {node}: {denials}".format(
             node=self.node, denials=self.denials)
+
+class QuotaExceededError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -110,8 +110,14 @@ def lock_machines(ctx, config):
                 assert 0, ('not enough machines free; need %s + %s, have %s' %
                            (reserved, requested, len(machines)))
 
-        newly_locked = lock.lock_many(ctx, requested, machine_type, ctx.owner,
-                                      ctx.archive, os_type, os_version, arch)
+        try:
+            newly_locked = lock.lock_many(ctx, requested, machine_type,
+                                          ctx.owner, ctx.archive, os_type,
+                                          os_version, arch)
+        except Exception:
+            # Lock failures should map to the 'dead' status instead of 'fail'
+            set_status(ctx.summary, 'dead')
+            raise
         all_locked.update(newly_locked)
         log.info(
             '{newly_locked} {mtype} machines locked this try, '


### PR DESCRIPTION
Also, add a specific exception for quota-exceeded errors. This will help us identify general OpenStack breakage sooner and more easily.

This is http://tracker.ceph.com/issues/14515