### PR TITLE
suite/openstack: implement the exit code

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -3,10 +3,8 @@ import sys
 
 import teuthology.openstack
 
-
 def main(argv=sys.argv[1:]):
-    teuthology.openstack.main(parse_args(argv), argv)
-
+    sys.exit(teuthology.openstack.main(parse_args(argv), argv))
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -92,4 +92,4 @@ Scheduler arguments:
 
 def main(argv=sys.argv[1:]):
     args = docopt.docopt(doc, argv=argv)
-    teuthology.suite.main(args)
+    return teuthology.suite.main(args)

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -455,10 +455,11 @@ class TeuthologyOpenStack(OpenStack):
         self.key_filename = self.args.key_filename
         self.verify_openstack()
         self.setup()
+        exit_code = 0
         if self.args.suite:
             if self.args.wait:
                 self.reminders()
-            self.run_suite()
+            exit_code = self.run_suite()
             self.reminders()
         if self.args.teardown:
             if self.args.suite and not self.args.wait:
@@ -466,6 +467,7 @@ class TeuthologyOpenStack(OpenStack):
                           " right after a suite is scheduled")
             else:
                 self.teardown()
+        return exit_code
 
     def run_suite(self):
         """
@@ -502,7 +504,7 @@ class TeuthologyOpenStack(OpenStack):
             " --machine-type openstack " +
             " ".join(map(lambda x: "'" + x + "'", argv))
         )
-        self.ssh(command)
+        return self.ssh(command)
 
     def reminders(self):
         if self.args.key_filename:


### PR DESCRIPTION
Make it so the exit code of the command reflects the success or failure
of the suite. This is useful when running with --wait.

Signed-off-by: Loic Dachary <loic@dachary.org>