### PR TITLE
Support all types of nodes for selinux

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -35,11 +35,7 @@ class SELinux(Task):
         super(SELinux, self).filter_hosts()
         new_cluster = Cluster()
         for (remote, roles) in self.cluster.remotes.iteritems():
-            status_info = get_status(remote.name)
-            if status_info and status_info.get('is_vm', False):
-                msg = "Excluding {host}: VMs are not yet supported"
-                log.info(msg.format(host=remote.shortname))
-            elif remote.os.package_type == 'rpm':
+            if remote.os.package_type == 'rpm':
                 new_cluster.add(remote, roles)
             else:
                 msg = "Excluding {host}: OS '{os}' does not support SELinux"


### PR DESCRIPTION
By default vps nodes are disabled for selinux, we should enable them it there as well.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>