### PR TITLE
openstack: default to 9h job timeout

### DIFF
--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -61,7 +61,7 @@ queue_port: 11300
 suite_verify_ceph_hash: false
 queue_host: localhost
 lab_domain: $labdomain
-max_job_time: 21600 # 6 hours
+max_job_time: 32400 # 9 hours
 teuthology_path: .
 openstack:
   clone: git clone http://github.com/ceph/teuthology


### PR DESCRIPTION
Because a few job take more than 6h. Ideally this could be overriden on
a case by case basis.

Signed-off-by: Loic Dachary <loic@dachary.org>