### PR TITLE
doc: update documentation of make_fake_fstools()

### DIFF
--- a/teuthology/test/fake_fs.py
+++ b/teuthology/test/fake_fs.py
@@ -4,8 +4,8 @@ from contextlib import closing
 
 def make_fake_fstools(fake_filesystem):
     """
-    Build a fake listdir() and isfile(), to be used instead of
-    os.isdir() and os.isfile()
+    Build fake versions of os.listdir(), os.isfile(), etc. for use in
+    unit tests
 
     An example fake_filesystem value:
         >>> fake_fs = {\


### PR DESCRIPTION
When the documentation of make_fake_fstools() was written, the function evidently only returned two values. Now it returns four values. Additional return values might be added later.

Signed-off-by: Nathan Cutler <ncutler@suse.com>