### PR TITLE
teuthology-queue: add --status

### DIFF
--- a/scripts/queue.py
+++ b/scripts/queue.py
@@ -5,7 +5,7 @@ import teuthology.beanstalk
 
 doc = """
 usage: teuthology-queue -h
-       teuthology-queue [-d|-f] -m MACHINE_TYPE
+       teuthology-queue [-s|-d|-f] -m MACHINE_TYPE
        teuthology-queue [-r] -m MACHINE_TYPE
        teuthology-queue -m MACHINE_TYPE -D PATTERN
        teuthology-queue -p SECONDS [-m MACHINE_TYPE]
@@ -24,6 +24,7 @@ optional arguments:
   -d, --description     Show job descriptions
   -r, --runs            Only show run names
   -f, --full            Print the entire job config. Use with caution.
+  -s, --status          Prints the status of the queue
   -p, --pause SECONDS   Pause queues for a number of seconds. A value of 0
                         will unpause. If -m is passed, pause that queue,
                         otherwise pause all queues.

--- a/teuthology/beanstalk.py
+++ b/teuthology/beanstalk.py
@@ -171,8 +171,19 @@ def pause_tube(connection, tube, duration):
         connection.pause_tube(tube, duration)
 
 
+def stats_tube(connection, tube):
+    stats = connection.stats_tube(tube)
+    result = dict(
+        name=tube,
+        count=stats['current-jobs-ready'],
+        paused=(stats['pause'] != 0),
+    )
+    return result
+
+
 def main(args):
     machine_type = args['--machine_type']
+    status = args['--status']
     delete = args['--delete']
     runs = args['--runs']
     show_desc = args['--description']
@@ -184,7 +195,9 @@ def main(args):
             # watch_tube needs to be run before we inspect individual jobs;
             # it is not needed for pausing tubes
             watch_tube(connection, machine_type)
-        if pause_duration:
+        if status:
+            print stats_tube(connection, machine_type)
+        elif pause_duration:
             pause_tube(connection, machine_type, pause_duration)
         elif delete:
             walk_jobs(connection, machine_type,


### PR DESCRIPTION
Prints queue status, e.g.:

    $ teuthology-queue -m smithi --status
    {'paused': False, 'count': 2900, 'name': 'smithi'}

Signed-off-by: Zack Cerza <zack@redhat.com>