### PR TITLE
suite.py: defaulting newest to 10 means it's always enabled

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -39,7 +39,7 @@ Standard arguments:
                               Search for the newest revision built on all
                               required distro/versions, starting from
                               either --ceph or --sha1, backtracking
-                              up to <newest> commits [default: 10]
+                              up to <newest> commits [default: 0]
   -k <kernel>, --kernel <kernel>
                               The kernel branch to run against; if not
                               supplied, the installed kernel is unchanged


### PR DESCRIPTION
Even if --newest isn't supplied, docopts will create it and
set it to the default.  Change the default to 0.

Signed-off-by: Dan Mick <dan.mick@redhat.com>