### PR TITLE
Reimplementing get_scratch_devices()

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -985,6 +985,24 @@ def translate_block_UUID(remote, devices):
     return devs
 
 
+def partitions_to_block_device(devices):
+    """
+    From a list of used partitions, let's compute the list of used block devices
+    """
+    devs = []
+    for device_name in devices:
+        # /dev/dm-0 should not be touched
+        if "-" not in device_name:
+            # Extracting device name "/dev/sda1" -> "/dev/sda"
+            matching_device = re.match('(/dev/[a-z]+)(\d?)', device_name, re.M | re.I)
+            if matching_device:
+                device_name = matching_device.group(1)
+
+        if device_name not in devs:
+            devs.append(device_name)
+    return devs
+
+
 def get_scratch_devices(remote):
     """
     Read the scratch disk list from remote host

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -873,6 +873,14 @@ def get_block_devices(remote):
     return devs
 
 
+def get_free_block_devices(available_block_devices, used_block_devices):
+    """
+    Compute the list of free block devices by comparing the list
+    of block devices we have and the one we consider as used
+    """
+    return list(set(available_block_devices) - set(used_block_devices))
+
+
 def get_used_block_devices(remote):
     """
     From the actual mount points, let's found out

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -857,7 +857,7 @@ def get_block_devices(remote):
                 for num in itertools.chain(range(15, 18), range(20, 30), range(113, 117), range(240, 250), range(255, 260)):
                     exclude_list.append(num)
                 if int(major) not in exclude_list:
-                    # Don't consider extended partitions which size = 1
+                    # Only consider partitions that have a valid size
                     if int(matching_line.group(3)) > 1:
                         device_name = matching_line.group(4)
                         # If we get a "dm-0", the device name should stay untouched
@@ -866,8 +866,9 @@ def get_block_devices(remote):
                             matching_device = re.match('([a-z]+)(\d?)', device_name, re.M | re.I)
                             if matching_device:
                                 device_name = matching_device.group(1)
-                        if device_name not in devs:
-                            devs.append(matching_line.group(4))
+                        full_device_name = "/dev/%s" % device_name
+                        if full_device_name not in devs:
+                            devs.append(full_device_name)
 
     return devs
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -863,6 +863,22 @@ def get_used_block_devices(remote):
     return devs
 
 
+def get_root_device(remote):
+    """
+    Extracting root device
+    """
+    r = remote.run(args=['cat', run.Raw('/proc/cmdline')],
+                   stdout=StringIO()
+                   )
+
+    cmdline = r.stdout.getvalue().strip()
+    matching_line = re.match('.*root=(\S+)\s+.*', cmdline, re.M | re.I)
+    if matching_line:
+        return matching_line.group(1)
+
+    return ""
+
+
 def translate_block_device_path(remote, device):
     """
     Extract the cannonized path of block devices

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -934,6 +934,29 @@ def expand_dm_devices(remote, devices):
     return devs
 
 
+def translate_block_UUID(remote, devices):
+    """
+    Extract the cannonized path of block devices
+    """
+    devs = []
+    r = remote.run(args=['blkid', run.Raw('')],
+                   stdout=StringIO()
+                   )
+
+    for device in devices:
+        matching_line = re.match('UUID=(.*)', device, re.M | re.I)
+        if matching_line:
+            for line in r.stdout.getvalue().strip().split('\n'):
+                if matching_line.group(1) in line:
+                    if line.split(': ')[0] not in devs:
+                        devs.append(line.split(': ')[0])
+        else:
+            if device not in devs:
+                devs.append(device)
+
+    return devs
+
+
 def get_scratch_devices(remote):
     """
     Read the scratch disk list from remote host

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1011,6 +1011,32 @@ def partitions_to_block_device(devices):
     return devs
 
 
