### PR TITLE
Mention that -kill must be run on the master node

### DIFF
--- a/scripts/kill.py
+++ b/scripts/kill.py
@@ -16,6 +16,9 @@ Kill running teuthology jobs:
 2. Kills any running jobs
 3. Nukes any machines involved
 
+NOTE: Must be run on the same machine that is executing the teuthology job
+processes.
+
 optional arguments:
   -h, --help            show this help message and exit
   -a ARCHIVE, --archive ARCHIVE


### PR DESCRIPTION
There isn't currently a remote kill-a-process feature.

Signed-off-by: Zack Cerza <zack@redhat.com>