### PR TITLE
openstack: only destroy target/ceph- VMs on restart

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -765,6 +765,7 @@ openstack security group rule create --proto udp --dst-port 53 teuthology # dns
         self.ssh("sudo /etc/init.d/teuthology stop || true")
         instance_id = self.get_instance_id(self.args.name)
         self.delete_floating_ip(instance_id)
+        misc.sh("openstack server delete packages-repository || true")
         misc.sh("openstack server delete --wait " + self.args.name)
 
 def main(ctx, argv):

--- a/teuthology/openstack/openstack-teuthology.init
+++ b/teuthology/openstack/openstack-teuthology.init
@@ -70,14 +70,24 @@ case $1 in
                 source /home/$user/teuthology/virtualenv/bin/activate
                 source /home/$user/openrc.sh
                 ip=$(ip a show dev eth0 | sed -n "s:.*inet \(.*\)/.*:\1:p")
-                openstack server list --long -f json | \
+                openstack server list --long -f json --name target | \
+                    jq ".[] | select(.Properties | contains(\"ownedby='$ip'\")) | .ID" | \
+                    xargs --no-run-if-empty --max-args 1 -P20 openstack server delete --wait
+                openstack server list --long -f json --name ceph- | \
                     jq ".[] | select(.Properties | contains(\"ownedby='$ip'\")) | .ID" | \
                     xargs --no-run-if-empty --max-args 1 -P20 openstack server delete --wait
                 openstack volume list --long -f json | \
                     jq ".[] | select(.Properties | contains(\"ownedby='$ip'\")) | .ID" | \
                     xargs --no-run-if-empty --max-args 1 -P20 openstack volume delete
                 perl -pi -e 's/.*gitbuilder_host.*/gitbuilder_host: gitbuilder.ceph.com/' /home/$user/.teuthology.yaml
-                rm -fr /home/$user/src/* /tmp/stampsdir
+                rm -fr /home/$user/src/*
+                mv /tmp/stampsdir /tmp/stampsdir.old
+                mkdir /tmp/stampsdir
+                chown $user /tmp/stampsdir
+                if test -f /tmp/stampsdir.old/packages-repository ; then
+                    mv /tmp/stampsdir.old/*packages-repository* /tmp/stampsdir
+                fi
+                rm -fr /tmp/stampsdir.old
                 ;;
         restart)
                 $0 stop


### PR DESCRIPTION
Obsolete resources will be taken care of by the teuthology-nuke
--stale-openstack cron job. We just want to avoid running into obsolete
targets.

The ceph-* targets which are created by the buildpackages task must also
be disposed of.

The timestamps dir is wiped out, except for packages-repository, if
it exists.

Signed-off-by: Loic Dachary <loic@dachary.org>