### PR TITLE
suite.py: must pass at least once through the backtrack loop

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -418,7 +418,7 @@ class Run(object):
         # if not, do it once
         backtrack = 0
         limit = self.args.newest
-        while backtrack < limit:
+        while backtrack <= limit:
             jobs_missing_packages, jobs_to_schedule = \
                 self.collect_jobs(arch, configs, self.args.newest)
             if jobs_missing_packages and self.args.newest:


### PR DESCRIPTION
Changing the default of newest to '0' meant that the combined
loop which handles both backtrack and non-backtrack conditions
was never executing, leading to undefined variables.

Signed-off-by: Dan Mick <dan.mick@redhat.com>