### PR TITLE
Install -release RPMs directly

### DIFF
--- a/teuthology/task/install.py
+++ b/teuthology/task/install.py
@@ -211,12 +211,7 @@ def _update_rpm_package_list_and_install(ctx, remote, rpm, config):
     rpm_name = "{rpm_nm}.rpm".format(rpm_nm=proj_release)
     base_url = "{start_of_url}/noarch/{rpm_name}".format(
         start_of_url=start_of_url, rpm_name=rpm_name)
-    # When this was one command with a pipe, it would sometimes
-    # fail with the message 'rpm: no packages given for install'
-    remote.run(args=['wget', base_url, ],)
-    remote.run(args=['sudo', 'yum', '-y', 'localinstall', rpm_name])
-
-    remote.run(args=['rm', '-f', rpm_name])
+    remote.run(args=['sudo', 'yum', '-y', 'install', base_url])
 
     uri = gitbuilder.uri_reference
     _yum_fix_repo_priority(remote, project, uri)


### PR DESCRIPTION
This avoids having to dance around with wget and rm -f.
Fixes: 10481
http://tracker.ceph.com/issues/10481

Signed-off-by: Zack Cerza <zack@redhat.com>