### PR TITLE
worker: Don't die on a beanstalkc SocketError

### DIFF
--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -133,7 +133,12 @@ def main(ctx):
         except SkipJob:
             continue
 
-        job.delete()
+        # This try/except block is to keep the worker from dying when
+        # beanstalkc throws a SocketError
+        try:
+            job.delete()
+        except Exception:
+            log.exception("Saw exception while trying to delete job")
 
 
 def prep_job(job_config, log_file_path, archive_dir):


### PR DESCRIPTION
I'm seeing this:

```
2016-08-09T18:24:42.415 DEBUG:teuthology.worker:Worker log: /home/teuthworker/archive/worker_logs/worker.vps.32001
2016-08-09T18:46:43.251 INFO:teuthology.worker:Success!
2016-08-09T18:46:43.252 CRITICAL:teuthology.worker:Uncaught exception
Traceback (most recent call last):
  File "/home/teuthworker/src/teuthology_master/virtualenv/bin/teuthology-worker", line 9, in <module>
    load_entry_point('teuthology', 'console_scripts', 'teuthology-worker')()
  File "/home/teuthworker/src/teuthology_master/scripts/worker.py", line 7, in main
    teuthology.worker.main(parse_args())
  File "/home/teuthworker/src/teuthology_master/teuthology/worker.py", line 136, in main
    job.delete()
  File "/home/teuthworker/src/teuthology_master/virtualenv/local/lib/python2.7/site-packages/beanstalkc.py", line 272, in delete
    self.conn.delete(self.jid)
  File "/home/teuthworker/src/teuthology_master/virtualenv/local/lib/python2.7/site-packages/beanstalkc.py", line 229, in delete
    self._interact('delete %d\r\n' % jid, ['DELETED'], ['NOT_FOUND'])
  File "/home/teuthworker/src/teuthology_master/virtualenv/local/lib/python2.7/site-packages/beanstalkc.py", line 87, in _interact
    status, results = self._read_response()
  File "/home/teuthworker/src/teuthology_master/virtualenv/local/lib/python2.7/site-packages/beanstalkc.py", line 98, in _read_response
    raise SocketError()
SocketError
```

I'm not sure what the root cause is yet, though.