### PR TITLE
Add a warning when gitbuilder 404s

### DIFF
--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -446,6 +446,16 @@ def get_hash(project='ceph', branch='master', flavor='basic',
     log.debug("Gitbuilder URL: %s", url)
     resp = requests.get(url)
     if not resp.ok:
+        msg = "Got a {0} trying to get hash for project '{1}' " + \
+            "and branch '{2}' from URL: {3}"
+        log.warn(
+            msg.format(
+                resp.status_code,
+                project,
+                branch,
+                url
+            )
+        )
         return None
     return str(resp.text.strip())
 


### PR DESCRIPTION
When determining the ceph hash, we usually ask gitbuilder. When that
fails, the error is misleading but it would take a bit of refactoring to
truly fix it. Let's at least put a useful warning before the confusing error
message.

Signed-off-by: Zack Cerza <zack@redhat.com>