### PR TITLE
packaging.py: make _get_distro() support openSUSE

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -599,6 +599,8 @@ class GitbuilderProject(object):
             distro = "centos"
         elif distro == "fedora":
             distro = "fc"
+        elif distro == "opensuse":
+            distro = "opensuse"
         else:
             # deb based systems use codename instead of a distro/version combo
             if not codename:


### PR DESCRIPTION
Add an explicit "elif" block for opensuse - without this, it falls through into
the else clause and dies because it cannot determine a codename.

Signed-off-by: Nathan Cutler <ncutler@suse.com>