### PR TITLE
openstack: do not use sitepackages for openstack-integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,6 @@ basepython=python2.7
 [testenv:openstack-integration]
 passenv = HOME OS_REGION_NAME OS_AUTH_URL OS_TENANT_ID OS_TENANT_NAME OS_PASSWORD OS_USERNAME
 basepython=python2
-sitepackages=True
 deps=
     -r{toxinidir}/requirements.txt
     mock


### PR DESCRIPTION
Signed-off-by: Loic Dachary <loic@dachary.org>