### PR TITLE
Add teuthology-suite --newest

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -51,6 +51,10 @@ Here is a sample configuration with many of the options set and documented::
     # Gitbuilder archive that stores e.g. ceph packages
     gitbuilder_host: gitbuilder.example.com
 
+    # URL for 'gitserver' helper web application
+    # see http://github.com/ceph/gitserver
+    githelper_base_url: http://git.ceph.com:8080
+
     # Verify the packages signatures
     check_package_signatures: true
 

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -35,6 +35,11 @@ Standard arguments:
                               If both -S and -c are supplied, -S wins, and
                               there is no validation that sha1 is contained
                               in branch
+  -n <newest>, --newest <newest>
+                              Search for the newest revision built on all
+                              required distro/versions, starting from
+                              either --ceph or --sha1, backtracking
+                              up to <newest> commits [default: 10]
   -k <kernel>, --kernel <kernel>
                               The kernel branch to run against; if not
                               supplied, the installed kernel is unchanged

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -138,6 +138,7 @@ class TeuthologyConfig(YamlConfig):
         'ceph_git_url': None,
         'ceph_qa_suite_git_url': None,
         'gitbuilder_host': 'gitbuilder.ceph.com',
+        'githelper_base_url': 'http://git.ceph.com:8080',
         'check_package_signatures': True,
         'lab_domain': 'front.sepia.ceph.com',
         'lock_server': 'http://paddles.front.sepia.ceph.com/',

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -470,21 +470,27 @@ class GitbuilderProject(object):
         """
         self.arch = self.job_config.get('arch', 'x86_64')
         self.os_type = self.job_config.get("os_type")
+        self.flavor = self.job_config.get("flavor")
+        self.codename = self.job_config.get("codename")
         self.os_version = self._get_version()
+        self.ref = self.job_config.get("ref")
         self.distro = self._get_distro(
             distro=self.os_type,
             version=self.os_version,
+            codename=self.codename,
         )
         self.pkg_type = "deb" if self.os_type.lower() in (
             "ubuntu",
             "debian",
         ) else "rpm"
-        # avoiding circular imports
-        from teuthology.suite.util import get_install_task_flavor
-        # when we're initializing from a full teuthology config, not just a
-        # task config we need to make sure we're looking at the flavor for
-        # the install task
-        self.flavor = get_install_task_flavor(self.job_config)
+
+        if not getattr(self, 'flavor'):
+            # avoiding circular imports
+            from teuthology.suite.util import get_install_task_flavor
+            # when we're initializing from a full teuthology config, not just a
+            # task config we need to make sure we're looking at the flavor for
+            # the install task
+            self.flavor = get_install_task_flavor(self.job_config)
 
     @property
     def sha1(self):
@@ -648,7 +654,7 @@ class GitbuilderProject(object):
         else:
             # FIXME: Should master be the default?
             log.debug("defaulting to master branch")
-            uri = 'ref/master'
+            uri = getattr(self, 'ref', 'ref/master')
         return uri
 
     def _get_base_url(self):

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -36,7 +36,7 @@ def process_args(args):
         key = rename_args.get(key) or key
         if key == 'suite':
             value = value.replace('/', ':')
-        elif key in ('limit', 'priority', 'num'):
+        elif key in ('limit', 'priority', 'num', 'newest'):
             value = int(value)
         elif key == 'subset' and value is not None:
             # take input string '2/3' and turn into (2, 3)

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -8,7 +8,9 @@ import yaml
 from datetime import datetime
 
 from ..config import config, JobConfig
-from ..exceptions import (BranchNotFoundError, CommitNotFoundError,)
+from ..exceptions import (
+    BranchNotFoundError, CommitNotFoundError, VersionNotFoundError
+)
 from ..misc import deep_merge, get_results_url
 
 from . import util
@@ -23,7 +25,7 @@ class Run(object):
     WAIT_PAUSE = 5 * 60
     __slots__ = (
         'args', 'name', 'base_config', 'suite_repo_path', 'base_yaml_paths',
-        'base_args',
+        'base_args', 'package_versions',
     )
 
     def __init__(self, args):
@@ -33,6 +35,8 @@ class Run(object):
         self.args = args
         self.name = self.make_run_name()
         self.base_config = self.create_initial_config()
+        # caches package versions to minimize requests to gbs
+        self.package_versions = dict()
 
         if self.args.suite_dir:
             self.suite_repo_path = self.args.suite_dir
@@ -148,7 +152,8 @@ class Run(object):
         return ceph_hash
 
     def choose_ceph_version(self, ceph_hash):
-        if config.suite_verify_ceph_hash:
+        if config.suite_verify_ceph_hash and not self.args.newest:
+            # don't bother if newest; we'll search for an older one
             # Get the ceph package version
             ceph_version = util.package_version_for_hash(
                 ceph_hash, self.args.kernel_flavor, self.args.distro,
@@ -255,27 +260,8 @@ class Run(object):
             if results_url:
                 log.info("Test results viewable at %s", results_url)
 
-    def schedule_suite(self):
-        """
-        Schedule the suite run. Returns the number of jobs scheduled.
-        """
-        name = self.name
-        arch = util.get_arch(self.base_config.machine_type)
-        suite_name = self.base_config.suite
-        suite_path = os.path.join(
-            self.suite_repo_path, 'suites',
-            self.base_config.suite.replace(':', '/'))
-        log.debug('Suite %s in %s' % (suite_name, suite_path))
-        configs = [
-            (combine_path(suite_name, item[0]), item[1]) for item in
-            build_matrix(suite_path, subset=self.args.subset)
-        ]
-        log.info('Suite %s in %s generated %d jobs (not yet filtered)' % (
-            suite_name, suite_path, len(configs)))
 
-    def collect_jobs(self, arch, configs):
-        # used as a local cache for package versions from gitbuilder
-        package_versions = dict()
+    def collect_jobs(self, arch, configs, newest=False):
         jobs_to_schedule = []
         jobs_missing_packages = []
         for description, fragment_paths in configs:
@@ -346,28 +332,35 @@ class Run(object):
                 args=arg
             )
 
+            sha1 = self.base_config.sha1
             if config.suite_verify_ceph_hash:
                 full_job_config = dict()
                 deep_merge(full_job_config, self.base_config.to_dict())
                 deep_merge(full_job_config, parsed_yaml)
                 flavor = util.get_install_task_flavor(full_job_config)
-                sha1 = self.base_config.sha1
                 # Get package versions for this sha1, os_type and flavor. If
                 # we've already retrieved them in a previous loop, they'll be
                 # present in package_versions and gitbuilder will not be asked
                 # again for them.
-                package_versions = util.get_package_versions(
-                    sha1,
-                    os_type,
-                    flavor,
-                    package_versions
-                )
+                try:
+                    self.package_versions = util.get_package_versions(
+                        sha1,
+                        os_type,
+                        flavor,
+                        self.package_versions
+                    )
+                except VersionNotFoundError:
+                    pass
                 if not util.has_packages_for_distro(sha1, os_type, flavor,
-                                                    package_versions):
+                                                    self.package_versions):
                     m = "Packages for os_type '{os}', flavor {flavor} and " + \
                         "ceph hash '{ver}' not found"
                     log.error(m.format(os=os_type, flavor=flavor, ver=sha1))
                     jobs_missing_packages.append(job)
+                    # optimization: one missing package causes backtrack in newest mode;
+                    # no point in continuing the search
+                    if newest:
+                        return jobs_missing_packages, None
 
             jobs_to_schedule.append(job)
         return jobs_missing_packages, jobs_to_schedule
@@ -419,7 +412,31 @@ class Run(object):
         log.info('Suite %s in %s generated %d jobs (not yet filtered)' % (
             suite_name, suite_path, len(configs)))
 
-        jobs_missing_packages, jobs_to_schedule = self.collect_jobs(arch, configs)
+        # if newest, do this until there are no missing packages
+        # if not, do it once
+        backtrack = 0
+        limit = self.args.newest
+        while backtrack < limit:
+            jobs_missing_packages, jobs_to_schedule = \
+                self.collect_jobs(arch, configs, self.args.newest)
+            if jobs_missing_packages and self.args.newest:
+                self.base_config.sha1 = \
+                    util.find_git_parent('ceph', self.base_config.sha1)
+                if self.base_config.sha1 is None:
+                    util.schedule_fail(
+                        name, message='Backtrack for --newest failed'
+                    )
+                backtrack += 1
+                continue
+            if backtrack:
+                log.info("--newest supplied, backtracked %d commits to %s" %
+                         (backtrack, self.base_config.sha1))
+            break
+        else:
+            util.schedule_fail(
+                name,
+                message='Exceeded %d backtracks; raise --newest value' % limit
+            )
 
         self.schedule_jobs(jobs_missing_packages, jobs_to_schedule, name)
 

--- a/teuthology/suite/test/test_util.py
+++ b/teuthology/suite/test/test_util.py
@@ -117,8 +117,21 @@ class TestUtil(object):
         assert util.git_ls_remote('ceph', 'nobranch') is None
         assert util.git_ls_remote('ceph', 'master') is not None
 
+    @patch('teuthology.suite.util.requests.get')
+    def test_find_git_parent(self, m_requests_get):
+        refresh_resp = Mock()
+        refresh_resp.ok = True
+        history_resp = Mock()
+        history_resp.ok = True
+        history_resp.json.return_value = {'sha1s': ['sha1', 'sha1_p']}
+        m_requests_get.side_effect = [refresh_resp, history_resp]
+        parent_sha1 = util.find_git_parent('ceph', 'sha1')
+        assert len(m_requests_get.mock_calls) == 2
+        assert parent_sha1 == 'sha1_p'
+
 
 class TestFlavor(object):
+
     def test_get_install_task_flavor_bare(self):
         config = dict(
             tasks=[

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -358,7 +358,7 @@ def get_package_versions(sha1, os_type, kernel_flavor, package_versions=None):
                              for all hashs and distros, not just for the given
                              hash and distro.
     """
-    if not package_versions:
+    if package_versions is None:
         package_versions = dict()
 
     os_type = str(os_type)
@@ -415,7 +415,7 @@ def has_packages_for_distro(sha1, os_type, kernel_flavor,
     :returns:                True, if packages are found. False otherwise.
     """
     os_type = str(os_type)
-    if not package_versions:
+    if package_versions is None:
         package_versions = get_package_versions(sha1, os_type, kernel_flavor)
 
     package_versions_for_hash = package_versions.get(sha1, dict()).get(


### PR DESCRIPTION
This adds a simple webserver (Flask, currently manually deployed on git.ceph.com) to allow querying git history from teuthology-suite in order to implement "--newest", a facility to search for the latest-built version of a branch and schedule it if the branch tip hasn't yet been built.  There's also a --newest-limit parameter to limit the amount of backtracking allowed (10 by default).  The number of commits backtracked is logged.

This uses GitbuilderProject to check for 'builds done' on the gitbuilders in the same way suite has been doing, but adds a loop to retry if newest is set, which uses util.find_git_parent() to find the sha1 of the parent of the requested branch/sha1 and retry.  There's some refactoring of suite.run to make this happen.

There could probably be more tests.