### PR TITLE
Revert "misc.sh(): Don't capture stderr by default"

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1331,21 +1331,19 @@ def is_in_dict(searchkey, searchval, d):
         return searchval == val
 
 
-def sh(command, log_limit=1024, include_stderr=False):
+def sh(command, log_limit=1024):
     """
-    Run the shell command and return the output in ascii (stdout and optionally
-    stderr). If the command fails, raise an exception. The command and its
-    output are logged, on success and on error.
+    Run the shell command and return the output in ascii (stderr and
+    stdout).  If the command fails, raise an exception. The command
+    and its output are logged, on success and on error.
     """
     log.debug(":sh: " + command)
     proc = subprocess.Popen(
         args=command,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT if include_stderr else subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         shell=True,
         bufsize=1)
-    if include_stderr is False:
-        log.debug("stderr: %s", proc.stderr.read())
     lines = []
     truncated = False
     with proc.stdout:

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -34,9 +34,8 @@ def test_sh_fail(caplog):
             assert ('replay full' in record.message or
                     'ABC\n' == record.message)
 
-
 def test_sh_progress(caplog):
-    misc.sh("echo AB ; sleep 5 ; /bin/echo C", 2, include_stderr=True) == "ABC\n"
+    misc.sh("echo AB ; sleep 5 ; /bin/echo C", 2) == "ABC\n"
     records = caplog.records()
     assert ':sh: ' in records[0].message
     assert 'AB' == records[1].message
@@ -49,7 +48,6 @@ def test_sh_progress(caplog):
     t1 = datetime.strptime(records[1].asctime.split(',')[0], "%Y-%m-%d %H:%M:%S")
     t2 = datetime.strptime(records[2].asctime.split(',')[0], "%Y-%m-%d %H:%M:%S")
     assert (t2 - t1).total_seconds() > 2
-
 
 def test_wait_until_osds_up():
     ctx = argparse.Namespace()


### PR DESCRIPTION
Reverts ceph/teuthology#925

This PR appears to be causing a deadlock in ``teuthology-nuke --stale-openstack``. I think we should probably merge #927 instead of this one.