### PR TITLE
task/selinux: another pcp whitelist

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -115,6 +115,7 @@ class SELinux(Task):
             'name="cephtest"',
             'scontext=system_u:system_r:nrpe_t:s0',
             'scontext=system_u:system_r:pcp_pmlogger_t',
+            'scontext=system_u:system_r:pcp_pmcd_t:s0',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
SELinux denials found on ubuntu@smithi027.front.sepia.ceph.com: ['type=AVC msg=audit(1462234212.274:85266): avc: denied { read } for pid=1984 comm="pmcd" name="pmlogger_daily.pid" dev="tmpfs" ino=1474542 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:cron_var_run_t:s0 tclass=file']

Signed-off-by: Sage Weil <sage@redhat.com>