### PR TITLE
openstack: allow override of openstack:clone:

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -62,6 +62,15 @@ and analyze results.
         help='destroy the cluster, if it exists',
     )
     parser.add_argument(
+        '--teuthology-git-url',
+        help=("git clone url for teuthology"),
+    )
+    parser.add_argument(
+        '--teuthology-branch',
+        help="use this teuthology branch instead of master",
+        default='master',
+    )
+    parser.add_argument(
         '--upload',
         action='store_true', default=False,
         help='upload archives to an rsync server',

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -478,6 +478,8 @@ class TeuthologyOpenStack(OpenStack):
         argv = []
         while len(original_argv) > 0:
             if original_argv[0] in ('--name',
+                                    '--teuthology-branch',
+                                    '--teuthology-git-url',
                                     '--archive-upload',
                                     '--archive-upload-url',
                                     '--key-name',
@@ -646,6 +648,10 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
         else:
             upload = ''
         clone = teuth_config.openstack['clone']
+        if self.args.teuthology_git_url:
+            clone = ("git clone -b {branch} {url}".format(
+                branch=self.args.teuthology_branch,
+                url=self.args.teuthology_git_url))
         log.debug("OPENRC = " + openrc + " " +
                   "TEUTHOLOGY_USERNAME = " + self.username + " " +
                   "CLONE_OPENSTACK = " + clone + " " +

--- a/teuthology/openstack/test/test_openstack.py
+++ b/teuthology/openstack/test/test_openstack.py
@@ -338,7 +338,9 @@ openstack keypair delete {key_name} || true
         ]
         archive_upload = 'user@archive:/tmp'
         argv = (self.options +
-                ['--upload',
+                ['--teuthology-git-url', 'TEUTHOLOGY_URL',
+                 '--teuthology-branch', 'TEUTHOLOGY_BRANCH',
+                 '--upload',
                  '--archive-upload', archive_upload] +
                 teuthology_argv)
         args = scripts.openstack.parse_args(argv)
@@ -358,7 +360,7 @@ openstack keypair delete {key_name} || true
         assert "nworkers=" + str(args.simultaneous_jobs) in l
         assert "username=" + teuthology.username in l
         assert "upload=--archive-upload user@archive:/tmp" in l
-        assert "clone=git clone" in l
+        assert "clone=git clone -b TEUTHOLOGY_BRANCH TEUTHOLOGY_URL" in l
         assert os.environ['OS_AUTH_URL'] in l
         assert " ".join(teuthology_argv) in l
 


### PR DESCRIPTION
When running from a wip teuthology branch, it is inconvenient to tweak
~/.teuthology.yaml. Add --teuthology-git-url and --teuthology-branch to
take precendence and override the defaults.

Signed-off-by: Loic Dachary <loic@dachary.org>