### PR TITLE
lock: Pass canonicalized hostname to create_if_vm

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -313,7 +313,10 @@ def main(ctx):
                     return ret
             else:
                 machines_to_update.append(machine)
-                provision.create_if_vm(ctx, machine)
+                provision.create_if_vm(
+                    ctx,
+                    misc.canonicalize_hostname(machine),
+                )
     elif ctx.unlock:
         if ctx.owner is None and user is None:
             user = misc.get_user()


### PR DESCRIPTION
This fixes this bug:
```
(virtualenv)zack@teuthology:~/teuthology$ teuthology-lock --lock vpm169 --os-type ubuntu --os-version 14.04
Traceback (most recent call last):
  File "/home/zack/teuthology/virtualenv/bin/teuthology-lock", line 9, in <module>
    load_entry_point('teuthology', 'console_scripts', 'teuthology-lock')()
  File "/home/zack/teuthology/scripts/lock.py", line 17, in main
    sys.exit(teuthology.lock.main(parse_args(sys.argv[1:])))
  File "/home/zack/teuthology/teuthology/lock.py", line 316, in main
    provision.create_if_vm(ctx, machine)
  File "/home/zack/teuthology/teuthology/provision.py", line 391, in create_if_vm
    return dbrst.create()
  File "/home/zack/teuthology/teuthology/provision.py", line 76, in create
    self.build_config()
  File "/home/zack/teuthology/teuthology/provision.py", line 176, in build_config
    fqdn = self.name.split('@')[1]
IndexError: list index out of range
```