### PR TITLE
support multiple ceph clusters

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -1,6 +1,6 @@
 [global]
 	chdir = ""
-	pid file = $name.pid
+	pid file = /var/run/ceph/$cluster-$name.pid
         auth supported = cephx
 
 	filestore xattr use omap = true
@@ -67,8 +67,8 @@
         rgw cache enabled = true
 	rgw enable ops log = true
 	rgw enable usage log = true
-	log file = /var/log/ceph/ceph-$name.$pid.log
-	admin socket = /var/run/ceph/ceph-$name.$pid.asok
+	log file = /var/log/ceph/$cluster-$name.$pid.log
+	admin socket = /var/run/ceph/$cluster-$name.$pid.asok
 
 
 	client mount timeout = 600

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -460,9 +460,10 @@ def num_instances_of_type(cluster, type_):
     return num
 
 
-def create_simple_monmap(ctx, remote, conf):
+def create_simple_monmap(ctx, remote, conf, path=None):
     """
-    Writes a simple monmap based on current ceph.conf into <tmpdir>/monmap.
+    Writes a simple monmap based on current ceph.conf into path, or
+    <testdir>/monmap by default.
 
     Assumes ceph_conf is up to date.
 
@@ -499,9 +500,11 @@ def create_simple_monmap(ctx, remote, conf):
     ]
     for (name, addr) in addresses:
         args.extend(('--add', name, addr))
+    if not path:
+        path = '{tdir}/monmap'.format(tdir=testdir)
     args.extend([
         '--print',
-        '{tdir}/monmap'.format(tdir=testdir),
+        path
     ])
 
     r = remote.run(

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -442,8 +442,8 @@ def num_instances_of_type(cluster, type_):
     """
     remotes_and_roles = cluster.remotes.items()
     roles = [roles for (remote, roles) in remotes_and_roles]
