### PR TITLE
Fix resolve_role_list in daemon.py

### DIFF
--- a/teuthology/orchestra/daemon.py
+++ b/teuthology/orchestra/daemon.py
@@ -238,7 +238,7 @@ class DaemonGroup(object):
                         prefix = type_
                         if cluster_aware:
                             prefix = daemon.role
-                        resolved.append(prefix + daemon.id_)
+                        resolved.append(prefix + '.' + daemon.id_)
         else:
             # Handle explicit list of roles or wildcards
             for raw_role in roles:
@@ -256,7 +256,7 @@ class DaemonGroup(object):
                         prefix = role_type
                         if cluster_aware:
                             prefix = daemon.role
-                        resolved.append(prefix + daemon.id_)
+                        resolved.append(prefix + '.' + daemon.id_)
                 else:
                     # Handle explicit role
                     resolved.append(raw_role)


### PR DESCRIPTION
resolve_role_list did not handle cases where roles specified contained wild-cards or
were not specified.  ceph.role.a would end up being resolved as ceph.rolea.

Fixes: tracker issue 16053
Signed-off-by: Warren Usui <wusui@redhat.com>