### PR TITLE
Fix bug when running archiveless jobs

### DIFF
--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -47,10 +47,13 @@ def run_one_task(taskname, **kwargs):
 
 def run_tasks(tasks, ctx):
     archive_path = ctx.config.get('archive_path')
-    timer = Timer(
-        path=os.path.join(archive_path, 'timing.yaml'),
-        sync=True,
-    )
+    if archive_path:
+        timer = Timer(
+            path=os.path.join(archive_path, 'timing.yaml'),
+            sync=True,
+        )
+    else:
+        timer = Timer()
     stack = []
     try:
         for taskdict in tasks:


### PR DESCRIPTION
We were trying to tell the timer to write to a nonexistent file

Signed-off-by: Zack Cerza <zack@redhat.com>