### PR TITLE
teuthology-lock: add centos 7.2 to downburst default table

### DIFF
--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -37,7 +37,6 @@ def get_distro_from_downburst():
                      u'fedora': [u'17', u'18', u'19', u'20', u'22'],
                      u'centos': [u'6.3', u'6.4', u'6.5', u'7.0',
 				 u'7.2'],
-                     u'opensuse': [u'12.2'],
                      u'centos_minimal': [u'6.4', u'6.5'],
                      u'ubuntu': [u'8.04(hardy)', u'9.10(karmic)',
                                  u'10.04(lucid)', u'10.10(maverick)',

--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -35,7 +35,8 @@ def get_distro_from_downburst():
     """
     default_table = {u'rhel_minimal': [u'6.4', u'6.5'],
                      u'fedora': [u'17', u'18', u'19', u'20', u'22'],
-                     u'centos': [u'6.3', u'6.4', u'6.5', u'7.0'],
+                     u'centos': [u'6.3', u'6.4', u'6.5', u'7.0',
+				 u'7.2'],
                      u'opensuse': [u'12.2'],
                      u'centos_minimal': [u'6.4', u'6.5'],
                      u'ubuntu': [u'8.04(hardy)', u'9.10(karmic)',


### PR DESCRIPTION
When downburst is unavailable, teuthology-lock reverts to default_table and
fails because the only supported CentOS version, 7.2., is missing.

Signed-off-by: Nathan Cutler <ncutler@suse.com>