+def is_block_device_valid(remote, device):
+    """
+    Check if a block device is reachable
+    """
+    try:
+        remote.run(args=[  # readable
+                           'sudo', 'dd', 'if=%s' % device, 'of=/dev/null', 'bs=1M', 'count=1', 'iflag=direct']
+                   )
+        return True
+    except:
+        log.warn("is_block_device_valid: %s is not reachable" % device)
+        return False
+
+
+def remove_invalid_block_devices(remote, devices):
+    """
+    Remove the invalid block devices from a list of devices
+    """
+    devs = []
+    for device in devices:
+        if is_block_device_valid(remote, device) is True:
+            if device not in devs:
+                devs.append(device)
+    return devs
+
+
 def get_scratch_devices(remote):
     """
     Read the scratch disk list from remote host

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -143,6 +143,13 @@ def test_translate_block_UUID():
         assert misc.translate_block_UUID(remote, PASS[1]) == PASS[2]
 
 
+def test_get_free_block_devices():
+    PASS_1 = BLOCK_DEVICES, TRANSLATED_USED_DEVICES, FREE_BLOCK_DEVICES
+    PASS_2 = MIRA_BLOCK_DEVICES, TRANSLATED_USED_DEVICES_MIRA, FREE_BLOCK_DEVICES_MIRA
+    for PASS in PASS_1, PASS_2:
+        assert sorted(misc.get_free_block_devices(PASS[0], misc.partitions_to_block_device(PASS[1]))) == sorted(PASS[2])
+
+
 def test_partitions_to_block_device():
     full_path = ["/dev/sda", "/dev/sdb1", "/dev/sdb", "/dev/dm-0"]
     expected_devices = ["/dev/sda", "/dev/sdb", "/dev/dm-0"]
@@ -513,3 +520,7 @@ BLKID_MIRA = '''
 '''
 
 NO_UUID_ROOT_DEVICE_MIRA = ['/dev/sda1', '/dev/sdk1']
+
+FREE_BLOCK_DEVICES = []
+FREE_BLOCK_DEVICES_MIRA = ['/dev/sdb', '/dev/sdc', '/dev/sdd', '/dev/sde',
+                           '/dev/sdf', '/dev/sdg', '/dev/sdh']

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -115,6 +115,19 @@ def test_expand_dm_devices():
     assert misc.expand_dm_devices(remote, TRANSLATED_USED_DEVICES) == EXPANDED_USED_DEVICES
 
 
+def test_get_root_device():
+    remote = FakeRemote()
+
+    class r():
+        class o:
+            def getvalue(self):
+                return PROC_CMDLINE
+        stdout = o()
+
+    remote.run = lambda **kwargs: r()
+    assert misc.get_root_device(remote) == ROOT_DEVICE_UUID
+
+
 def test_wait_until_osds_up():
     ctx = argparse.Namespace()
     remote = FakeRemote()
@@ -375,3 +388,9 @@ luks-daddc2c4-2345-2345-acb1-b15770b79fff <dm-1> (253:1)
 '''
 
 EXPANDED_USED_DEVICES = ['/dev/sda5', '/dev/sda1', '/dev/sda2']
+
+PROC_CMDLINE = '''
+BOOT_IMAGE=/vmlinuz-4.4.6-300.fc23.x86_64 root=UUID=4945724f-27de-48e3-937f-c767f92e86a6 ro rootflags=subvol=root rd.luks.uuid=luks-daddc2c4-1463-4d46-abc7-b15770b79f94 rhgb quiet LANG=fr_FR.UTF-8 "acpi_osi=!Windows 2013" nouveau.runpm=0 intel_iommu=on
+'''
+
+ROOT_DEVICE_UUID = '''UUID=4945724f-27de-48e3-937f-c767f92e86a6'''

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -54,9 +54,9 @@ def test_get_block_devices():
     remote = FakeRemote()
     PASS_1 = PROC_PARTITIONS, BLOCK_DEVICES
     PASS_2 = MIRA_PROC_PARTITIONS, MIRA_BLOCK_DEVICES
-    PASSES = PASS_1, PASS_2
+    PASS_3 = BIG_PROC_PARTITIONS, BIG_BLOCK_DEVICES
 
-    for current_pass in PASSES:
+    for current_pass in PASS_1, PASS_2, PASS_3:
         class r():
             class o:
                 def getvalue(self):
@@ -335,6 +335,67 @@ major minor  #blocks  name
  253        0  168546304 dm-0
 '''
 BLOCK_DEVICES = ['sda', 'dm-0']
+
+BIG_PROC_PARTITIONS = '''
+major minor  #blocks  name
+
+   8     0   17774160 sda
+   8     1    1052226 sda1
+   8     2     208845 sda2
+   8     3   10490445 sda3
+   8    16     976576 sdb
+   8    32     976576 sdc
+   8    48     976576 sdd
+   8    64     976576 sde
+   8    80     976576 sdf
+   8    96     976576 sdg
+   8   112     976576 sdh
+   8   128     976576 sdi
+   8   144     976576 sdj
+   8   160     976576 sdk
+   8   176     976576 sdl
+   8   192     976576 sdm
+   8   208     976576 sdn
+   8   224     976576 sdo
+   8   240     976576 sdp
+  65     0     976576 sdq
+  65    16    1048576 sdr
+  65    32    1048576 sds
+  65    48    1048576 sdt
+  65    64    1048576 sdu
+  65    80    1048576 sdv
+  65    96    1048576 sdw
+  65   112    1048576 sdx
+  65   128    1048576 sdy
+  65   144    1048576 sdz
+  65   160    1048576 sdaa
+  65   176    1048576 sdab
+  65   192    1048576 sdac
+  65   208    1048576 sdad
+  65   224    1048576 sdae
+  65   240    1048576 sdaf
+  66     0    1048576 sdag
+  66    16    1048576 sdah
+  66    32    1048576 sdai
+  66    48    1048576 sdaj
+  66    64    1048576 sdak
+  66    80    1048576 sdal
+  66    96    1048576 sdam
+  66   112    1048576 sdan
+  66   128    1048576 sdao
+  66   144    1048576 sdap
+  66   160    1048576 sdaq
+  66   176    1048576 sdar
+  66   192    1048576 sdas
+  66   208    1048576 sdat
+  66   224    1048576 sdau
+  66   240    1048576 sdav
+'''
+
+BIG_BLOCK_DEVICES = ['sda','sdb','sdc','sdd','sde','sdf','sdg','sdh','sdi','sdj','sdk','sdl','sdm','sdn','sdo','sdp',
+'sdq','sdr','sds','sdt','sdu','sdv','sdw','sdx','sdy','sdz', 'sdaa','sdab','sdac','sdad','sdae','sdaf','sdag','sdah',
+'sdai','sdaj','sdak','sdal','sdam','sdan','sdao','sdap','sdaq','sdar','sdas','sdat','sdau','sdav']
+
 
 MIRA_PROC_PARTITIONS = '''
 major minor  #blocks  name

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -334,7 +334,7 @@ major minor  #blocks  name
   11        0    1048575 sr0
  253        0  168546304 dm-0
 '''
-BLOCK_DEVICES = ['sda', 'sda1', 'sda2', 'sda3', 'sda5', 'dm-0']
+BLOCK_DEVICES = ['sda', 'dm-0']
 
 MIRA_PROC_PARTITIONS = '''
 major minor  #blocks  name
@@ -371,7 +371,7 @@ major minor  #blocks  name
    8        1  976760832 sda1
 '''
 
-MIRA_BLOCK_DEVICES = ['sdb', 'sdb1', 'sdb3', 'sdc', 'sdc1', 'sdd', 'sde', 'sde1', 'sde2', 'sdf', 'sdg', 'sdh', 'sda', 'sda1']
+MIRA_BLOCK_DEVICES = ['sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg', 'sdh', 'sda']
 
 PROC_MOUNTS = '''
 /dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94 / btrfs rw,seclabel,relatime,ssd,space_cache,subvolid=257,subvol=/root 0 0

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -143,6 +143,12 @@ def test_translate_block_UUID():
         assert misc.translate_block_UUID(remote, PASS[1]) == PASS[2]
 
 
+def test_partitions_to_block_device():
+    full_path = ["/dev/sda", "/dev/sdb1", "/dev/sdb", "/dev/dm-0"]
+    expected_devices = ["/dev/sda", "/dev/sdb", "/dev/dm-0"]
+    assert misc.partitions_to_block_device(full_path) == expected_devices
+
+
 def test_wait_until_osds_up():
     ctx = argparse.Namespace()
     remote = FakeRemote()

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -334,7 +334,7 @@ major minor  #blocks  name
   11        0    1048575 sr0
  253        0  168546304 dm-0
 '''
-BLOCK_DEVICES = ['sda', 'dm-0']
+BLOCK_DEVICES = ['/dev/sda', '/dev/dm-0']
 
 BIG_PROC_PARTITIONS = '''
 major minor  #blocks  name
@@ -392,9 +392,15 @@ major minor  #blocks  name
   66   240    1048576 sdav
 '''
 
-BIG_BLOCK_DEVICES = ['sda','sdb','sdc','sdd','sde','sdf','sdg','sdh','sdi','sdj','sdk','sdl','sdm','sdn','sdo','sdp',
-'sdq','sdr','sds','sdt','sdu','sdv','sdw','sdx','sdy','sdz', 'sdaa','sdab','sdac','sdad','sdae','sdaf','sdag','sdah',
-'sdai','sdaj','sdak','sdal','sdam','sdan','sdao','sdap','sdaq','sdar','sdas','sdat','sdau','sdav']
+BIG_BLOCK_DEVICES = ['/dev/sda', '/dev/sdb', '/dev/sdc', '/dev/sdd', '/dev/sde', '/dev/sdf',
+                     '/dev/sdg', '/dev/sdh', '/dev/sdi', '/dev/sdj', '/dev/sdk', '/dev/sdl',
+                     '/dev/sdm', '/dev/sdn', '/dev/sdo', '/dev/sdp', '/dev/sdq', '/dev/sdr',
+                     '/dev/sds', '/dev/sdt', '/dev/sdu', '/dev/sdv', '/dev/sdw', '/dev/sdx',
+                     '/dev/sdy', '/dev/sdz',
+                     '/dev/sdaa', '/dev/sdab', '/dev/sdac', '/dev/sdad', '/dev/sdae', '/dev/sdaf',
+                     '/dev/sdag', '/dev/sdah', '/dev/sdai', '/dev/sdaj', '/dev/sdak', '/dev/sdal',
+                     '/dev/sdam', '/dev/sdan', '/dev/sdao', '/dev/sdap', '/dev/sdaq', '/dev/sdar',
+                     '/dev/sdas', '/dev/sdat', '/dev/sdau', '/dev/sdav']
 
 
 MIRA_PROC_PARTITIONS = '''
@@ -432,7 +438,7 @@ major minor  #blocks  name
    8        1  976760832 sda1
 '''
 
-MIRA_BLOCK_DEVICES = ['sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg', 'sdh', 'sda']
+MIRA_BLOCK_DEVICES = ['/dev/sdb', '/dev/sdc', '/dev/sdd', '/dev/sde', '/dev/sdf', '/dev/sdg', '/dev/sdh', '/dev/sda']
 
 PROC_MOUNTS = '''
 /dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94 / btrfs rw,seclabel,relatime,ssd,space_cache,subvolid=257,subvol=/root 0 0

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -55,8 +55,9 @@ def test_get_block_devices():
     PASS_1 = PROC_PARTITIONS, BLOCK_DEVICES
     PASS_2 = MIRA_PROC_PARTITIONS, MIRA_BLOCK_DEVICES
     PASS_3 = BIG_PROC_PARTITIONS, BIG_BLOCK_DEVICES
+    PASS_4 = NVME_PROC_PARTITIONS, NVME_BLOCK_DEVICES
 
-    for current_pass in PASS_1, PASS_2, PASS_3:
+    for current_pass in PASS_1, PASS_2, PASS_3, PASS_4:
         class r():
             class o:
                 def getvalue(self):
@@ -151,8 +152,8 @@ def test_get_free_block_devices():
 
 
 def test_partitions_to_block_device():
-    full_path = ["/dev/sda", "/dev/sdb1", "/dev/sdb", "/dev/dm-0"]
-    expected_devices = ["/dev/sda", "/dev/sdb", "/dev/dm-0"]
+    full_path = ["/dev/sda", "/dev/sdb1", "/dev/sdb", "/dev/dm-0", "/dev/nvme0n1p1", "/dev/nvme0n1"]
+    expected_devices = ["/dev/sda", "/dev/sdb", "/dev/dm-0", "/dev/nvme0n1"]
     assert misc.partitions_to_block_device(full_path) == expected_devices
 
 
@@ -348,6 +349,19 @@ major minor  #blocks  name
  253        0  168546304 dm-0
 '''
 BLOCK_DEVICES = ['/dev/sda', '/dev/dm-0']
+
+NVME_PROC_PARTITIONS = '''
+major minor  #blocks  name
+
+ 259        0  390711384 nvme0n1
+ 259        1   97677312 nvme0n1p1
+ 259        2   97677312 nvme0n1p2
+ 259        3   97678336 nvme0n1p3
+ 259        4   97677312 nvme0n1p4
+   8        0  976762584 sda
+   8        1  976760832 sda1
+'''
+NVME_BLOCK_DEVICES = ['/dev/nvme0n1', '/dev/sda']
 
 BIG_PROC_PARTITIONS = '''
 major minor  #blocks  name

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -128,6 +128,21 @@ def test_get_root_device():
     assert misc.get_root_device(remote) == ROOT_DEVICE_UUID
 
 
+def test_translate_block_UUID():
+    remote = FakeRemote()
+    PASS_1 = BLKID, COMBINED_USED_DEVICES, NO_UUID_ROOT_DEVICE
+    PASS_2 = BLKID_MIRA, COMBINED_USED_DEVICES_MIRA, NO_UUID_ROOT_DEVICE_MIRA
+    for PASS in PASS_1, PASS_2, :
+        class r():
+            class o:
+                def getvalue(self):
+                    return PASS[0]
+            stdout = o()
+
+        remote.run = lambda **kwargs: r()
+        assert misc.translate_block_UUID(remote, PASS[1]) == PASS[2]
+
+
 def test_wait_until_osds_up():
     ctx = argparse.Namespace()
     remote = FakeRemote()
@@ -394,3 +409,32 @@ BOOT_IMAGE=/vmlinuz-4.4.6-300.fc23.x86_64 root=UUID=4945724f-27de-48e3-937f-c767
 '''
 
 ROOT_DEVICE_UUID = '''UUID=4945724f-27de-48e3-937f-c767f92e86a6'''
+COMBINED_USED_DEVICES = ['/dev/sda1', 'UUID=4945724f-27de-48e3-937f-c767f92e86a6']
+COMBINED_USED_DEVICES_MIRA = ['/dev/sda1', 'UUID=df552b84-1070-47da-aec3-946873ebdfba']
+
+BLKID = '''
+/dev/sda2: LABEL="buildgroup" UUID="c3d3ae17-1ece-432e-bb4b-f38bfa12e876" UUID_SUB="dd2b2031-6c8a-4f46-8f59-27153376e90d" TYPE="btrfs" PARTUUID="ee3a7940-02"
+/dev/sda3: UUID="51f0126d-0d7f-4708-b8b8-f122ac8dcf46" TYPE="swap" PARTUUID="ee3a7940-03"
+/dev/sda5: UUID="daddc2c4-1463-4d46-abc7-b15770b79f94" TYPE="crypto_LUKS" PARTUUID="ee3a7940-05"
+/dev/block/8:5: UUID="daddc2c4-1463-4d46-abc7-b15770b79f94" TYPE="crypto_LUKS" PARTUUID="ee3a7940-05"
+/dev/block/253:0: LABEL="fedora" UUID="4945724f-27de-48e3-937f-c767f92e86a6" UUID_SUB="ee1d1234-29bc-43b0-8e4f-7bfa2aa55981" TYPE="btrfs"
+/dev/block/8:1: UUID="71adc8ce-fc61-419d-82d5-0faec6d97f60" TYPE="ext4" PARTUUID="ee3a7940-01"
+/dev/dm-0: LABEL="fedora" UUID="4945724f-27de-48e3-937f-c767f92e86a6" UUID_SUB="ee1d1234-29bc-43b0-8e4f-7bfa2aa55981" TYPE="btrfs"
+/dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94: LABEL="fedora" UUID="4945724f-27de-48e3-937f-c767f92e86a6" UUID_SUB="ee1d1234-29bc-43b0-8e4f-7bfa2aa55981" TYPE="btrfs"
+/dev/sda1: UUID="71adc8ce-fc61-419d-82d5-0faec6d97f60" TYPE="ext4" PARTUUID="ee3a7940-01"
+'''
+
+NO_UUID_ROOT_DEVICE = ['/dev/sda1', '/dev/block/253:0', '/dev/dm-0', '/dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94']
+
+BLKID_MIRA = '''
+/dev/sdb1: UUID="37e3bde1-ef3a-4649-827e-acd8552ca803" TYPE="crypto_LUKS"
+/dev/sdb3: UUID="12164eb1-f0d2-4da0-b2cf-814300d4f420" TYPE="ext4"
+/dev/sdc1: UUID="e8e1fbb1-3230-43e0-be0c-1bfa88971666" TYPE="crypto_LUKS"
+/dev/sde1: UUID="2d61ce6d-edaf-4b29-839b-505b6c064474" TYPE="xfs"
+/dev/sdf: UUID="c222eb40-6083-47ec-aefb-09f1afb217c2" UUID_SUB="3da3ba22-df27-4691-bab0-79e7e26c605b" TYPE="btrfs"
+/dev/sdg: UUID="b98f1509-d729-476d-b901-d2acc760da26" UUID_SUB="c476c314-6abc-4d4b-94a4-de1a8cc007bd" TYPE="btrfs"
+/dev/sdh: UUID="57f503cf-05dd-429b-9957-3cd316db2bf0" UUID_SUB="50fe83f2-1e29-4107-82c1-319f2b935371" TYPE="btrfs"
+/dev/sdk1: UUID="df552b84-1070-47da-aec3-946873ebdfba" TYPE="ext4"
+'''
+
+NO_UUID_ROOT_DEVICE_MIRA = ['/dev/sda1', '/dev/sdk1']

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -88,7 +88,7 @@ def test_get_used_block_devices():
 
 def test_translate_block_device_path():
     remote = FakeRemote()
-    PASS_1 = USED_DEVICES, READLINK
+    PASS_1 = USED_DEVICES_WITH_BLOCK, READLINK
     PASS_2 = USED_DEVICES_MIRA, READLINK_MIRA
     for current_pass in PASS_1, PASS_2:
         for device in current_pass[0]:
@@ -384,13 +384,15 @@ PROC_MOUNTS_MIRA = '''
 '''
 
 USED_DEVICES = ['/dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94', '/dev/sda1', '/dev/sda2']
+USED_DEVICES_WITH_BLOCK = ['/dev/block/8:1', '/dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94', '/dev/sda1', '/dev/sda2']
 USED_DEVICES_MIRA = ['/dev/disk/by-uuid/df552b84-1070-47da-aec3-946873ebdfba']
 
-READLINK = {'/dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94': '/dev/dm-0',
+READLINK = {'/dev/block/8:1': '/dev/sda1',
+            '/dev/mapper/luks-daddc2c4-1463-4d46-abc7-b15770b79f94': '/dev/dm-0',
             '/dev/sda1': '/dev/sda1',
             '/dev/sda2': '/dev/sda2'}
 
-READLINK_MIRA = {'dev/disk/by-uuid/df552b84-1070-47da-aec3-946873ebdfba': '/dev/sda1'}
+READLINK_MIRA = {'/dev/disk/by-uuid/df552b84-1070-47da-aec3-946873ebdfba': '/dev/sda1'}
 
 TRANSLATED_USED_DEVICES = ['/dev/dm-0', '/dev/sda1', '/dev/sda2']
 TRANSLATED_USED_DEVICES_MIRA = ['/dev/sda1']


### PR DESCRIPTION
This PR is about re-implementing get_scratch_devices() while keeping the same input/outputs and adding news features
- listing all present block devices and not only sda or vda
- supporting more than 26 disks per host : sdaa vs sda
- auto-detecting the backing device of the root system by reading /proc/cdmline
- inspecting dm devices to detect more used devices
- expanding UUIDs & symlinks to understand the underlying block devices
- return no free block devices if known was detected as used to avoid damaging
  data
- return no free block devices if we cannot get intersections between the list
  of available devices and used devices to avoid damaging data
- compute the list of free devices by removing the detected used device from the
  complete list

As a result, a block reported to be free is a detected block devices which is
proven not being used by : the root fs, a dm device or a user mounted
filesystem.
