### PR TITLE
Fix ceph-deploy 'branch' override

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -73,9 +73,6 @@ dict_templ = {
             'sha1': Placeholder('ceph_hash'),
         },
         'ceph-deploy': {
-            'branch': {
-                'dev-commit': Placeholder('ceph_hash'),
-            },
             'conf': {
                 'client': {
                     'log file': '/var/log/ceph/ceph-$name.$pid.log'


### PR DESCRIPTION
Default ceph-deploy override template defines devcommit which makes
'branch' overrides in the qa-suite useless since it only picksup one option
Remove the devcommit overrides from the template and use that as
default in case no other 'branch' override exist.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>