### PR TITLE
Complete --newest feature, add some cleanups

### DIFF
--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -5,7 +5,6 @@
 import logging
 import os
 import time
-from tempfile import NamedTemporaryFile
 
 import teuthology
 from ..config import config, YamlConfig
@@ -63,26 +62,8 @@ def main(args):
         log.info('Will upload archives to ' + args['--archive-upload'])
 
     run = Run(fn)
-    job_config = run.base_config
     name = run.name
-
-    job_config.name = name
-    job_config.priority = fn.priority
-    if config.results_email:
-        job_config.email = config.results_email
-    if fn.owner:
-        job_config.owner = fn.owner
-
-    if fn.dry_run:
-        log.debug("Base job config:\n%s" % job_config)
-
-    with NamedTemporaryFile(prefix='schedule_suite_',
-                            delete=False) as base_yaml:
-        base_yaml.write(str(job_config))
-        base_yaml_path = base_yaml.name
-    run.base_yaml_paths.insert(0, base_yaml_path)
     run.prepare_and_schedule()
-    os.remove(base_yaml_path)
     if not fn.dry_run and args['--wait']:
         return wait(name, config.max_job_time,
                     args['--archive-upload-url'])

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -57,16 +57,16 @@ def main(args):
 
     if fn.email:
         config.results_email = fn.email
-    if args['--archive-upload']:
-        config.archive_upload = args['--archive-upload']
-        log.info('Will upload archives to ' + args['--archive-upload'])
+    if fn.archive_upload:
+        config.archive_upload = fn.archive_upload
+        log.info('Will upload archives to ' + fn.archive_upload)
 
     run = Run(fn)
     name = run.name
     run.prepare_and_schedule()
     if not fn.dry_run and args['--wait']:
         return wait(name, config.max_job_time,
-                    args['--archive-upload-url'])
+                    fn.archive_upload_url)
 
 
 class WaitException(Exception):

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -45,28 +45,28 @@ def process_args(args):
 
 
 def main(args):
-    fn = process_args(args)
-    if fn.verbose:
+    conf = process_args(args)
+    if conf.verbose:
         teuthology.log.setLevel(logging.DEBUG)
 
-    if not fn.machine_type or fn.machine_type == 'None':
+    if not conf.machine_type or conf.machine_type == 'None':
         schedule_fail("Must specify a machine_type")
-    elif 'multi' in fn.machine_type:
+    elif 'multi' in conf.machine_type:
         schedule_fail("'multi' is not a valid machine_type. " +
                       "Maybe you want 'plana,mira,burnupi' or similar")
 
-    if fn.email:
-        config.results_email = fn.email
-    if fn.archive_upload:
-        config.archive_upload = fn.archive_upload
-        log.info('Will upload archives to ' + fn.archive_upload)
+    if conf.email:
+        config.results_email = conf.email
+    if conf.archive_upload:
+        config.archive_upload = conf.archive_upload
+        log.info('Will upload archives to ' + conf.archive_upload)
 
-    run = Run(fn)
+    run = Run(conf)
     name = run.name
     run.prepare_and_schedule()
-    if not fn.dry_run and args['--wait']:
+    if not conf.dry_run and conf.wait:
         return wait(name, config.max_job_time,
-                    fn.archive_upload_url)
+                    conf.archive_upload_url)
 
 
 class WaitException(Exception):

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -343,8 +343,7 @@ class Run(object):
 
             sha1 = self.base_config.sha1
             if config.suite_verify_ceph_hash:
-                full_job_config = dict()
-                deep_merge(full_job_config, self.base_config.to_dict())
+                full_job_config = copy.deepcopy(self.base_config.to_dict())
                 deep_merge(full_job_config, parsed_yaml)
                 flavor = util.get_install_task_flavor(full_job_config)
                 # Get package versions for this sha1, os_type and flavor. If


### PR DESCRIPTION
two major fixes for --newest:

1) rewrite the /tmp yaml file that holds base_config when base_config is finally done (backtracking rewrites this info)
2) make sure that the copy of the job configuration doesn't share refs with the base_config dict so that it doesn't corrupt base_config while backtracking

The other two commits are cleanup in arg processing.