### PR TITLE
lock: add the --arch option

### DIFF
--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -159,6 +159,11 @@ def parse_args(argv):
         help='OS (distro) version such as "12.10"',
     )
     parser.add_argument(
+        '--arch',
+        default=None,
+        help='architecture (x86_64, i386, armv7, arm64)',
+    )
+    parser.add_argument(
         '--json-query',
         default=None,
         help=textwrap.dedent('''\

--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -333,7 +333,7 @@ def main(ctx):
                 machines_to_update.append(machine)
     elif ctx.num_to_lock:
         result = lock_many(ctx, ctx.num_to_lock, ctx.machine_type, user,
-                           ctx.desc, ctx.os_type, ctx.os_version)
+                           ctx.desc, ctx.os_type, ctx.os_version, ctx.arch)
         if not result:
             ret = 1
         else:


### PR DESCRIPTION
So that it is possible to lock a target of a given arch. The lock_many
function already has the argument, it only needs to be added to the list
of available options.

Signed-off-by: Loic Dachary <loic@dachary.org>