### PR TITLE
openstack: do not display openstack client warnings

### DIFF
--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -450,7 +450,7 @@ def stale_openstack_volumes(ctx, volumes):
     for volume in volumes:
         volume_id = volume.get('ID') or volume['id']
         try:
-            volume = json.loads(sh("openstack volume show -f json " +
+            volume = json.loads(sh("openstack -q volume show -f json " +
                                    volume_id))
         except subprocess.CalledProcessError:
             log.debug("stale-openstack: {id} disappeared, ignored"

--- a/teuthology/openstack/test/openstack-integration.py
+++ b/teuthology/openstack/test/openstack-integration.py
@@ -58,10 +58,10 @@ class Integration(object):
         # move that to def tearDown for debug and when it works move it
         # back in tearDownClass so it is not called on every test
         ownedby = "ownedby='" + teuth_config.openstack['ip']
-        all_instances = teuthology.misc.sh("openstack server list -f json --long")
+        all_instances = teuthology.misc.sh("openstack -q server list -f json --long")
         for instance in json.loads(all_instances):
             if ownedby in instance['Properties']:
-                teuthology.misc.sh("openstack server delete --wait " + instance['ID'])
+                teuthology.misc.sh("openstack -q server delete --wait " + instance['ID'])
 
     def setup_worker(self):
         self.logs = self.d + "/log"
@@ -192,7 +192,7 @@ class TestSchedule(Integration):
         account if the instance has less than 4GB RAM.
         """
         try:
-            teuthology.misc.sh("openstack volume list")
+            teuthology.misc.sh("openstack -q volume list")
             job = 'teuthology/openstack/test/resources_hint.yaml'
             has_cinder = True
         except subprocess.CalledProcessError:

--- a/teuthology/openstack/test/test_openstack.py
+++ b/teuthology/openstack/test/test_openstack.py
@@ -286,7 +286,7 @@ class TestTeuthologyOpenStack(object):
         ip = TeuthologyOpenStack.create_floating_ip()
         if ip:
             ip_id = TeuthologyOpenStack.get_floating_ip_id(ip)
-            misc.sh("openstack ip floating delete " + ip_id)
+            misc.sh("openstack -q ip floating delete " + ip_id)
             self.can_create_floating_ips = True
         else:
             self.can_create_floating_ips = False
@@ -378,4 +378,4 @@ openstack keypair delete {key_name} || true
         ip = TeuthologyOpenStack.get_unassociated_floating_ip()
         assert expected == ip
         ip_id = TeuthologyOpenStack.get_floating_ip_id(ip)
-        misc.sh("openstack ip floating delete " + ip_id)
+        misc.sh("openstack -q ip floating delete " + ip_id)

--- a/teuthology/provision/openstack.py
+++ b/teuthology/provision/openstack.py
@@ -75,7 +75,7 @@ class ProvisionOpenStack(OpenStack):
             with safe_while(sleep=2, tries=100,
                             action="volume " + volume_name) as proceed:
                 while proceed():
-                    r = misc.sh("openstack volume show  -f json " +
+                    r = misc.sh("openstack -q volume show  -f json " +
                                 volume_name)
                     status = self.get_value(json.loads(r), 'status')
                     if status == 'available':


### PR DESCRIPTION
Because they are concatenated with the STDOUT by the sh function despite
being output on STDERR and that breaks json parsing.

Fixes: http://tracker.ceph.com/issues/16972

Signed-off-by: Loic Dachary <ldachary@redhat.com>