### PR TITLE
bootstrap: install python-libvirt from package

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -16,7 +16,7 @@ case "$(uname -s)" in
 Linux)
     case "$(lsb_release --id --short)" in
     Ubuntu|Debian)
-        for package in qemu-utils python-dev libssl-dev python-pip python-virtualenv libev-dev libvirt-dev libmysqlclient-dev libffi-dev libyaml-dev ; do
+        for package in qemu-utils python-dev libssl-dev python-pip python-virtualenv libev-dev libvirt-dev libmysqlclient-dev libffi-dev libyaml-dev python-libvirt ; do
             if [ "$(dpkg --status -- $package|sed -n 's/^Status: //p')" != "install ok installed" ]; then
                 # add a space after old values
                 missing="${missing:+$missing }$package"


### PR DESCRIPTION
Otherwise Ubuntu 14.04 will try to install python-libvirt 1.3.X from
pypi and fail because only libvirt-devel 1.2.x is packaged.

http://tracker.ceph.com/issues/14917 Fixes: #14917

Signed-off-by: Loic Dachary <loic@dachary.org>