### PR TITLE
modify initial of help in teuthology of explain function

### DIFF
--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -5,17 +5,17 @@ Analyze the coverage of a suite of test runs, generating html output with
 lcov.
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit
   -o LCOV_OUTPUT, --lcov-output LCOV_OUTPUT
-                        the directory in which to store results
+                        The directory in which to store results
   --html-output HTML_OUTPUT
-                        the directory in which to store html output
+                        The directory in which to store html output
   --cov-tools-dir COV_TOOLS_DIR
-                        the location of coverage scripts (cov-init and cov-
+                        The location of coverage scripts (cov-init and cov-
                         analyze) [default: ../../coverage]
-  --skip-init           skip initialization (useful if a run stopped partway
+  --skip-init           Skip initialization (useful if a run stopped partway
                         through)
-  -v, --verbose         be more verbose
+  -v, --verbose         Be more verbose
 """
 import docopt
 

--- a/scripts/describe_tests.py
+++ b/scripts/describe_tests.py
@@ -23,7 +23,7 @@ meta:
 Fields are user-defined, and are not required to be in all yaml files.
 
 positional arguments:
-  <suite_dir>                        path of qa suite
+  <suite_dir>                        Path of qa suite
 
 optional arguments:
   -h, --help                         Show this help message and exit

--- a/scripts/kill.py
+++ b/scripts/kill.py
@@ -20,7 +20,7 @@ NOTE: Must be run on the same machine that is executing the teuthology job
 processes.
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit
   -a ARCHIVE, --archive ARCHIVE
                         The base archive directory
                         [default: {archive_base}]

--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -35,7 +35,7 @@ def parse_args(argv):
         '-v', '--verbose',
         action='store_true',
         default=False,
-        help='be more verbose',
+        help='Be more verbose',
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
@@ -63,59 +63,59 @@ def parse_args(argv):
         '--lock',
         action='store_true',
         default=False,
-        help='lock particular machines',
+        help='Lock particular machines',
     )
     group.add_argument(
         '--unlock',
         action='store_true',
         default=False,
-        help='unlock particular machines',
+        help='Unlock particular machines',
     )
     group.add_argument(
         '--lock-many',
         dest='num_to_lock',
         type=_positive_int,
-        help='lock this many machines',
+        help='Lock this many machines',
     )
     group.add_argument(
         '--update',
         action='store_true',
         default=False,
-        help='update the description or status of some machines',
+        help='Update the description or status of some machines',
     )
     group.add_argument(
         '--summary',
         action='store_true',
         default=False,
-        help='summarize locked-machine counts by owner',
+        help='Summarize locked-machine counts by owner',
     )
     parser.add_argument(
         '-a', '--all',
         action='store_true',
         default=False,
-        help='list all machines, not just those owned by you',
+        help='List all machines, not just those owned by you',
     )
     parser.add_argument(
         '--owner',
         default=None,
-        help='owner of the lock(s) (must match to unlock a machine)',
+        help='Owner of the lock(s) (must match to unlock a machine)',
     )
     parser.add_argument(
         '-f',
         action='store_true',
         default=False,
-        help="don't exit after the first error, continue locking or " +
+        help="Don't exit after the first error, continue locking or " +
         "unlocking other machines",
     )
     parser.add_argument(
         '--desc',
         default=None,
-        help='lock description',
+        help='Lock description',
     )
     parser.add_argument(
         '--desc-pattern',
         default=None,
-        help='lock description',
+        help='Lock description',
     )
     parser.add_argument(
         '--machine-type',
@@ -127,26 +127,26 @@ def parse_args(argv):
         '--status',
         default=None,
         choices=['up', 'down'],
-        help='whether a machine is usable for testing',
+        help='Whether a machine is usable for testing',
     )
     parser.add_argument(
         '--locked',
         default=None,
         choices=['true', 'false'],
-        help='whether a machine is locked',
+        help='Whether a machine is locked',
     )
     parser.add_argument(
         '-t', '--targets',
         dest='targets',
         default=None,
-        help='input yaml containing targets',
+        help='Input yaml containing targets',
     )
     parser.add_argument(
         'machines',
         metavar='MACHINE',
         default=[],
         nargs='*',
-        help='machines to operate on',
+        help='Machines to operate on',
     )
     parser.add_argument(
         '--os-type',
@@ -161,7 +161,7 @@ def parse_args(argv):
     parser.add_argument(
         '--arch',
         default=None,
-        help='architecture (x86_64, i386, armv7, arm64)',
+        help='Architecture (x86_64, i386, armv7, arm64)',
     )
     parser.add_argument(
         '--json-query',

--- a/scripts/ls.py
+++ b/scripts/ls.py
@@ -4,11 +4,11 @@ usage: teuthology-ls [-h] [-v] <archive_dir>
 List teuthology job results
 
 positional arguments:
-  <archive_dir>            path under which to archive results
+  <archive_dir>            Path under which to archive results
 
 optional arguments:
-  -h, --help     show this help message and exit
-  -v, --verbose  show reasons tests failed
+  -h, --help     Show this help message and exit
+  -v, --verbose  Show reasons tests failed
 """
 import docopt
 import teuthology.ls

--- a/scripts/nuke.py
+++ b/scripts/nuke.py
@@ -13,22 +13,22 @@ usage:
 Reset test machines
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -v, --verbose         be more verbose
+  -h, --help            Show this help message and exit
+  -v, --verbose         Be more verbose
   -t CONFIG [CONFIG ...], --targets CONFIG [CONFIG ...]
-                        yaml config containing machines to nuke
+                        Yaml config containing machines to nuke
   -a DIR, --archive DIR
-                        archive path for a job to kill and nuke
-  --stale               attempt to find and nuke 'stale' machines
+                        Archive path for a job to kill and nuke
+  --stale               Attempt to find and nuke 'stale' machines
                         (e.g. locked by jobs that are no longer running)
-  --stale-openstack     nuke 'stale' OpenStack instances and volumes
+  --stale-openstack     Nuke 'stale' OpenStack instances and volumes
                         and unlock OpenStack targets with no instance
   --dry-run             Don't actually nuke anything; just print the list of
                         targets that would be nuked
-  --owner OWNER         job owner
-  -p PID, --pid PID     pid of the process to be killed
-  -r, --reboot-all      reboot all machines
-  -s, --synch-clocks    synchronize clocks on all machines
+  --owner OWNER         Job owner
+  -p PID, --pid PID     Pid of the process to be killed
+  -r, --reboot-all      Reboot all machines
+  -s, --synch-clocks    Synchronize clocks on all machines
   -u, --unlock          Unlock each successfully nuked machine, and output
                         targets thatcould not be nuked.
   -n NAME, --name NAME  Name of run to cleanup

--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -29,12 +29,12 @@ and analyze results.
     parser.add_argument(
         '-v', '--verbose',
         action='store_true', default=None,
-        help='be more verbose',
+        help='Be more verbose',
     )
     parser.add_argument(
         '--wait',
         action='store_true', default=None,
-        help='block until the suite is finished',
+        help='Block until the suite is finished',
     )
     parser.add_argument(
         '--name',
@@ -48,36 +48,36 @@ and analyze results.
     )
     parser.add_argument(
         '--key-filename',
-        help='path to the ssh private key',
+        help='Path to the ssh private key',
     )
     parser.add_argument(
         '--simultaneous-jobs',
-        help='maximum number of jobs running in parallel',
+        help='Maximum number of jobs running in parallel',
         type=int,
         default=1,
     )
     parser.add_argument(
         '--teardown',
         action='store_true', default=None,
-        help='destroy the cluster, if it exists',
+        help='Destroy the cluster, if it exists',
     )
     parser.add_argument(
         '--teuthology-git-url',
-        help=("git clone url for teuthology"),
+        help=("Git clone url for teuthology"),
     )
     parser.add_argument(
         '--teuthology-branch',
-        help="use this teuthology branch instead of master",
+        help="Use this teuthology branch instead of master",
         default='master',
     )
     parser.add_argument(
         '--upload',
         action='store_true', default=False,
-        help='upload archives to an rsync server',
+        help='Upload archives to an rsync server',
     )
     parser.add_argument(
         '--archive-upload',
-        help='rsync destination to upload archives',
+        help='Rsync destination to upload archives',
         default='ubuntu@teuthology-logs.public.ceph.com:./',
     )
     parser.add_argument(
@@ -185,11 +185,11 @@ and analyze results.
     )
     parser.add_argument(
         '--ceph-git-url',
-        help=("git clone url for Ceph"),
+        help=("Git clone url for Ceph"),
     )
     parser.add_argument(
         '--ceph-qa-suite-git-url',
-        help=("git clone url for ceph-qa-suite"),
+        help=("Git clone url for ceph-qa-suite"),
     )
 
     return parser.parse_args(argv)

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -12,7 +12,7 @@ usage:
 Submit test results to a web service
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit
   -a ARCHIVE, --archive ARCHIVE
                         The base archive directory
                         [default: {archive_base}]
@@ -33,7 +33,7 @@ optional arguments:
                         behavior.
   -D, --dead            Mark all given jobs (or entire runs) with status
                         'dead'. Implies --refresh.
-  -v, --verbose         be more verbose
+  -v, --verbose         Be more verbose
 """.format(archive_base=teuthology.config.config.archive_base)
 
 

--- a/scripts/results.py
+++ b/scripts/results.py
@@ -4,14 +4,14 @@ usage: teuthology-results [-h] [-v] [--dry-run] [--email EMAIL] [--timeout TIMEO
 Email teuthology suite results
 
 optional arguments:
-  -h, --help         show this help message and exit
-  -v, --verbose      be more verbose
+  -h, --help         Show this help message and exit
+  -v, --verbose      Se more verbose
   --dry-run          Instead of sending the email, just print it
-  --email EMAIL      address to email test failures to
-  --timeout TIMEOUT  how many seconds to wait for all tests to finish
+  --email EMAIL      Address to email test failures to
+  --timeout TIMEOUT  How many seconds to wait for all tests to finish
                      [default: 0]
-  --archive-dir DIR  path under which results for the suite are stored
-  --name NAME        name of the suite
+  --archive-dir DIR  Path under which results for the suite are stored
+  --name NAME        Name of the suite
 """
 import docopt
 import teuthology.results

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -9,18 +9,18 @@ positional arguments:
   <config> one or more config files to read
 
 optional arguments:
-  -h, --help                     show this help message and exit
-  -v, --verbose                  be more verbose
-  --version                      the current installed version of teuthology
-  -a DIR, --archive DIR          path to archive results in
-  --description DESCRIPTION      job description
-  --owner OWNER                  job owner
-  --lock                         lock machines for the duration of the run
+  -h, --help                     Show this help message and exit
+  -v, --verbose                  Be more verbose
+  --version                      The current installed version of teuthology
+  -a DIR, --archive DIR          Path to archive results in
+  --description DESCRIPTION      Job description
+  --owner OWNER                  Job owner
+  --lock                         Lock machines for the duration of the run
   --machine-type MACHINE_TYPE    Type of machine to lock/run tests on.
   --os-type OS_TYPE              Distro/OS of machine to run test on.
   --os-version OS_VERSION        Distro/OS version of machine to run test on.
-  --block                        block until locking machines succeeds (use with --lock)
-  --name NAME                    name for this teuthology run
+  --block                        Block until locking machines succeeds (use with --lock)
+  --name NAME                    Name for this teuthology run
   --suite-path SUITE_PATH        Location of ceph-qa-suite on disk. If not specified,
                                  it will be fetched
 """

--- a/scripts/update_inventory.py
+++ b/scripts/update_inventory.py
@@ -13,9 +13,9 @@ usage: teuthology-update-inventory -h
 Update the given nodes' inventory information on the lock server
 
 
-  -h, --help            show this help message and exit
-  -v, --verbose         be more verbose
-  REMOTE                hostnames of machines whose information to update
+  -h, --help            Show this help message and exit
+  -v, --verbose         Be more verbose
+  REMOTE                Hostnames of machines whose information to update
 
 """
 

--- a/scripts/updatekeys.py
+++ b/scripts/updatekeys.py
@@ -11,7 +11,7 @@ Update any hostkeys that have changed. You can list specific machines to run
 on, or use -a to check all of them automatically.
 
 positional arguments:
-  MACHINES              hosts to check for updated keys
+  MACHINES              Hosts to check for updated keys
 
 optional arguments:
   -h, --help            Show this help message and exit

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -15,22 +15,22 @@ describe. One job is run at a time.
     parser.add_argument(
         '-v', '--verbose',
         action='store_true', default=None,
-        help='be more verbose',
+        help='Be more verbose',
     )
     parser.add_argument(
         '--archive-dir',
         metavar='DIR',
-        help='path under which to archive results',
+        help='Path under which to archive results',
         required=True,
     )
     parser.add_argument(
         '-l', '--log-dir',
-        help='path in which to store logs',
+        help='Path in which to store logs',
         required=True,
     )
     parser.add_argument(
         '-t', '--tube',
-        help='which beanstalk tube to read jobs from',
+        help='Which beanstalk tube to read jobs from',
         required=True,
     )
 


### PR DESCRIPTION
I run the help for teuthology(like: teuthology-lock -h), the arguments for helps of explain function didn't distinguish between upper case and lower case in the first letter.

Signed-off-by: zhang.zezhu <zhang.zezhu@zte.com.cn>