### PR TITLE
Unpin gevent and avoid patching subprocess

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'Topic :: System :: Filesystems',
     ],
     install_requires=['setuptools',
-                      'gevent == 1.0.2',
+                      'gevent',
                       'MySQL-python == 1.2.3',
                       'PyYAML',
                       'argparse >= 1.2.1',

--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -1,5 +1,9 @@
 from gevent import monkey
-monkey.patch_all(dns=False)
+monkey.patch_all(
+    dns=False,
+    # Don't patch subprocess to avoid http://tracker.ceph.com/issues/14990
+    subprocess=False,
+)
 from .orchestra import monkey
 monkey.patch_all()
 


### PR DESCRIPTION
Recently, gevent updated to 1.1.0, breaking a few things like misc.sh().
PR #810 pinned gevent to 1.0.2, but I wanted to properly investigate the
issue to not be stuck on an old version. Some git bisects later, I
discovered that gevent began patching the subprocess module by default
in:

https://github.com/gevent/gevent/commit/fc73e9afa34d811ede5d62531025d2e3876b8c01

Unpinning gevent and also telling it not to patch subprocess fixes the
issue.

Signed-off-by: Zack Cerza <zack@redhat.com>