### PR TITLE
get_gitbuilder_hash: use default distro if needed

### DIFF
--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -96,6 +96,8 @@ def get_gitbuilder_hash(project='ceph', branch='master', flavor='basic',
     #     'https://api.github.com/repos/ceph/ceph/git/refs/heads/master')
     # hash = .json()['object']['sha']
     (arch, release, _os) = get_distro_defaults(distro, machine_type)
+    if distro is None:
+        distro = _os.name
     gp = GitbuilderProject(
         project,
         dict(


### PR DESCRIPTION
http://tracker.ceph.com/issues/16328
Fixes: 16328

Signed-off-by: Zack Cerza <zack@redhat.com>