### PR TITLE
[DNM] install.upgrade: add pre-upgrade sanity check

### DIFF
--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -14,6 +14,7 @@ from teuthology import contextutil, packaging
 from teuthology.parallel import parallel
 from ..orchestra import run
 from . import ansible
+from distutils.version import LooseVersion
 
 log = logging.getLogger(__name__)
 
@@ -940,6 +941,10 @@ def upgrade_remote_to_config(ctx, config):
     return result
 
 
+def _upgrade_is_downgrade(installed_version, upgrade_version):
+    return LooseVersion(installed_version) > LooseVersion(upgrade_version)
+
+
 def upgrade_common(ctx, config, deploy_style):
     """
     Common code for upgrading
@@ -963,8 +968,22 @@ def upgrade_common(ctx, config, deploy_style):
             # FIXME: again, make extra_pkgs distro-agnostic
         pkgs += extra_pkgs
 
+        installed_version = packaging.get_package_version(remote, 'ceph-common')
+        upgrade_version = _get_gitbuilder_project(ctx, remote, node).version
+        log.info("Ceph {s} upgrade from {i} to {u}".format(
+            s=system_type,
+            i=installed_version,
+            u=upgrade_version
+        ))
+	if _upgrade_is_downgrade(installed_version, upgrade_version):
+            raise RuntimeError(
+                "An attempt to upgrade from a higher version to a lower one "
+                "will always fail. Hint: check tags in the target git branch."
+            )
+
         deploy_style(ctx, node, remote, pkgs, system_type)
         verify_package_version(ctx, node, remote)
+
     return len(remotes)
 
 docstring_for_upgrade = """"

--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -254,6 +254,12 @@ def _update_rpm_package_list_and_install(ctx, remote, rpm, config):
                         run.Raw(';'), 'fi'])
 
 
+def get_upgrade_version(ctx, config, remote):
+    gitbuilder = _get_gitbuilder_project(ctx, remote, config)
+    version = gitbuilder.version
+    return version
+
+
 def verify_package_version(ctx, config, remote):
     """
     Ensures that the version of package installed is what
@@ -942,6 +948,8 @@ def upgrade_remote_to_config(ctx, config):
 
 
 def _upgrade_is_downgrade(installed_version, upgrade_version):
+    assert installed_version, "installed_version is empty"
+    assert upgrade_version, "upgrade_version is empty"
     return LooseVersion(installed_version) > LooseVersion(upgrade_version)
 
 
@@ -969,7 +977,7 @@ def upgrade_common(ctx, config, deploy_style):
         pkgs += extra_pkgs
 
         installed_version = packaging.get_package_version(remote, 'ceph-common')
-        upgrade_version = _get_gitbuilder_project(ctx, remote, node).version
+        upgrade_version = get_upgrade_version(ctx, remote, node)
         log.info("Ceph {s} upgrade from {i} to {u}".format(
             s=system_type,
             i=installed_version,

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -48,6 +48,17 @@ class TestInstall(object):
 
     @patch("teuthology.task.install._get_gitbuilder_project")
     @patch("teuthology.task.install.packaging.get_package_version")
+    def test_get_upgrade_version(self, m_get_package_version,
+                                         m_gitbuilder_project):
+        gb = Mock()
+        gb.version = "11.0.0"
+        gb.project = "ceph"
+        m_gitbuilder_project.return_value = gb
+        m_get_package_version.return_value = "11.0.0"
+        install.get_upgrade_version(Mock(), Mock(), Mock())
+
+    @patch("teuthology.task.install._get_gitbuilder_project")
+    @patch("teuthology.task.install.packaging.get_package_version")
     def test_verify_ceph_version_success(self, m_get_package_version,
                                          m_gitbuilder_project):
         gb = Mock()
@@ -102,9 +113,20 @@ class TestInstall(object):
         )
         assert install.get_flavor(config) == 'notcmalloc'
 
+    def test_upgrade_is_downgrade(self):
+        assert_ok_vals = [
+	    ('9.0.0', '10.0.0'),
+	    ('10.2.2-63-g8542898-1trusty', '10.2.2-64-gabcdef1-1trusty'),
+	    ('11.0.0-918.g13c13c7', '11.0.0-2165.gabcdef1')
+	]
+	for t in assert_ok_vals:
+            assert install._upgrade_is_downgrade(t[0], t[1]) == False
+    
     @patch("teuthology.misc.get_system_type")
     @patch("teuthology.task.install.verify_package_version")
+    @patch("teuthology.task.install.get_upgrade_version")
     def test_upgrade_common(self,
+                            m_get_upgrade_version,
                             m_verify_package_version,
                             m_get_system_type):
         expected_system_type = 'deb'
@@ -146,6 +168,7 @@ class TestInstall(object):
                 },
             ],
         }
+	m_get_upgrade_version.return_value = "11.0.0"
         m_get_system_type.return_value = "deb"
         def upgrade(ctx, node, remote, pkgs, system_type):
             assert system_type == expected_system_type


### PR DESCRIPTION
Add a pre-upgrade sanity check to the install.upgrade task. This sanity check:
1. determines the version of Ceph installed on the remote ("installed_version")
2. determines the version of Ceph in the target gitbuilder repo
   ("upgrade_version")
3. if "installed_version" is greater than "upgrade_version", fail immediately

Since the upgrade itself cannot succeed if upgrade_version < installed_version,
it's better to fail before attempting the upgrade.

Before this patch, we were failing in the verify_package_version() sanity check
which is run after attempting (and failing) to upgrade the packages.

Fixes: http://tracker.ceph.com/issues/16521
Signed-off-by: Nathan Cutler ncutler@suse.com