-    prefix = '{type}.'.format(type=type_)
-    num = sum(sum(1 for role in hostroles if role.startswith(prefix))
+    is_ceph_type = is_type(type_)
+    num = sum(sum(1 for role in hostroles if is_ceph_type(role))
               for hostroles in roles)
     return num
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -319,7 +319,7 @@ def generate_caps(type_):
         yield capability
 
 
-def skeleton_config(ctx, roles, ips):
+def skeleton_config(ctx, roles, ips, cluster='ceph'):
     """
     Returns a ConfigObj that is prefilled with a skeleton config.
 
@@ -333,6 +333,9 @@ def skeleton_config(ctx, roles, ips):
     conf = configobj.ConfigObj(StringIO(skconf), file_error=True)
     mons = get_mons(roles=roles, ips=ips)
     for role, addr in mons.iteritems():
+        mon_cluster, _, _ = split_role(role)
+        if mon_cluster != cluster:
+            continue
         name = ceph_role(role)
         conf.setdefault(name, {})
         conf[name]['mon addr'] = addr

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -346,6 +346,26 @@ def skeleton_config(ctx, roles, ips):
     return conf
 
 
+def ceph_role(role):
+    """
+    Return the ceph name for the role, without any cluster prefix, e.g. osd.0.
+    """
+    _, type_, id_ = split_role(role)
+    return type_ + '.' + id_
+
+
+def split_role(role):
+    """
+    Return a tuple of cluster, type, and id
+    If no cluster is included in the role, the default cluster, 'ceph', is used
+    """
+    cluster = 'ceph'
+    if role.count('.') > 1:
+        cluster, role = role.split('.', 1)
+    type_, id_ = role.split('.', 1)
+    return cluster, type_, id_
+
+
 def roles_of_type(roles_for_host, type_):
     """
     Generator of roles.

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -404,12 +404,8 @@ def all_roles_of_type(cluster, type_):
     :param cluster: Cluster extracted from the ctx.
     :type_: role type
     """
-    prefix = '{type}.'.format(type=type_)
     for _, roles_for_host in cluster.remotes.iteritems():
-        for name in roles_for_host:
-            if not name.startswith(prefix):
-                continue
-            id_ = name[len(prefix):]
+        for id_ in roles_of_type(roles_for_host, type_):
             yield id_
 
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -377,11 +377,11 @@ def roles_of_type(roles_for_host, type_):
     :param roles_for host: list of roles possible
     :param type_: type of role
     """
-    prefix = '{type}.'.format(type=type_)
+    is_of_type = is_type(type_)
     for name in roles_for_host:
-        if not name.startswith(prefix):
+        if not is_of_type(name):
             continue
-        id_ = name[len(prefix):]
+        _, _, id_ = split_role(name)
         yield id_
 
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1024,26 +1024,24 @@ def get_user():
     return getpass.getuser() + '@' + socket.gethostname()
 
 
-def get_mon_names(ctx):
+def get_mon_names(ctx, cluster='ceph'):
     """
     :returns: a list of monitor names
     """
-    mons = []
-    for remote, roles in ctx.cluster.remotes.items():
-        for role in roles:
-            if not role.startswith('mon.'):
-                continue
-            mons.append(role)
-    return mons
+    is_mon = is_type('mon', cluster)
+    host_mons = [[role for role in roles if is_mon(role)]
+                 for roles in ctx.cluster.remotes.values()]
+    return [mon for mons in host_mons for mon in mons]
 
 
-def get_first_mon(ctx, config):
+def get_first_mon(ctx, config, cluster='ceph'):
     """
-    return the "first" mon (alphanumerically, for lack of anything better)
+    return the "first" mon role (alphanumerically, for lack of anything better)
     """
-    firstmon = sorted(get_mon_names(ctx))[0]
-    assert firstmon
-    return firstmon
+    mons = get_mon_names(ctx, cluster)
+    if mons:
+        return sorted(mons)[0]
+    assert False, 'no mon for cluster found'
 
 
 def replace_all_with_clients(cluster, config):

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -445,16 +445,17 @@ def is_type(type_, cluster=None):
     return _is_type
 
 
-def num_instances_of_type(cluster, type_):
+def num_instances_of_type(cluster, type_, ceph_cluster='ceph'):
     """
     Total the number of instances of the role type specified in all remotes.
 
     :param cluster: Cluster extracted from ctx.
     :param type_: role
+    :param ceph_cluster: filter for ceph cluster name
     """
     remotes_and_roles = cluster.remotes.items()
     roles = [roles for (remote, roles) in remotes_and_roles]
-    is_ceph_type = is_type(type_)
+    is_ceph_type = is_type(type_, ceph_cluster)
     num = sum(sum(1 for role in hostroles if is_ceph_type(role))
               for hostroles in roles)
     return num

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -409,12 +409,12 @@ def all_roles_of_type(cluster, type_):
             yield id_
 
 
-def is_type(type_):
+def is_type(type_, cluster=None):
     """
     Returns a matcher function for whether role is of type given.
-    """
-    prefix = '{type}.'.format(type=type_)
 
+    :param cluster: cluster name to check in matcher (default to no check for cluster)
+    """
     def _is_type(role):
         """
         Return type based on the starting role name.
@@ -422,10 +422,10 @@ def is_type(type_):
         If there is more than one period, strip the first part
         (ostensibly a cluster name) and check the remainder for the prefix.
         """
-        if role.startswith(prefix):
-            return True
-        return (role.count('.') > 1 and
-                role[role.find('.') + 1:].startswith(prefix))
+        role_cluster, role_type, _ = split_role(role)
+        if cluster is not None and role_cluster != cluster:
+            return False
+        return role_type == type_
     return _is_type
 
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -397,10 +397,15 @@ def is_type(type_):
 
     def _is_type(role):
         """
-        Return type based on the starting role name.  This should
-        probably be improved in the future.
+        Return type based on the starting role name.
+
+        If there is more than one period, strip the first part
+        (ostensibly a cluster name) and check the remainder for the prefix.
         """
-        return role.startswith(prefix)
+        if role.startswith(prefix):
+            return True
+        return (role.count('.') > 1 and
+                role[role.find('.') + 1:].startswith(prefix))
     return _is_type
 
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -333,16 +333,19 @@ def skeleton_config(ctx, roles, ips):
     conf = configobj.ConfigObj(StringIO(skconf), file_error=True)
     mons = get_mons(roles=roles, ips=ips)
     for role, addr in mons.iteritems():
-        conf.setdefault(role, {})
-        conf[role]['mon addr'] = addr
+        name = ceph_role(role)
+        conf.setdefault(name, {})
+        conf[name]['mon addr'] = addr
     # set up standby mds's
+    is_mds = is_type('mds', cluster)
     for roles_subset in roles:
         for role in roles_subset:
-            if role.startswith('mds.'):
-                conf.setdefault(role, {})
-                if role.find('-s-') != -1:
-                    standby_mds = role[role.find('-s-') + 3:]
-                    conf[role]['mds standby for name'] = standby_mds
+            if is_mds(role):
+                name = ceph_role(role)
+                conf.setdefault(name, {})
+                if '-s-' in name:
+                    standby_mds = name[name.find('-s-') + 3:]
+                    conf[name]['mds standby for name'] = standby_mds
     return conf
 
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -272,9 +272,10 @@ def get_mons(roles, ips):
     mons = {}
     mon_ports = {}
     mon_id = 0
+    is_mon = is_type('mon')
     for idx, roles in enumerate(roles):
         for role in roles:
-            if not role.startswith('mon.'):
+            if not is_mon(role):
                 continue
             if ips[idx] not in mon_ports:
                 mon_ports[ips[idx]] = 6789

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -371,18 +371,31 @@ def split_role(role):
 
 def roles_of_type(roles_for_host, type_):
     """
-    Generator of roles.
+    Generator of ids.
 
     Each call returns the next possible role of the type specified.
     :param roles_for host: list of roles possible
     :param type_: type of role
     """
-    is_of_type = is_type(type_)
-    for name in roles_for_host:
-        if not is_of_type(name):
-            continue
-        _, _, id_ = split_role(name)
+    for role in cluster_roles_of_type(roles_for_host, type_, None):
+        _, _, id_ = split_role(role)
         yield id_
+
+
+def cluster_roles_of_type(roles_for_host, type_, cluster):
+    """
+    Generator of roles.
+
+    Each call returns the next possible role of the type specified.
+    :param roles_for host: list of roles possible
+    :param type_: type of role
+    :param cluster: cluster name
+    """
+    is_type_in_cluster = is_type(type_, cluster)
+    for role in roles_for_host:
+        if not is_type_in_cluster(role):
+            continue
+        yield role
 
 
 def all_roles(cluster):

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1015,9 +1015,8 @@ def get_clients(ctx, roles):
     """
     for role in roles:
         assert isinstance(role, basestring)
-        PREFIX = 'client.'
-        assert role.startswith(PREFIX)
-        id_ = role[len(PREFIX):]
+        assert 'client.' in role
+        _, _, id_ = split_role(role)
         (remote,) = ctx.cluster.only(role).remotes.iterkeys()
         yield (id_, remote)
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -937,9 +937,9 @@ def wait_until_healthy(ctx, remote):
             time.sleep(1)
 
 
-def wait_until_osds_up(ctx, cluster, remote):
+def wait_until_osds_up(ctx, cluster, remote, ceph_cluster='ceph'):
     """Wait until all Ceph OSDs are booted."""
-    num_osds = num_instances_of_type(cluster, 'osd')
+    num_osds = num_instances_of_type(cluster, 'osd', ceph_cluster)
     testdir = get_testdir(ctx)
     while True:
         r = remote.run(
@@ -948,6 +948,7 @@ def wait_until_osds_up(ctx, cluster, remote):
                 'ceph-coverage',
                 '{tdir}/archive/coverage'.format(tdir=testdir),
                 'ceph',
+                '--cluster', ceph_cluster,
                 'osd', 'dump', '--format=json'
             ],
             stdout=StringIO(),

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -912,7 +912,7 @@ def get_scratch_devices(remote):
     return retval
 
 
-def wait_until_healthy(ctx, remote):
+def wait_until_healthy(ctx, remote, ceph_cluster='ceph'):
     """
     Wait until a Ceph cluster is healthy. Give up after 15min.
     """
@@ -925,6 +925,7 @@ def wait_until_healthy(ctx, remote):
                     'ceph-coverage',
                     '{tdir}/archive/coverage'.format(tdir=testdir),
                     'ceph',
+                    '--cluster', ceph_cluster,
                     'health',
                 ],
                 stdout=StringIO(),

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1173,13 +1173,13 @@ def ssh_keyscan_wait(hostname):
             log.info("try ssh_keyscan again for " + str(hostname))
         return success
 
