### PR TITLE
task/ansible: disable color output

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -246,6 +246,7 @@ class Ansible(Task):
         environ['ANSIBLE_SSH_PIPELINING'] = '1'
         environ['ANSIBLE_FAILURE_LOG'] = self.failure_log.name
         environ['ANSIBLE_ROLES_PATH'] = "%s/roles" % self.repo_path
+        environ['ANSIBLE_NOCOLOR'] = "1"
         args = self._build_args()
         command = ' '.join(args)
         log.debug("Running %s", command)


### PR DESCRIPTION
This was messing up all logs with ANSI
codes.

Signed-off-by: John Spray <john.spray@redhat.com>