### PR TITLE
valgrind: wildcard boost supression

### DIFF
--- a/teuthology/task/valgrind.supp
+++ b/teuthology/task/valgrind.supp
@@ -303,9 +303,9 @@
 	thread_local memory is falsely detected (https://svn.boost.org/trac/boost/ticket/3296)
 	Memcheck:Leak
 	...
-	fun:boost::detail::get_once_per_thread_epoch()
-	fun:void boost::call_once*
-	fun:boost::detail::get_current_thread_data()
+	fun:*boost*detail*get_once_per_thread_epoch*
+	fun:*boost*call_once*
+	fun:*boost*detail*get_current_thread_data*
 	...
 }
 {


### PR DESCRIPTION
...so that it will match mangled names.

Fixes: http://tracker.ceph.com/issues/14794
Signed-off-by: John Spray <john.spray@redhat.com>