### PR TITLE
Pass --wait to downburst

### DIFF
--- a/teuthology/provision.py
+++ b/teuthology/provision.py
@@ -113,6 +113,7 @@ class Downburst(object):
             self.executable,
             '-c', self.host,
             'create',
+            '--wait',
             '--meta-data=%s' % self.config_path,
             '--user-data=%s' % self.user_path,
             shortname,


### PR DESCRIPTION
We recently made a change to cause downburst VMs to install python on Ubuntu systems via cloud-init. This caused a race condition since teuthology started job execution while the package was still installing. This causes downburst to block until cloud-init is finished.