### PR TITLE
nuke.py: remove trailing fi token

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -113,7 +113,6 @@ def remove_kernel_mounts(ctx):
                 'grep', '-o', "/.* ", run.Raw('|'),
                 'xargs', '-r',
                 'sudo', 'umount', '-f', run.Raw(';'),
-                'fi'
             ],
             check_status=False,
             timeout=60


### PR DESCRIPTION
This caused a syntax error in one of the teuthology runs:

    2016-06-10T02:30:39.291 INFO:teuthology.nuke:clearing kernel mount from all nodes
    2016-06-10T02:30:39.292 INFO:teuthology.orchestra.run:Running command with timeout 60
    2016-06-10T02:30:39.292 INFO:teuthology.orchestra.run.mira069:Running: "grep ceph /etc/mtab | grep -o 'on /.* type' | grep -o '/.* ' | xargs -r sudo umount -f ; fi"
    2016-06-10T02:30:39.363 INFO:teuthology.orchestra.run.mira069.stderr:bash: -c: line 0: syntax error near unexpected token `fi'
    2016-06-10T02:30:39.364 INFO:teuthology.orchestra.run.mira069.stderr:bash: -c: line 0: `grep ceph /etc/mtab | grep -o 'on /.* type' | grep -o '/.* ' | xargs -r sudo umount -f ; fi'

Signed-off-by: Patrick Donnelly <batrick@batbytes.com>