### PR TITLE
suite/openstack: add --archive-upload-url

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -126,6 +126,19 @@ Here is a sample configuration with many of the options set and documented::
     # demand.
     suite_verify_ceph_hash: True
 
+    # The rsync destination to upload the job results, when --upload is
+    # is provided to teuthology-suite.
+    #
+    archive_upload: ubuntu@teuthology-logs.public.ceph.com:./
+
+    # The path to the SSH private key for rsync to upload to archive_upload
+    #
+    archive_upload_key: None
+
+    # The public facing URL of the archive_upload location
+    #
+    archive_upload_url: http://teuthology-logs.public.ceph.com/
+
     # The OpenStack backend configuration, a dictionary interpreted as follows
     #
     openstack:

--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -68,6 +68,11 @@ and analyze results.
         help='rsync destination to upload archives',
         default='ubuntu@teuthology-logs.public.ceph.com:./',
     )
+    parser.add_argument(
+        '--archive-upload-url',
+        help='Public facing URL where archives are uploaded',
+        default='http://teuthology-logs.public.ceph.com',
+    )
     # copy/pasted from scripts/suite.py
     parser.add_argument(
         'config_yaml',

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -82,6 +82,7 @@ Scheduler arguments:
                               the keywords in the comma separated keyword
                               string specified.
   --archive-upload RSYNC_DEST Rsync destination to upload archives.
+  --archive-upload-url URL    Public facing URL where archives are uploaded.
   --throttle SLEEP            When scheduling, wait SLEEP seconds between jobs.
                               Useful to avoid bursts that may be too hard on
                               the underlying infrastructure or exceed OpenStack API

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -131,6 +131,7 @@ class TeuthologyConfig(YamlConfig):
         'archive_base': '/var/lib/teuthworker/archive',
         'archive_upload': None,
         'archive_upload_key': None,
+        'archive_upload_url': None,
         'automated_scheduling': False,
         'reserve_machines': 5,
         'ceph_git_base_url': 'https://github.com/ceph/',

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -477,6 +477,7 @@ class TeuthologyOpenStack(OpenStack):
         while len(original_argv) > 0:
             if original_argv[0] in ('--name',
                                     '--archive-upload',
+                                    '--archive-upload-url',
                                     '--key-name',
                                     '--key-filename',
                                     '--simultaneous-jobs',
@@ -488,6 +489,15 @@ class TeuthologyOpenStack(OpenStack):
                 del original_argv[0]
             else:
                 argv.append(original_argv.pop(0))
+        #
+        # If --upload, provide --archive-upload{,-url} regardless of
+        # what was originally provided on the command line because the
+        # teuthology-openstack defaults are different from the
+        # teuthology-suite defaults.
+        #
+        if self.args.upload:
+            argv.extend(['--archive-upload', self.args.archive_upload,
+                         '--archive-upload-url', self.args.archive_upload_url])
         for arg in ('ceph_git_url', 'ceph_qa_suite_git_url'):
             if getattr(self.args, arg):
                 command = (

--- a/teuthology/openstack/test/test_openstack.py
+++ b/teuthology/openstack/test/test_openstack.py
@@ -336,11 +336,16 @@ openstack keypair delete {key_name} || true
             '--filter-out', 'erasure-code',
             '--throttle', '3',
         ]
+        archive_upload = 'user@archive:/tmp'
         argv = (self.options +
                 ['--upload',
-                 '--archive-upload', 'user@archive:/tmp'] +
+                 '--archive-upload', archive_upload] +
                 teuthology_argv)
         args = scripts.openstack.parse_args(argv)
+        teuthology_argv.extend([
+            '--archive-upload', archive_upload,
+            '--archive-upload-url', args.archive_upload_url,
+        ])
         teuthology = TeuthologyOpenStack(args, None, argv)
         teuthology.user_data = 'teuthology/openstack/test/user-data-test1.txt'
         teuthology.teuthology_suite = 'echo --'

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -125,7 +125,7 @@ def main(args):
     os.remove(base_yaml_path)
     if not dry_run and args['--wait']:
         return wait(name, config.max_job_time,
-                    None)
+                    args['--archive-upload-url'])
 
 WAIT_MAX_JOB_TIME = 30 * 60
 WAIT_PAUSE = 5 * 60


### PR DESCRIPTION
When uploading job results with --upload, it may be non-trivial to
figure out the public facing URL where the job will be visible. When
used via teuthology-openstack, it defaults to

    http://teuthology-logs.public.ceph.com

so that using --wait --upload --teardown displays the URLs of the
uploaded job results that are accessible even after the cluster is
gone.

Signed-off-by: Loic Dachary <loic@dachary.org>