### PR TITLE
modify parameter of user

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -59,6 +59,7 @@ Standard arguments:
 
 Scheduler arguments:
   --owner <owner>             Job owner
+  --user <user>               Job user
   -e <email>, --email <email>
                               When tests finish or time out, send an email
                               here. May also be specified in ~/.teuthology.yaml

--- a/teuthology/suite.py
+++ b/teuthology/suite.py
@@ -60,6 +60,7 @@ def main(args):
     priority = int(args['--priority'])
     num = int(args['--num'])
     owner = args['--owner']
+    user = args['--user']
     email = args['--email']
     if email:
         config.results_email = email
@@ -78,7 +79,7 @@ def main(args):
         log.info('Passed subset=%s/%s' % (str(subset[0]), str(subset[1])))
 
     name = make_run_name(suite, ceph_branch, kernel_branch, kernel_flavor,
-                         machine_type)
+                         machine_type, user)
 
     job_config = create_initial_config(suite, suite_branch, ceph_branch,
                                        ceph_sha1, teuthology_branch,


### PR DESCRIPTION
If two persons (or more) run the same teuthology-suite tasks in the same environment (having the same owner, like: scheduled_teuthology@scheduler),  we can't  distinguish which one suite for your runnig jobs in pulpito. So I commit the modify for parameter of user to see or understant which one tasks for your running in pulpito

Signed-off-by: Zhang.Zezhu zhang.zezhu@zte.com.cn
