### PR TITLE
teuthology-suite: Spelling error in web API + minor test improvement

### DIFF
--- a/teuthology/suite/test/test_util.py
+++ b/teuthology/suite/test/test_util.py
@@ -119,10 +119,8 @@ class TestUtil(object):
 
     @patch('teuthology.suite.util.requests.get')
     def test_find_git_parent(self, m_requests_get):
-        refresh_resp = Mock()
-        refresh_resp.ok = True
-        history_resp = Mock()
-        history_resp.ok = True
+        refresh_resp = Mock(ok=True)
+        history_resp = Mock(ok=True)
         history_resp.json.return_value = {'sha1s': ['sha1', 'sha1_p']}
         m_requests_get.side_effect = [refresh_resp, history_resp]
         parent_sha1 = util.find_git_parent('ceph', 'sha1')

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -468,9 +468,9 @@ def find_git_parent(project, sha1):
         if not resp.ok:
             log.error('git refresh failed for %s: %s', project, resp.content)
 
-    def get_sha1s(project, commitish, count):
+    def get_sha1s(project, committish, count):
         url = '/'.join((base_url, '%s.git' % project,
-                       'history/?commitish=%s&count=%d' % (commitish, count)))
+                       'history/?committish=%s&count=%d' % (committish, count)))
         resp = requests.get(url)
         resp.raise_for_status()
         sha1s = resp.json()['sha1s']


### PR DESCRIPTION
In my defense, "committish" isn't a word, and I'm not the only one:  https://git.kaarsemaker.net/git/commit/a8a5406ab32fccabf8ed08001d50b5373e18ff1a/