### PR TITLE
packages.yaml: drop ceph-devel from rpm section

### DIFF
--- a/teuthology/task/packages.yaml
+++ b/teuthology/task/packages.yaml
@@ -25,7 +25,6 @@ ceph:
   rpm:
   - ceph-radosgw
   - ceph-test
-  - ceph-devel
   - ceph
   - ceph-fuse
   - cephfs-java


### PR DESCRIPTION
Upgrade tests on https://github.com/ceph/ceph/9744 (which drops the ceph-devel
package after a long period of deprecation) are currently failing
because teuthology tries to install ceph-devel, even though it is not needed
for any tests.

See also https://github.com/ceph/ceph-qa-suite/pull/1068

Signed-off-by: Nathan Cutler <ncutler@suse.com>