-def stop_daemons_of_type(ctx, type_):
+def stop_daemons_of_type(ctx, type_, cluster='ceph'):
     """
     :param type_: type of daemons to be stopped.
     """
     log.info('Shutting down %s daemons...' % type_)
     exc_info = (None, None, None)
-    for daemon in ctx.daemons.iter_daemons_of_role(type_):
+    for daemon in ctx.daemons.iter_daemons_of_role(type_, cluster):
         try:
             daemon.stop()
         except (CommandFailedError,

--- a/teuthology/orchestra/daemon.py
+++ b/teuthology/orchestra/daemon.py
@@ -146,17 +146,21 @@ class DaemonGroup(object):
         """
         self.daemons = {}
 
-    def add_daemon(self, remote, role, id_, *args, **kwargs):
+    def add_daemon(self, remote, type_, id_, *args, **kwargs):
         """
         Add a daemon.  If there already is a daemon for this id_ and role, stop
         that daemon and.  Restart the damon once the new value is set.
 
         :param remote: Remote site
-        :param role: Role (osd, mds, mon, rgw,  for example)
+        :param type_: type of daemon (osd, mds, mon, rgw,  for example)
         :param id_: Id (index into role dictionary)
         :param args: Daemonstate positional parameters
         :param kwargs: Daemonstate keyword parameters
         """
+        # for backwards compatibility with older ceph-qa-suite branches,
+        # we can only get optional args from unused kwargs entries
+        cluster = kwargs.pop('cluster', 'ceph')
+        role = cluster + '.' + type_
         if role not in self.daemons:
             self.daemons[role] = {}
         if id_ in self.daemons[role]:
@@ -166,24 +170,26 @@ class DaemonGroup(object):
                                               **kwargs)
         self.daemons[role][id_].restart()
 
-    def get_daemon(self, role, id_):
+    def get_daemon(self, type_, id_, cluster='ceph'):
         """
         get the daemon associated with this id_ for this role.
 
-        :param role: Role (osd, mds, mon, rgw,  for example)
+        :param type_: type of daemon (osd, mds, mon, rgw,  for example)
         :param id_: Id (index into role dictionary)
         """
+        role = cluster + '.' + type_
         if role not in self.daemons:
             return None
         return self.daemons[role].get(str(id_), None)
 
-    def iter_daemons_of_role(self, role):
+    def iter_daemons_of_role(self, type_, cluster='ceph'):
         """
         Iterate through all daemon instances for this role.  Return dictionary
         of daemon values.
 
-        :param role: Role (osd, mds, mon, rgw,  for example)
+        :param type_: type of daemon (osd, mds, mon, rgw,  for example)
         """
+        role = cluster + '.' + type_
         return self.daemons.get(role, {}).values()
 
     def resolve_role_list(self, roles, types):

--- a/teuthology/task/common_fs_utils.py
+++ b/teuthology/task/common_fs_utils.py
@@ -74,15 +74,6 @@ def generic_mount(ctx, config, devname_rtn):
     else:
         role_images = [(role, None) for role in config]
 
-    def strip_client_prefix(role):
-        """
-        Extract the number from the name of a client role
-        """
-        prefix = 'client.'
-        assert role.startswith(prefix)
-        id_ = role[len(prefix):]
-        return id_
-
     testdir = teuthology.get_testdir(ctx)
 
     mnt_template = '{tdir}/mnt.{id}'
@@ -91,7 +82,7 @@ def generic_mount(ctx, config, devname_rtn):
         if image is None:
             image = default_image_name(role)
         (remote,) = ctx.cluster.only(role).remotes.keys()
-        id_ = strip_client_prefix(role)
+        _, _, id_ = teuthology.split_role(role)
         mnt = mnt_template.format(tdir=testdir, id=id_)
         mounted.append((remote, mnt))
         remote.run(

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -146,8 +146,8 @@ def test_cluster_roles_of_type():
         (['foo.client.1', 'bar.client.2.3', 'baz.osd.1'], 'client', 'bar',
          ['bar.client.2.3']),
         ]
-    for roles_for_host, type_, cluster, expected_roles in expected:
-        roles = list(misc.cluster_roles_of_type(roles_for_host, type_, cluster))
+    for roles_for_host, type_, cluster_, expected_roles in expected:
+        roles = list(misc.cluster_roles_of_type(roles_for_host, type_, cluster_))
         assert roles == expected_roles
 
 
@@ -162,9 +162,9 @@ def test_all_roles_of_type():
          'client', ['1', '2.3', 'bar']),
         ]
     for host_roles, type_, expected_ids in expected:
-        cluster = Mock()
-        cluster.remotes = dict(enumerate(host_roles))
-        ids = list(misc.all_roles_of_type(cluster, type_))
+        cluster_ = Mock()
+        cluster_.remotes = dict(enumerate(host_roles))
+        ids = list(misc.all_roles_of_type(cluster_, type_))
         assert ids == expected_ids
 
 

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -89,6 +89,19 @@ def test_get_clients_simple():
         next(g)
 
 
+def test_roles_of_type():
+    expected = [
+        (['client.0', 'osd.0', 'ceph.osd.1'], 'osd', ['0', '1']),
+        (['client.0', 'osd.0', 'ceph.osd.1'], 'client', ['0']),
+        (['foo.client.1', 'bar.client.2.3', 'baz.osd.1'], 'mon', []),
+        (['foo.client.1', 'bar.client.2.3', 'baz.osd.1'], 'client',
+         ['1', '2.3']),
+        ]
+    for roles_for_host, type_, expected_ids in expected:
+        ids = list(misc.roles_of_type(roles_for_host, type_))
+        assert ids == expected_ids
+
+
 def test_get_http_log_path():
     # Fake configuration
     archive_server = "http://example.com/server_root"

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -134,6 +134,23 @@ def test_roles_of_type():
         assert ids == expected_ids
 
 
+def test_cluster_roles_of_type():
+    expected = [
+        (['client.0', 'osd.0', 'ceph.osd.1'], 'osd', 'ceph',
+         ['osd.0', 'ceph.osd.1']),
+        (['client.0', 'osd.0', 'ceph.osd.1'], 'client', 'ceph',
+         ['client.0']),
+        (['foo.client.1', 'bar.client.2.3', 'baz.osd.1'], 'mon', None, []),
+        (['foo.client.1', 'bar.client.2.3', 'baz.osd.1'], 'client', None,
+         ['foo.client.1', 'bar.client.2.3']),
+        (['foo.client.1', 'bar.client.2.3', 'baz.osd.1'], 'client', 'bar',
+         ['bar.client.2.3']),
+        ]
+    for roles_for_host, type_, cluster, expected_roles in expected:
+        roles = list(misc.cluster_roles_of_type(roles_for_host, type_, cluster))
+        assert roles == expected_roles
+
+
 def test_all_roles_of_type():
     expected = [
         ([['client.0', 'osd.0', 'ceph.osd.1'], ['bar.osd.2']],

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -128,6 +128,27 @@ def test_is_type():
     assert not is_client('hadoop.master.0')
 
 
+def test_get_mons():
+    ips = ['1.1.1.1', '2.2.2.2', '3.3.3.3']
+    addrs = ['1.1.1.1:6789', '1.1.1.1:6790', '1.1.1.1:6791']
+
+    mons = misc.get_mons([['mon.a']], ips)
+    assert mons == {'mon.a': addrs[0]}
+
+    mons = misc.get_mons([['cluster-a.mon.foo', 'client.b'], ['osd.0']], ips)
+    assert mons == {'cluster-a.mon.foo': addrs[0]}
+
+    mons = misc.get_mons([['mon.a', 'mon.b', 'ceph.mon.c']], ips)
+    assert mons == {'mon.a': addrs[0],
+                    'mon.b': addrs[1],
+                    'ceph.mon.c': addrs[2]}
+
+    mons = misc.get_mons([['mon.a'], ['mon.b'], ['ceph.mon.c']], ips)
+    assert mons == {'mon.a': addrs[0],
+                    'mon.b': ips[1] + ':6789',
+                    'ceph.mon.c': ips[2] + ':6789'}
+
+
 class TestHostnames(object):
     def setup(self):
         config._conf = dict()

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -183,11 +183,24 @@ def test_is_type():
     assert is_client('foo.client.0')
     assert is_client('foo.client.bar.baz')
 
-    assert not is_client('')
+    with pytest.raises(ValueError):
+        is_client('')
+        is_client('client')
     assert not is_client('foo.bar.baz')
     assert not is_client('ceph.client')
-    assert not is_client('client')
     assert not is_client('hadoop.master.0')
+
+
+def test_is_type_in_cluster():
+    is_c1_osd = misc.is_type('osd', 'c1')
+    with pytest.raises(ValueError):
+        is_c1_osd('')
+    assert not is_c1_osd('osd.0')
+    assert not is_c1_osd('ceph.osd.0')
+    assert not is_c1_osd('ceph.osd.0')
+    assert not is_c1_osd('c11.osd.0')
+    assert is_c1_osd('c1.osd.0')
+    assert is_c1_osd('c1.osd.999')
 
 
 def test_get_mons():

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -149,6 +149,18 @@ def test_get_mons():
                     'ceph.mon.c': ips[2] + ':6789'}
 
 
+def test_split_role():
+    expected = {
+        'client.0': ('ceph', 'client', '0'),
+        'foo.client.0': ('foo', 'client', '0'),
+        'bar.baz.x.y.z': ('bar', 'baz', 'x.y.z'),
+        'mds.a-s-b': ('ceph', 'mds', 'a-s-b'),
+    }
+
+    for role, expected_split in expected.items():
+        actual_split = misc.split_role(role)
+        assert actual_split == expected_split
+
 class TestHostnames(object):
     def setup(self):
         config._conf = dict()

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -1,7 +1,7 @@
 import argparse
 from datetime import datetime
 
-from mock import patch
+from mock import Mock, patch
 from ..orchestra import cluster
 from .. import misc
 from ..config import config
@@ -99,6 +99,23 @@ def test_roles_of_type():
         ]
     for roles_for_host, type_, expected_ids in expected:
         ids = list(misc.roles_of_type(roles_for_host, type_))
+        assert ids == expected_ids
+
+
+def test_all_roles_of_type():
+    expected = [
+        ([['client.0', 'osd.0', 'ceph.osd.1'], ['bar.osd.2']],
+         'osd', ['0', '1', '2']),
+        ([['client.0', 'osd.0', 'ceph.osd.1'], ['bar.osd.2', 'baz.client.1']],
+         'client', ['0', '1']),
+        ([['foo.client.1', 'bar.client.2.3'], ['baz.osd.1']], 'mon', []),
+        ([['foo.client.1', 'bar.client.2.3'], ['baz.osd.1', 'ceph.client.bar']],
+         'client', ['1', '2.3', 'bar']),
+        ]
+    for host_roles, type_, expected_ids in expected:
+        cluster = Mock()
+        cluster.remotes = dict(enumerate(host_roles))
+        ids = list(misc.all_roles_of_type(cluster, type_))
         assert ids == expected_ids
 
 

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -89,6 +89,38 @@ def test_get_clients_simple():
         next(g)
 
 
+def test_get_mon_names():
+    expected = [
+        ([['mon.a', 'osd.0', 'mon.c']], 'ceph', ['mon.a', 'mon.c']),
+        ([['ceph.mon.a', 'osd.0', 'ceph.mon.c']], 'ceph', ['ceph.mon.a', 'ceph.mon.c']),
+        ([['mon.a', 'osd.0', 'mon.c'], ['ceph.mon.b']], 'ceph', ['mon.a', 'mon.c', 'ceph.mon.b']),
+        ([['mon.a', 'osd.0', 'mon.c'], ['foo.mon.a']], 'ceph', ['mon.a', 'mon.c']),
+        ([['mon.a', 'osd.0', 'mon.c'], ['foo.mon.a']], 'foo', ['foo.mon.a']),
+    ]
+    for remote_roles, cluster_name, expected_mons in expected:
+        ctx = argparse.Namespace()
+        ctx.cluster = Mock()
+        ctx.cluster.remotes = {i: roles for i, roles in enumerate(remote_roles)}
+        mons = misc.get_mon_names(ctx, cluster_name)
+        assert expected_mons == mons
+
+
+def test_get_first_mon():
+    expected = [
+        ([['mon.a', 'osd.0', 'mon.c']], 'ceph', 'mon.a'),
+        ([['ceph.mon.a', 'osd.0', 'ceph.mon.c']], 'ceph', 'ceph.mon.a'),
+        ([['mon.a', 'osd.0', 'mon.c'], ['ceph.mon.b']], 'ceph', 'ceph.mon.b'),
+        ([['mon.a', 'osd.0', 'mon.c'], ['foo.mon.a']], 'ceph', 'mon.a'),
+        ([['foo.mon.b', 'osd.0', 'mon.c'], ['foo.mon.a']], 'foo', 'foo.mon.a'),
+    ]
+    for remote_roles, cluster_name, expected_mon in expected:
+        ctx = argparse.Namespace()
+        ctx.cluster = Mock()
+        ctx.cluster.remotes = {i: roles for i, roles in enumerate(remote_roles)}
+        mon = misc.get_first_mon(ctx, None, cluster_name)
+        assert expected_mon == mon
+
+
 def test_roles_of_type():
     expected = [
         (['client.0', 'osd.0', 'ceph.osd.1'], 'osd', ['0', '1']),

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -114,6 +114,20 @@ def test_get_http_log_path():
     assert path == "http://qa-proxy.ceph.com/teuthology/teuthology-2013-09-12_11:49:50-ceph-deploy-master-testing-basic-vps/"
 
 
+def test_is_type():
+    is_client = misc.is_type('client')
+    assert is_client('client.0')
+    assert is_client('ceph.client.0')
+    assert is_client('foo.client.0')
+    assert is_client('foo.client.bar.baz')
+
+    assert not is_client('')
+    assert not is_client('foo.bar.baz')
+    assert not is_client('ceph.client')
+    assert not is_client('client')
+    assert not is_client('hadoop.master.0')
+
+
 class TestHostnames(object):
     def setup(self):
         config._conf = dict()


### PR DESCRIPTION
Tested against master, hammer and infernalis ceph-qa-suites, running a couple kinds of upgrade tests, plus subsets of the fs, rados, rbd, and rgw suites. The impetus for this is being able to test rbd mirroring, which uses multiple ceph clusters. There's a companion PR for ceph-qa-suite: https://github.com/ceph/ceph-qa-suite/pull/937

The general idea is that roles can have a prefix of the ceph cluster name. Since roles are only interpreted by some tasks (mainly the ceph task), this localizes the required changes somewhat, and makes it simple to stay compatible with existing single-cluster suites.