### PR TITLE
pcp: Use a smarter check for archive presence

### DIFF
--- a/teuthology/task/pcp.py
+++ b/teuthology/task/pcp.py
@@ -256,7 +256,7 @@ class PCP(Task):
             )
 
     def setup_graphite(self, hosts):
-        if not hasattr(self.ctx, 'archive'):
+        if not getattr(self.ctx, 'archive', None):
             self.use_graphite = False
         if self.use_graphite:
             out_dir = os.path.join(
@@ -275,7 +275,7 @@ class PCP(Task):
             )
 
     def setup_archive(self, hosts):
-        if not hasattr(self.ctx, 'archive'):
+        if not getattr(self.ctx, 'archive', None):
             self.fetch_archives = False
         if self.fetch_archives:
             self.archiver = PCPArchive(


### PR DESCRIPTION
If ctx.archive was set, but to None, we were failing.

Signed-off-by: Zack Cerza <zack@redhat.com>