### PR TITLE
Insure left-over ceph-release doesn't break a machine.

### DIFF
--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -426,7 +426,9 @@ def _update_rpm_package_list_and_install(ctx, remote, rpm, config):
         start_of_url=start_of_url, rpm_name=rpm_name)
     # When this was one command with a pipe, it would sometimes
     # fail with the message 'rpm: no packages given for install'
-    remote.run(args=['wget', base_url, ],)
+    # Also try deleting the file first incase it existed from previous
+    # run where connection broke or failed after install attempt.
+    remote.run(args=['rm', '-f', rpm_name, run.Raw('&&'), 'wget', base_url, ],)
     remote.run(args=['sudo', 'yum', '-y', 'localinstall', rpm_name])
 
     remote.run(args=['rm', '-f', rpm_name])


### PR DESCRIPTION
We had a situation where a machine had a left-over ceph-release
file. Possibly due to a bad download at the time causing the
initial failure of the install command or a connection loss but
the rm that runs after the install command never ran and thus
wget just kept appending a download number to the file names
leaving around a blank/broken ceph-release RPM causing failures
in its wake.

This should prevent that by running a rm -f on the file first.

Signed-off-by: Sandon Van Ness <sandon@redhat.com>