### PR TITLE
openstack: create default ~/.vault_pass.txt

### DIFF
--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -95,6 +95,8 @@ openstack:
   $network
 EOF
     echo "OVERRIDE ~/.teuthology.yaml"
+    echo 'no password' > ~/.vault_pass.txt
+    echo "OVERRIDE ~/.vault_pass.txt"
     return 0
 }
 


### PR DESCRIPTION
It is now required by teuthology.

http://tracker.ceph.com/issues/14914 Fixes: #14914

Signed-off-by: Loic Dachary <loic@dachary.org>