### PR TITLE
openstack: openstacklient >= 2.1.0 does not depend on neutronclient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,9 @@ setup(
                       'ndg-httpsclient',
                       'pyasn1',
                       'python-openstackclient',
+                      # with openstacklient >= 2.1.0, neutronclient no longer is
+                      # a dependency but we need it anyway.
+                      'python-neutronclient',
                       'prettytable',
                       'libvirt-python',
                       # For teuthology-coverage


### PR DESCRIPTION
Explicitly require python-neutronclient.

Signed-off-by: Loic Dachary <loic@dachary.org>