### PR TITLE
Python 3 compatibility

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -16,7 +16,7 @@ case "$(uname -s)" in
 Linux)
     case "$(lsb_release --id --short)" in
     Ubuntu|Debian)
-        for package in qemu-utils python-dev libssl-dev python-pip python-virtualenv libev-dev libvirt-dev libmysqlclient-dev libffi-dev libyaml-dev ; do
+        for package in qemu-utils python-dev python3-dev libssl-dev python-pip python-virtualenv libev-dev libvirt-dev libmysqlclient-dev libffi-dev libyaml-dev ; do
             if [ "$(dpkg --status -- $package|sed -n 's/^Status: //p')" != "install ok installed" ]; then
                 # add a space after old values
                 missing="${missing:+$missing }$package"
@@ -36,7 +36,7 @@ Linux)
         fi
         ;;
     RedHatEnterpriseWorkstation|RedHatEnterpriseServer)
-        for package in python-pip python-virtualenv mariadb-devel libev-devel libvirt-devel libffi-devel; do
+        for package in python-devel python34-devel python-pip python-virtualenv mariadb-devel libev-devel libvirt-devel libffi-devel; do
 	    if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
 		missing="${missing:+$missing }$package"
 	    fi
@@ -55,7 +55,7 @@ Linux)
 	fi
 	;;
     Fedora)
-        for package in python-pip python-virtualenv libev-devel libvirt-devel community-mysql-devel libffi-devel; do
+        for package in python-devel python3-devel python-pip python-virtualenv libev-devel libvirt-devel community-mysql-devel libffi-devel; do
 	    if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
 		missing="${missing:+$missing }$package"
 	    fi
@@ -79,7 +79,7 @@ Linux)
 	fi
 	;;
     "openSUSE project"|"SUSE LINUX")
-        for package in python-pip python-devel python-virtualenv libev-devel libvirt-devel libmysqlclient-devel libffi-devel; do
+        for package in python-devel python3-devel python-pip python-virtualenv libev-devel libvirt-devel libmysqlclient-devel libffi-devel; do
             if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
                 if [ "$(rpm -q --whatprovides $package)" == "no package provides $package" ]; then
                     missing="${missing:+$missing }$package"
@@ -103,7 +103,7 @@ Darwin)
         echo "You need Homebrew: http://brew.sh/"
         exit 1
     fi
-    for keg in python libvirt libev mysql libffi; do
+    for keg in python python3 libvirt libev mysql libffi; do
         if brew list $keg >/dev/null 2>&1; then
             echo "Found $keg"
         else
@@ -118,7 +118,7 @@ Darwin)
 esac
 
 # Forcibly remove old virtualenvs which used system site-packages
-if [ -e ./virtualenv ]  && [ ! -e ./virtualenv/lib/python2.7/no-global-site-packages.txt ]; then
+if [ -e ./virtualenv ]  && [ ! -e ./virtualenv/lib/python*/no-global-site-packages.txt ]; then
     echo "Removing old virtualenv because it uses system site-packages"
     rm -rf ./virtualenv
 fi

--- a/scripts/test/script.py
+++ b/scripts/test/script.py
@@ -8,7 +8,7 @@ class Script(object):
     def test_help(self):
         args = (self.script_name, '--help')
         out = subprocess.check_output(args)
-        assert out.startswith('usage')
+        assert out.startswith(b'usage')
 
     def test_invalid(self):
         args = (self.script_name, '--invalid-option')

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
                       'configparser',
                       'pytest',
                       'pytest-capturelog',
-                      'mock',
+                      'mock >= 1.1.0',
                       'fudge',
                       'ansible>=2.0',
                       'pyopenssl>=0.13',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 import re
+import sys
 
 module_file = open("teuthology/__init__.py").read()
 metadata = dict(re.findall(r"__([a-z]+)__\s*=\s*['\"]([^'\"]*)['\"]", module_file))
@@ -51,10 +52,10 @@ setup(
     install_requires=['setuptools',
                       'gevent',
                       # For teuthology-coverage
-                      'MySQL-python == 1.2.3',
+                      'MySQL-python == 1.2.3' if sys.version_info < (3,) else 'mysqlclient',
                       'PyYAML',
                       'argparse >= 1.2.1',
-                      'beanstalkc >= 0.2.0',
+                      'beanstalkc >= 0.2.0' if sys.version_info < (3,) else 'pystalkd',
                       'boto >= 2.0b4',
                       'bunch >= 1.0.0',
                       'configobj',
@@ -64,7 +65,6 @@ setup(
                       'pexpect',
                       'requests',
                       'raven',
-                      'web.py',
                       'docopt',
                       'psutil >= 2.1.0',
                       'configparser',
@@ -88,7 +88,7 @@ setup(
                       'prettytable',
                       'libvirt-python',
                       'python-dateutil',
-                      ],
+                      ] + (['web.py'] if sys.version_info < (3,) else []),
 
 
     # to find the code associated with entry point

--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -18,15 +18,17 @@ import logging
 import os
 import subprocess
 
+from .compat import stringify
+
 __version__ = '1.0.0'
 
 # do our best, but if it fails, continue with above
 
 try:
-    __version__ += '-' + subprocess.check_output(
+    __version__ += '-' + stringify(subprocess.check_output(
         'git rev-parse --short HEAD'.split(),
         cwd=os.path.dirname(os.path.realpath(__file__))
-    ).strip()
+    ).strip())
 except Exception as e:
     # before logging; should be unusual
     print('Can\'t get version from git rev-parse', e, file=sys.stderr)

--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from gevent import monkey
 monkey.patch_all(
     dns=False,
@@ -27,7 +29,7 @@ try:
     ).strip()
 except Exception as e:
     # before logging; should be unusual
-    print >>sys.stderr, 'Can\'t get version from git rev-parse', e
+    print('Can\'t get version from git rev-parse', e, file=sys.stderr)
 
 # If we are running inside a virtualenv, ensure we have its 'bin' directory in
 # our PATH. This doesn't happen automatically if scripts are called without

--- a/teuthology/beanstalk.py
+++ b/teuthology/beanstalk.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import beanstalkc
 import yaml
 import logging
@@ -109,17 +110,17 @@ class JobPrinter(JobProcessor):
         job_priority = job_config['priority']
         job_name = job_config['name']
         job_desc = job_config['description']
-        print 'Job: {i:>4} priority: {pri:>4} {job_name}/{job_id}'.format(
+        print('Job: {i:>4} priority: {pri:>4} {job_name}/{job_id}'.format(
             i=job_index,
             pri=job_priority,
             job_id=job_id,
             job_name=job_name,
-            )
+            ))
         if self.full:
             pprint.pprint(job_config)
         elif job_desc and self.show_desc:
             for desc in job_desc.split():
-                print '\t {desc}'.format(desc=desc)
+                print('\t {desc}'.format(desc=desc))
 
 
 class RunPrinter(JobProcessor):
@@ -131,7 +132,7 @@ class RunPrinter(JobProcessor):
         run = self.jobs[job_id]['job_config']['name']
         if run not in self.runs:
             self.runs.append(run)
-            print run
+            print(run)
 
 
 class JobDeleter(JobProcessor):
@@ -147,10 +148,10 @@ class JobDeleter(JobProcessor):
     def process_job(self, job_id):
         job_config = self.jobs[job_id]['job_config']
         job_name = job_config['name']
-        print 'Deleting {job_name}/{job_id}'.format(
+        print('Deleting {job_name}/{job_id}'.format(
             job_id=job_id,
             job_name=job_name,
-            )
+            ))
         job_obj = self.jobs[job_id].get('job_obj')
         if job_obj:
             job_obj.delete()
@@ -196,7 +197,7 @@ def main(args):
             # it is not needed for pausing tubes
             watch_tube(connection, machine_type)
         if status:
-            print stats_tube(connection, machine_type)
+            print(stats_tube(connection, machine_type))
         elif pause_duration:
             pause_tube(connection, machine_type, pause_duration)
         elif delete:

--- a/teuthology/beanstalk.py
+++ b/teuthology/beanstalk.py
@@ -1,10 +1,14 @@
 from __future__ import print_function
-import beanstalkc
-import yaml
 import logging
 import pprint
 import sys
 from collections import OrderedDict
+
+import yaml
+try:
+    import beanstalkc
+except ImportError:
+    import pystalkd.Beanstalkd as beanstalkc
 
 from .config import config
 from . import report

--- a/teuthology/compat.py
+++ b/teuthology/compat.py
@@ -1,0 +1,23 @@
+# flake8: noqa
+
+try:
+    from cStringIO import StringIO
+    BytesIO = StringIO
+    from StringIO import StringIO as PyStringIO
+    PyBytesIO = PyStringIO
+except ImportError:
+    from io import StringIO, BytesIO
+    PyStringIO = StringIO
+    PyBytesIO = BytesIO
+
+from io import StringIO as TextIO
+
+
+if str is bytes:
+    def stringify(s):
+        return s
+else:
+    def stringify(s):
+        if isinstance(s, bytes):
+            return s.decode('utf-8', 'replace')
+        return s

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -31,7 +31,7 @@ class YamlConfig(collections.MutableMapping):
 
     def load(self):
         if os.path.exists(self.yaml_path):
-            self._conf = yaml.safe_load(file(self.yaml_path))
+            self._conf = yaml.safe_load(open(self.yaml_path))
         else:
             log.debug("%s not found", self.yaml_path)
             self._conf = dict()
@@ -209,7 +209,7 @@ class FakeNamespace(YamlConfig):
         correctly.
         """
         result = dict()
-        for key, value in config_dict.iteritems():
+        for key, value in config_dict.items():
             new_key = key
             if new_key.startswith("--"):
                 new_key = new_key[2:]

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -3,6 +3,8 @@ import yaml
 import logging
 import collections
 
+from teuthology.compat import stringify
+
 
 def init_logging():
     log = logging.getLogger(__name__)
@@ -84,7 +86,7 @@ class YamlConfig(collections.MutableMapping):
         return self._conf.get(key, default)
 
     def __str__(self):
-        return yaml.safe_dump(self._conf, default_flow_style=False).strip()
+        return stringify(yaml.safe_dump(self._conf, default_flow_style=False)).strip()
 
     def __repr__(self):
         return self.__str__()

--- a/teuthology/contextutil.py
+++ b/teuthology/contextutil.py
@@ -4,6 +4,8 @@ import logging
 import time
 import itertools
 
+from six import reraise
+
 from .config import config
 from .exceptions import MaxWhileTries
 
@@ -51,7 +53,7 @@ def nested(*managers):
             # Don't rely on sys.exc_info() still containing
             # the right information. Another exception may
             # have been raised and caught by an exit method
-            raise exc[0], exc[1], exc[2]
+            reraise(*exc)
 
 
 class safe_while(object):
@@ -66,7 +68,7 @@ class safe_while(object):
         >>> with safe_while() as proceed:
         ...    while proceed():
         ...        # repetitive code here
-        ...        print "hello world"
+        ...        print("hello world")
         ...
         Traceback (most recent call last):
         ...

--- a/teuthology/coverage.py
+++ b/teuthology/coverage.py
@@ -7,6 +7,7 @@ import MySQLdb
 import yaml
 
 import teuthology
+from teuthology.compat import stringify
 from teuthology.config import config
 
 log = logging.getLogger(__name__)
@@ -171,7 +172,7 @@ def analyze(test_dir, cov_tools_dir, lcov_output, html_output, skip_init):
         )
         output, _ = proc.communicate()
         desc = summary.get('description', test)
-        test_coverage[desc] = read_coverage(output)
+        test_coverage[desc] = read_coverage(stringify(output))
 
         log.info('adding %s data to total', test)
         proc = subprocess.Popen(
@@ -190,7 +191,7 @@ def analyze(test_dir, cov_tools_dir, lcov_output, html_output, skip_init):
             os.path.join(lcov_output, 'total.lcov')
         )
 
-    coverage = read_coverage(output)
+    coverage = read_coverage(stringify(output))
     test_coverage['total for {suite}'.format(suite=suite)] = coverage
     log.debug('total coverage is %s', str(coverage))
 

--- a/teuthology/coverage.py
+++ b/teuthology/coverage.py
@@ -46,7 +46,7 @@ def connect_to_db():
 def store_coverage(test_coverage, rev, suite):
     with closing(connect_to_db()) as db:
         rows = []
-        for test, coverage in test_coverage.iteritems():
+        for test, coverage in test_coverage.items():
             flattened_cov = [item for sublist in coverage for item in sublist]
             rows.append([rev, test, suite] + flattened_cov)
         log.debug('inserting rows into db: %s', str(rows))
@@ -122,7 +122,7 @@ def analyze(test_dir, cov_tools_dir, lcov_output, html_output, skip_init):
     test_summaries = {}
     for test in tests:
         summary = {}
-        with file(os.path.join(test_dir, test, 'summary.yaml')) as f:
+        with open(os.path.join(test_dir, test, 'summary.yaml')) as f:
             g = yaml.safe_load_all(f)
             for new in g:
                 summary.update(new)
@@ -156,7 +156,7 @@ def analyze(test_dir, cov_tools_dir, lcov_output, html_output, skip_init):
         )
 
     test_coverage = {}
-    for test, summary in test_summaries.iteritems():
+    for test, summary in test_summaries.items():
         lcov_file = '{name}.lcov'.format(name=test)
 
         log.info('analyzing coverage for %s', test)

--- a/teuthology/describe_tests.py
+++ b/teuthology/describe_tests.py
@@ -7,6 +7,9 @@ from prettytable import PrettyTable, FRAME, ALL
 import os
 import sys
 import yaml
+# Directly imported for easy patching
+from os import listdir
+from os.path import isdir
 
 from teuthology.exceptions import ParseError
 from teuthology.suite.build_matrix import build_matrix, combine_path
@@ -195,7 +198,7 @@ def extract_info(file_name, fields):
     message and raises ParseError.
     """
     empty_result = {f: '' for f in fields}
-    if os.path.isdir(file_name) or not file_name.endswith('.yaml'):
+    if isdir(file_name) or not file_name.endswith('.yaml'):
         return empty_result
 
     with open(file_name, 'r') as f:
@@ -240,7 +243,7 @@ def tree_with_info(cur_dir, fields, include_facet, prefix, rows,
     3) the values of the provided fields in the path ('' is used for
        missing values) in the same order as the provided fields
     """
-    files = sorted(os.listdir(cur_dir))
+    files = sorted(listdir(cur_dir))
     has_yamls = any([x.endswith('.yaml') for x in files])
     facet = os.path.basename(cur_dir) if has_yamls else ''
     for i, f in enumerate(files):
@@ -260,7 +263,7 @@ def tree_with_info(cur_dir, fields, include_facet, prefix, rows,
         if include_facet:
             row.append(facet)
         rows.append(row + meta)
-        if os.path.isdir(path):
+        if isdir(path):
             tree_with_info(path, fields, include_facet,
                            prefix + dir_pad, rows, output_format)
     return rows

--- a/teuthology/describe_tests.py
+++ b/teuthology/describe_tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import csv
 import json
@@ -207,9 +208,9 @@ def extract_info(file_name, fields):
     if not (isinstance(meta, list) and
             len(meta) == 1 and
             isinstance(meta[0], dict)):
-        print 'Error in meta format in', file_name
-        print 'Meta must be a list containing exactly one dict.'
-        print 'Meta is:', meta
+        print('Error in meta format in', file_name)
+        print('Meta must be a list containing exactly one dict.')
+        print('Meta is:', meta)
         raise ParseError()
 
     return {field: meta[0].get(field, '') for field in fields}

--- a/teuthology/describe_tests.py
+++ b/teuthology/describe_tests.py
@@ -35,7 +35,7 @@ def describe_tests(args):
             filter_out = [f.strip() for f in args['--filter-out'].split(',')]
         subset = None
         if args['--subset']:
-            subset = map(int, args['--subset'].split('/'))
+            subset = [int(args) for arg in args['--subset'].split('/')]
         headers, rows = get_combinations(suite_dir, fields, subset,
                                          limit, filter_in,
                                          filter_out, include_facet)

--- a/teuthology/kill.py
+++ b/teuthology/kill.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import os
 import sys
 import yaml
@@ -143,7 +144,7 @@ def remove_beanstalk_jobs(run_name, tube_name):
                 log.info(msg)
                 job.delete()
     else:
-        print "No jobs in Beanstalk Queue"
+        print("No jobs in Beanstalk Queue")
     beanstalk_conn.close()
 
 

--- a/teuthology/kill.py
+++ b/teuthology/kill.py
@@ -90,7 +90,7 @@ def find_run_info(serializer, run_name):
     job_num = 0
     jobs = serializer.jobs_for_run(run_name)
     job_total = len(jobs)
-    for (job_id, job_dir) in jobs.iteritems():
+    for (job_id, job_dir) in jobs.items():
         if not os.path.isdir(job_dir):
             continue
         job_num += 1

--- a/teuthology/kill.py
+++ b/teuthology/kill.py
@@ -9,6 +9,7 @@ import tempfile
 import logging
 import getpass
 
+from teuthology.compat import stringify
 from . import beanstalk
 from . import report
 from .config import config
@@ -223,7 +224,7 @@ def nuke_targets(targets_dict, owner):
         to_nuke.append(misc.decanonicalize_hostname(target))
 
     target_file = tempfile.NamedTemporaryFile(delete=False)
-    target_file.write(yaml.safe_dump(targets_dict))
+    target_file.write(yaml.safe_dump(targets_dict, encoding='utf-8'))
     target_file.close()
 
     log.info("Nuking machines: " + str(to_nuke))
@@ -240,9 +241,9 @@ def nuke_targets(targets_dict, owner):
         nuke_args,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    for line in iter(proc.stdout.readline, ''):
-        line = line.replace('\r', '').replace('\n', '')
-        log.info(line)
+    for line in iter(proc.stdout.readline, b''):
+        line = line.rstrip()
+        log.info(stringify(line))
         sys.stdout.flush()
 
     os.unlink(target_file.name)

--- a/teuthology/lock.py
+++ b/teuthology/lock.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import datetime
 import json
@@ -278,22 +279,22 @@ def main(ctx):
                 if vm_host_name:
                     s['vm_host'] = vm_host_name
             if ctx.list:
-                    print json.dumps(statuses, indent=4)
+                    print(json.dumps(statuses, indent=4))
 
             elif ctx.brief:
                 for s in sorted(statuses, key=lambda s: s.get('name')):
                     locked = "un" if s['locked'] == 0 else "  "
                     mo = re.match('\w+@(\w+?)\..*', s['name'])
                     host = mo.group(1) if mo else s['name']
-                    print '{host} {locked}locked {owner} "{desc}"'.format(
+                    print('{host} {locked}locked {owner} "{desc}"'.format(
                         locked=locked, host=host,
-                        owner=s['locked_by'], desc=s['description'])
+                        owner=s['locked_by'], desc=s['description']))
 
             else:
                 frag = {'targets': {}}
                 for f in statuses:
                     frag['targets'][f['name']] = f['ssh_pub_key']
-                print yaml.safe_dump(frag, default_flow_style=False)
+                print(yaml.safe_dump(frag, default_flow_style=False))
         else:
             log.error('error retrieving lock statuses')
             ret = 1
@@ -359,9 +360,9 @@ def main(ctx):
                         "these machines come up.",
                         shortnames)
             else:
-                print yaml.safe_dump(
+                print(yaml.safe_dump(
                     dict(targets=result),
-                    default_flow_style=False)
+                    default_flow_style=False))
     elif ctx.update:
         assert ctx.desc is not None or ctx.status is not None, \
             'you must specify description or status to update'
@@ -746,15 +747,15 @@ def do_summary(ctx):
     locks = sorted([p for p in lockd.iteritems()
                     ], key=lambda sort: (sort[1][2], sort[1][0]))
     total_count, total_up = 0, 0
-    print "TYPE     COUNT  UP  OWNER"
+    print("TYPE     COUNT  UP  OWNER")
 
     for (owner, (count, upcount, machinetype)) in locks:
             # if machinetype == spectype:
-            print "{machinetype:8s} {count:3d}  {up:3d}  {owner}".format(
+            print("{machinetype:8s} {count:3d}  {up:3d}  {owner}".format(
                 count=count, up=upcount, owner=owner[0],
-                machinetype=machinetype)
+                machinetype=machinetype))
             total_count += count
             total_up += upcount
 
-    print "         ---  ---"
-    print "{cnt:12d}  {up:3d}".format(cnt=total_count, up=total_up)
+    print("         ---  ---")
+    print("{cnt:12d}  {up:3d}".format(cnt=total_count, up=total_up))

--- a/teuthology/ls.py
+++ b/teuthology/ls.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import yaml
 import errno
@@ -26,15 +27,15 @@ def ls(archive_dir, verbose):
             else:
                 raise
 
-        print "{job} {status} {owner} {desc} {duration}s".format(
+        print("{job} {status} {owner} {desc} {duration}s".format(
             job=j,
             owner=summary.get('owner', '-'),
             desc=summary.get('description', '-'),
             status=get_status(summary),
             duration=int(summary.get('duration', 0)),
-        )
+        ))
         if verbose and 'failure_reason' in summary:
-            print '    {reason}'.format(reason=summary['failure_reason'])
+            print('    {reason}'.format(reason=summary['failure_reason']))
 
 
 def get_jobs(archive_dir):
@@ -51,7 +52,7 @@ def get_jobs(archive_dir):
 
 
 def print_debug_info(job, job_dir, archive_dir):
-    print '%s      ' % job,
+    print('%s      ' % job, end='')
 
     try:
         pidfile = os.path.join(job_dir, 'pid')
@@ -62,15 +63,15 @@ def print_debug_info(job, job_dir, archive_dir):
                 cmdline = open('/proc/%s/cmdline' % pid,
                                'r').read()
                 if cmdline.find(archive_dir) >= 0:
-                    print '(pid %s)' % pid,
+                    print('(pid %s)' % pid, end='')
                     found = True
         if not found:
-            print '(no process or summary.yaml)',
+            print('(no process or summary.yaml)', end='')
         # tail
         tail = os.popen(
             'tail -1 %s/%s/teuthology.log' % (archive_dir, job)
         ).read().rstrip()
-        print tail,
+        print(tail, end='')
     except IOError:
         pass
-    print ''
+    print()

--- a/teuthology/ls.py
+++ b/teuthology/ls.py
@@ -16,7 +16,7 @@ def ls(archive_dir, verbose):
         job_dir = os.path.join(archive_dir, j)
         summary = {}
         try:
-            with file(os.path.join(job_dir, 'summary.yaml')) as f:
+            with open(os.path.join(job_dir, 'summary.yaml')) as f:
                 g = yaml.safe_load_all(f)
                 for new in g:
                     summary.update(new)

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -22,6 +22,8 @@ import re
 import tempfile
 import pprint
 
+from six import reraise
+
 from teuthology import safepath
 from teuthology.exceptions import (CommandCrashedError, CommandFailedError,
                                    ConnectionLostError)
@@ -1210,7 +1212,7 @@ def stop_daemons_of_type(ctx, type_, cluster='ceph'):
             exc_info = sys.exc_info()
             log.exception('Saw exception from %s.%s', daemon.role, daemon.id_)
     if exc_info != (None, None, None):
-        raise exc_info[0], exc_info[1], exc_info[2]
+        reraise(*exc_info)
 
 
 def get_system_type(remote, distro=False, version=False):

--- a/teuthology/nuke.py
+++ b/teuthology/nuke.py
@@ -8,8 +8,8 @@ import time
 import yaml
 
 import teuthology
+import teuthology.orchestra.remote
 from . import orchestra
-import orchestra.remote
 from .openstack import OpenStack, OpenStackInstance, enforce_json_dictionary
 from .orchestra import run
 from .config import config, FakeNamespace

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -61,7 +61,7 @@ class OpenStackInstance(object):
         if info is None:
             self.set_info()
         else:
-            self.info = dict(map(lambda (k,v): (k.lower(), v), info.iteritems()))
+            self.info = dict((k.lower(), v) for k, v in info.iteritems())
 
     def set_info(self):
         try:

--- a/teuthology/openstack/test/openstack-integration.py
+++ b/teuthology/openstack/test/openstack-integration.py
@@ -38,6 +38,7 @@ import teuthology.openstack
 import scripts.schedule
 import scripts.lock
 import scripts.suite
+from teuthology.compat import stringify
 from teuthology.config import config as teuth_config
 from teuthology.config import set_config_attr
 
@@ -82,8 +83,8 @@ class Integration(object):
             return
 
         (stdoutdata, stderrdata) = self.worker.communicate()
-        stdoutdata = stdoutdata.decode('utf-8')
-        stderrdata = stderrdata.decode('utf-8')
+        stdoutdata = stringify(stdoutdata)
+        stderrdata = stringify(stderrdata)
         logging.info(self.worker_cmd + ":" +
                      " stdout " + stdoutdata +
                      " stderr " + stderrdata + " end ")

--- a/teuthology/openstack/test/openstack-integration.py
+++ b/teuthology/openstack/test/openstack-integration.py
@@ -249,7 +249,7 @@ class TestNuke(Integration):
                         '--machine-type', 'openstack']
 
     def test_nuke(self):
-        image = teuthology.openstack.OpenStack.image2url.keys()[0]
+        image = list(teuthology.openstack.OpenStack.image2url)[0]
 
         (os_type, os_version) = image.split('-')
         args = scripts.lock.parse_args(self.options +

--- a/teuthology/orchestra/cluster.py
+++ b/teuthology/orchestra/cluster.py
@@ -60,7 +60,7 @@ class Cluster(object):
 
         Returns a list of `RemoteProcess`.
         """
-        remotes = sorted(self.remotes.iterkeys(), key=lambda rem: rem.name)
+        remotes = sorted(self.remotes.keys(), key=lambda rem: rem.name)
         return [remote.run(**kwargs) for remote in remotes]
 
     def write_file(self, file_name, content, sudo=False, perms=None, owner=None):
@@ -72,7 +72,7 @@ class Cluster(object):
         :param sudo: use sudo
         :param perms: file permissions (passed to chmod) ONLY if sudo is True
         """
-        remotes = sorted(self.remotes.iterkeys(), key=lambda rem: rem.name)
+        remotes = sorted(self.remotes.keys(), key=lambda rem: rem.name)
         for remote in remotes:
             if sudo:
                 teuthology.misc.sudo_write_file(remote, file_name, content, perms=perms, owner=owner)
@@ -104,7 +104,7 @@ class Cluster(object):
         want = frozenset(r for r in roles if not callable(r))
         matchers = [r for r in roles if callable(r)]
 
-        for remote, has_roles in self.remotes.iteritems():
+        for remote, has_roles in self.remotes.items():
             # strings given as roles must all match
             if frozenset(has_roles) & want != want:
                 # not a match
@@ -129,7 +129,7 @@ class Cluster(object):
         """
         matches = self.only(*roles)
         c = self.__class__()
-        for remote, has_roles in self.remotes.iteritems():
+        for remote, has_roles in self.remotes.items():
             if remote not in matches.remotes:
                 c.add(remote, has_roles)
         return c

--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -29,6 +29,8 @@ def create_key(keytype, key):
     """
     Create an ssh-rsa or ssh-dss key.
     """
+    if not isinstance(key, bytes):
+        key = key.encode('ascii')
     if keytype == 'ssh-rsa':
         return paramiko.rsakey.RSAKey(data=base64.decodestring(key))
     elif keytype == 'ssh-dss':

--- a/teuthology/orchestra/daemon.py
+++ b/teuthology/orchestra/daemon.py
@@ -191,7 +191,7 @@ class DaemonGroup(object):
         :param type_: type of daemon (osd, mds, mon, rgw,  for example)
         """
         role = cluster + '.' + type_
-        return self.daemons.get(role, {}).values()
+        return list(self.daemons.get(role, {}).values())
 
     def resolve_role_list(self, roles, types, cluster_aware=False):
         """

--- a/teuthology/orchestra/monkey.py
+++ b/teuthology/orchestra/monkey.py
@@ -49,8 +49,7 @@ def patch_all():
     """
     Run all the patch_* functions in this module.
     """
-    monkeys = [(k, v) for (k, v) in globals().iteritems() if k.startswith('patch_') and k != 'patch_all']
-    monkeys.sort()
-    for k, v in monkeys:
-        log.debug('Patching %s', k)
-        v()
+    for name, value in sorted(globals().items()):
+        if name.startswith('patch_') and name != 'patch_all':
+            log.debug('Patching %s', name)
+            value()

--- a/teuthology/orchestra/opsys.py
+++ b/teuthology/orchestra/opsys.py
@@ -59,13 +59,13 @@ class OS(object):
 
     @staticmethod
     def _version_to_codename(name, version):
-        for (_version, codename) in DISTRO_CODENAME_MAP[name].iteritems():
+        for (_version, codename) in DISTRO_CODENAME_MAP[name].items():
             if version == _version or version.split('.')[0] == _version:
                 return codename
 
     @staticmethod
     def _codename_to_version(name, codename):
-        for (version, _codename) in DISTRO_CODENAME_MAP[name].iteritems():
+        for (version, _codename) in DISTRO_CODENAME_MAP[name].items():
             if codename == _codename:
                 return version
         raise RuntimeError("No version found for %s %s !" % (

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -1,16 +1,11 @@
 """
 Support for paramiko remote objects.
 """
-from . import run
-from .opsys import OS
-import connection
-from teuthology import misc
 import time
 import pexpect
 import re
 import logging
 from cStringIO import StringIO
-from teuthology import lockstatus as ls
 import os
 import pwd
 import tempfile
@@ -20,6 +15,13 @@ try:
     import libvirt
 except ImportError:
     libvirt = None
+
+from teuthology import misc
+from teuthology import lockstatus as ls
+from . import run
+from .opsys import OS
+from . import connection
+
 
 log = logging.getLogger(__name__)
 
@@ -379,7 +381,7 @@ class Remote(object):
             proc = self.run(
                 args=[
                     'python', '-c',
-                    'import platform; print platform.linux_distribution()'],
+                    'import platform; print(platform.linux_distribution())'],
                 stdout=StringIO(), stderr=StringIO(), check_status=False)
             if proc.exitstatus == 0:
                 self._os = OS.from_python(proc.stdout.getvalue().strip())

--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -11,6 +11,8 @@ import pipes
 import logging
 import shutil
 
+from six import string_types as basestring
+
 from ..contextutil import safe_while
 from ..exceptions import (CommandCrashedError, CommandFailedError,
                           ConnectionLostError)

--- a/teuthology/orchestra/test/integration/test_integration.py
+++ b/teuthology/orchestra/test/integration/test_integration.py
@@ -1,9 +1,8 @@
 from teuthology.orchestra import monkey
 monkey.patch_all()
 
-from cStringIO import StringIO
-
 import os
+from teuthology.compat import BytesIO
 from teuthology.orchestra import connection, remote, run
 from teuthology.orchestra.test.util import assert_raises
 from teuthology.exceptions import CommandCrashedError, ConnectionLostError
@@ -54,27 +53,27 @@ class TestIntegration():
             client=ssh,
             args=['cat'],
             stdin=run.PIPE,
-            stdout=StringIO(),
+            stdout=BytesIO(),
             wait=False,
             )
-        assert r.stdout.getvalue() == ''
-        r.stdin.write('foo\n')
-        r.stdin.write('bar\n')
+        assert r.stdout.getvalue() == b''
+        r.stdin.write(b'foo\n')
+        r.stdin.write(b'bar\n')
         r.stdin.close()
 
         r.wait()
         got = r.exitstatus
         assert got == 0
-        assert r.stdout.getvalue() == 'foo\nbar\n'
+        assert r.stdout.getvalue() == b'foo\nbar\n'
 
     def test_and(self):
         ssh = connection.connect(HOST)
         r = run.run(
             client=ssh,
             args=['true', run.Raw('&&'), 'echo', 'yup'],
-            stdout=StringIO(),
+            stdout=BytesIO(),
             )
-        assert r.stdout.getvalue() == 'yup\n'
+        assert r.stdout.getvalue() == b'yup\n'
 
     def test_os(self):
         rem = remote.Remote(HOST)

--- a/teuthology/orchestra/test/test_remote.py
+++ b/teuthology/orchestra/test/test_remote.py
@@ -1,7 +1,6 @@
 from mock import patch, Mock, MagicMock
 
-from cStringIO import StringIO
-
+from teuthology.compat import BytesIO
 from .. import remote
 from .. import opsys
 from ..run import RemoteProcess
@@ -74,7 +73,7 @@ class TestRemote(object):
             'hostname',
             '--fqdn',
             ]
-        stdout = StringIO('test_hostname')
+        stdout = BytesIO(b'test_hostname')
         stdout.seek(0)
         proc = RemoteProcess(
             client=self.m_ssh,
@@ -97,7 +96,7 @@ class TestRemote(object):
             'uname',
             '-m',
             ]
-        stdout = StringIO('test_arch')
+        stdout = BytesIO(b'test_arch')
         stdout.seek(0)
         proc = RemoteProcess(
             client=self.m_ssh,
@@ -116,7 +115,7 @@ class TestRemote(object):
         assert m_run.called_once_with(
             client=self.m_ssh,
             args=args,
-            stdout=StringIO(),
+            stdout=BytesIO(),
             name=r.shortname,
         )
         assert r.arch == 'test_arch'

--- a/teuthology/orchestra/test/util.py
+++ b/teuthology/orchestra/test/util.py
@@ -4,7 +4,7 @@ def assert_raises(excClass, callableObj, *args, **kwargs):
     """
     try:
         callableObj(*args, **kwargs)
-    except excClass, e:
+    except excClass as e:
         return e
     else:
         if hasattr(excClass,'__name__'): excName = excClass.__name__

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -658,8 +658,7 @@ class GitbuilderProject(object):
         def warn(attrname):
             names = ('ref', 'tag', 'branch', 'sha1')
             vars = (ref, tag, branch, sha1)
-            # filter(None,) filters for truth
-            if len(filter(None, vars)) > 1:
+            if len([v for v in vars if v]) > 1:
                 log.warning(
                     'More than one of ref, tag, branch, or sha1 supplied; using %s',
                      attrname

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -134,7 +134,7 @@ def get_koji_task_result(task_id, remote, ctx):
     """
     py_cmd = ('import koji; '
               'hub = koji.ClientSession("{kojihub_url}"); '
-              'print hub.getTaskResult({task_id})')
+              'print(hub.getTaskResult({task_id}))')
     py_cmd = py_cmd.format(
         task_id=task_id,
         kojihub_url=config.kojihub_url
@@ -254,7 +254,7 @@ def get_koji_build_info(build_id, remote, ctx):
     """
     py_cmd = ('import koji; '
               'hub = koji.ClientSession("{kojihub_url}"); '
-              'print hub.getBuild({build_id})')
+              'print(hub.getBuild({build_id}))')
     py_cmd = py_cmd.format(
         build_id=build_id,
         kojihub_url=config.kojihub_url

--- a/teuthology/parallel.py
+++ b/teuthology/parallel.py
@@ -93,7 +93,7 @@ class parallel(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         if not self.any_spawned or self.iteration_stopped:
             raise StopIteration()
         result = self.results.get()
@@ -105,6 +105,8 @@ class parallel(object):
             raise
 
         return result
+
+    next = __next__
 
     def _finish(self, greenlet):
         if greenlet.successful():

--- a/teuthology/parallel.py
+++ b/teuthology/parallel.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from six import reraise
 import gevent.pool
 import gevent.queue
 
@@ -28,7 +29,7 @@ def resurrect_traceback(exc):
     else:
         return
 
-    raise exc_info[0], exc_info[1], exc_info[2]
+    reraise(*exc_info)
 
 class parallel(object):
     """
@@ -46,7 +47,7 @@ class parallel(object):
             for foo in bar:
                 p.spawn(quux, foo, baz=True)
             for result in p:
-                print result
+                print(result)
 
     If one of the spawned functions throws an exception, it will be thrown
     when iterating over the results, or when the with block ends.

--- a/teuthology/provision/downburst.py
+++ b/teuthology/provision/downburst.py
@@ -4,6 +4,7 @@ import subprocess
 import tempfile
 import yaml
 
+from ..compat import stringify
 from ..config import config
 from ..contextutil import safe_while
 from ..misc import decanonicalize_hostname
@@ -71,13 +72,13 @@ class Downburst(object):
             while proceed():
                 (returncode, stdout, stderr) = self._run_create()
                 if returncode == 0:
-                    log.info("Downburst created %s: %s" % (self.name,
-                                                           stdout.strip()))
+                    log.info("Downburst created %s: %s" % (self.name, stringify(
+                                                           stdout.strip())))
                     success = True
                     break
                 elif stderr:
                     # If the guest already exists first destroy then re-create:
-                    if 'exists' in stderr:
+                    if b'exists' in stderr:
                         success = False
                         log.info("Guest files exist. Re-creating guest: %s" %
                                  (self.name))
@@ -85,7 +86,7 @@ class Downburst(object):
                     else:
                         success = False
                         log.info("Downburst failed on %s: %s" % (
-                            self.name, stderr.strip()))
+                            self.name, stringify(stderr.strip())))
                         break
             return success
 
@@ -170,7 +171,7 @@ class Downburst(object):
             'downburst': file_info,
             'local-hostname': fqdn,
         }
-        yaml.safe_dump(file_out, config_fd)
+        yaml.safe_dump(file_out, config_fd, encoding='utf-8')
         self.config_path = config_fd.name
 
         user_info = {
@@ -195,7 +196,7 @@ class Downburst(object):
                 'python',
             ])
         user_fd = tempfile.NamedTemporaryFile(delete=False)
-        yaml.safe_dump(user_info, user_fd)
+        yaml.safe_dump(user_info, user_fd, encoding='utf-8')
         self.user_path = user_fd.name
         return True
 

--- a/teuthology/provision/openstack.py
+++ b/teuthology/provision/openstack.py
@@ -135,9 +135,8 @@ class ProvisionOpenStack(OpenStack):
             if "quota exceeded" in exc.output.lower():
                 raise QuotaExceededError(message=exc.output)
             raise
-        instances = filter(
-            lambda instance: self.property in instance['Properties'],
-            self.list_instances())
+        instances = [inst for inst in self.list_instances()
+                     if self.property in inst['Properties']]
         instances = [OpenStackInstance(i['ID']) for i in instances]
         fqdns = []
         try:

--- a/teuthology/prune.py
+++ b/teuthology/prune.py
@@ -37,10 +37,7 @@ def prune_archive(archive_dir, pass_days, remotes_days, dry_run=False):
     log.debug("Archive {archive} has {count} children".format(
         archive=archive_dir, count=len(os.listdir(archive_dir))))
     # Use full paths
-    children = map(
-        lambda p: os.path.join(archive_dir, p),
-        listdir(archive_dir)
-    )
+    children = [os.path.join(archive_dir, p) for p in listdir(archive_dir)]
     run_dirs = list()
     for child in children:
         # Ensure that the path is not a symlink, is a directory, and is old
@@ -123,7 +120,7 @@ def maybe_remove_passes(run_dir, days, dry_run=False):
             continue
         # Is it a passed job?
         summary_lines = [line.strip() for line in
-                         file(summary_path).readlines()]
+                         open(summary_path).readlines()]
         if 'success: true' in summary_lines:
             log.info("{job} is a {days}-day old passed job; removing".format(
                 job=item, days=days))
@@ -152,7 +149,7 @@ def maybe_remove_remotes(run_dir, days, dry_run=False):
         if (should_preserve(item) or not os.path.isdir(item) or not
                 is_old_enough(item, days)):
             continue
-        for (subdir, description) in subdirs.iteritems():
+        for (subdir, description) in subdirs.items():
             _maybe_remove_subdir(item, subdir, days, description, dry_run)
 
 

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import time
 
+from teuthology.compat import stringify
 from .config import config
 from .contextutil import safe_while, MaxWhileTries
 from .exceptions import BootstrapError, BranchNotFoundError, GitError
@@ -87,7 +88,7 @@ def clone_repo(repo_url, dest_path, branch):
         stderr=subprocess.STDOUT)
 
     not_found_str = "Remote branch %s not found" % branch
-    out = proc.stdout.read()
+    out = stringify(proc.stdout.read())
     result = proc.wait()
     # Newer git versions will bail if the branch is not found, but older ones
     # will not. Fortunately they both output similar text.
@@ -117,7 +118,7 @@ def set_remote(repo_path, repo_url):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
     if proc.wait() != 0:
-        out = proc.stdout.read()
+        out = stringify(proc.stdout.read())
         log.error(out)
         raise GitError("git remote set-url failed!")
 
@@ -136,7 +137,7 @@ def fetch(repo_path):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
     if proc.wait() != 0:
-        out = proc.stdout.read()
+        out = stringify(proc.stdout.read())
         log.error(out)
         raise GitError("git fetch failed!")
 
@@ -159,7 +160,7 @@ def fetch_branch(repo_path, branch):
         stderr=subprocess.STDOUT)
     if proc.wait() != 0:
         not_found_str = "fatal: Couldn't find remote ref %s" % branch
-        out = proc.stdout.read()
+        out = stringify(proc.stdout.read())
         log.error(out)
         if not_found_str in out:
             raise BranchNotFoundError(branch)
@@ -282,7 +283,7 @@ def bootstrap_teuthology(dest_path):
         log.info("Bootstrap exited with status %s", returncode)
         if returncode != 0:
             for line in boot_proc.stdout.readlines():
-                log.warn(line.strip())
+                log.warn(stringify(line.strip()))
             venv_path = os.path.join(dest_path, 'virtualenv')
             log.info("Removing %s", venv_path)
             shutil.rmtree(venv_path, ignore_errors=True)

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -299,7 +299,7 @@ class FileLock(object):
     def __enter__(self):
         if not self.noop:
             assert self.file is None
-            self.file = file(self.filename, 'w')
+            self.file = open(self.filename, 'w')
             fcntl.lockf(self.file, fcntl.LOCK_EX)
         return self
 

--- a/teuthology/report.py
+++ b/teuthology/report.py
@@ -91,7 +91,7 @@ class ResultsSerializer(object):
             yaml_path = os.path.join(job_archive_dir, yaml_name)
             if not os.path.exists(yaml_path):
                 continue
-            with file(yaml_path) as yaml_file:
+            with open(yaml_path) as yaml_file:
                 partial_info = yaml.safe_load(yaml_file)
                 if partial_info is not None:
                     job_info.update(partial_info)
@@ -157,7 +157,7 @@ class ResultsSerializer(object):
         :returns:        A dict like: {'1': '/path/to/1', '2': 'path/to/2'}
         """
         jobs = self.jobs_for_run(run_name)
-        for job_id in jobs.keys():
+        for job_id in list(jobs):
             if os.path.exists(os.path.join(jobs[job_id], 'summary.yaml')):
                 jobs.pop(job_id)
         return jobs
@@ -329,14 +329,14 @@ class ResultsReporter(object):
         if hasattr(self, '__last_run'):
             return self.__last_run
         elif os.path.exists(self.last_run_file):
-            with file(self.last_run_file) as f:
+            with open(self.last_run_file) as f:
                 self.__last_run = f.read().strip()
             return self.__last_run
 
     @last_run.setter
     def last_run(self, run_name):
         self.__last_run = run_name
-        with file(self.last_run_file, 'w') as f:
+        with open(self.last_run_file, 'w') as f:
             f.write(run_name)
 
     @last_run.deleter

--- a/teuthology/report.py
+++ b/teuthology/report.py
@@ -1,11 +1,13 @@
 import os
-import yaml
 import json
 import re
 import requests
 import logging
 import socket
 from datetime import datetime
+
+import yaml
+from six import string_types as basestring
 
 import teuthology
 from .config import config

--- a/teuthology/results.py
+++ b/teuthology/results.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import time
@@ -59,10 +60,10 @@ def results(archive_dir, name, email, timeout, dry_run):
 
     try:
         if email and dry_run:
-            print "From: %s" % (config.results_sending_email or 'teuthology')
-            print "To: %s" % email
-            print "Subject: %s" % subject
-            print body
+            print("From: %s" % (config.results_sending_email or 'teuthology'))
+            print("To: %s" % email)
+            print("Subject: %s" % subject)
+            print(body)
         elif email:
             email_results(
                 subject=subject,

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -223,7 +223,7 @@ def get_initial_tasks(lock, config, machine_type):
         init_tasks.extend([
             {'pcp': None},
             {'selinux': None},
-            #{'ansible.cephlab': None},
+            {'ansible.cephlab': None},
             {'clock.check': None}
         ])
 

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -35,7 +35,7 @@ def set_up_logging(verbose, archive):
 def install_except_hook():
     def log_exception(exception_class, exception, traceback):
         logging.critical(''.join(format_tb(traceback)))
-        if not exception.message:
+        if not str(exception):
             logging.critical(exception_class.__name__)
             return
         logging.critical('{0}: {1}'.format(
@@ -46,13 +46,13 @@ def install_except_hook():
 
 def write_initial_metadata(archive, config, name, description, owner):
     if archive is not None:
-        with file(os.path.join(archive, 'pid'), 'w') as f:
+        with open(os.path.join(archive, 'pid'), 'w') as f:
             f.write('%d' % os.getpid())
 
-        with file(os.path.join(archive, 'owner'), 'w') as f:
+        with open(os.path.join(archive, 'owner'), 'w') as f:
             f.write(owner + '\n')
 
-        with file(os.path.join(archive, 'orig.config.yaml'), 'w') as f:
+        with open(os.path.join(archive, 'orig.config.yaml'), 'w') as f:
             yaml.safe_dump(config, f, default_flow_style=False)
 
         info = {
@@ -64,7 +64,7 @@ def write_initial_metadata(archive, config, name, description, owner):
         if 'job_id' in config:
             info['job_id'] = config['job_id']
 
-        with file(os.path.join(archive, 'info.yaml'), 'w') as f:
+        with open(os.path.join(archive, 'info.yaml'), 'w') as f:
             yaml.safe_dump(info, f, default_flow_style=False)
 
 
@@ -240,7 +240,7 @@ def report_outcome(config, archive, summary, fake_ctx):
         nuke(fake_ctx, fake_ctx.lock)
 
     if archive is not None:
-        with file(os.path.join(archive, 'summary.yaml'), 'w') as f:
+        with open(os.path.join(archive, 'summary.yaml'), 'w') as f:
             yaml.safe_dump(summary, f, default_flow_style=False)
 
     with contextlib.closing(StringIO.StringIO()) as f:
@@ -273,7 +273,7 @@ def get_teuthology_command(args):
     and returns it as a string.
     """
     cmd = ["teuthology"]
-    for key, value in args.iteritems():
+    for key, value in args.items():
         if value:
             # an option, not an argument
             if not key.startswith("<"):

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -223,7 +223,7 @@ def get_initial_tasks(lock, config, machine_type):
         init_tasks.extend([
             {'pcp': None},
             {'selinux': None},
-            {'ansible.cephlab': None},
+            #{'ansible.cephlab': None},
             {'clock.check': None}
         ])
 

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -1,12 +1,12 @@
 import os
 import yaml
-import StringIO
 import contextlib
 import sys
 import logging
 from traceback import format_tb
 
 import teuthology
+from teuthology.compat import StringIO
 from . import report
 from .job_status import get_status
 from .misc import get_user, merge_configs
@@ -243,11 +243,11 @@ def report_outcome(config, archive, summary, fake_ctx):
         with open(os.path.join(archive, 'summary.yaml'), 'w') as f:
             yaml.safe_dump(summary, f, default_flow_style=False)
 
-    with contextlib.closing(StringIO.StringIO()) as f:
+    with contextlib.closing(StringIO()) as f:
         yaml.safe_dump(summary, f)
         log.info('Summary data:\n%s' % f.getvalue())
 
-    with contextlib.closing(StringIO.StringIO()) as f:
+    with contextlib.closing(StringIO()) as f:
         if ('email-on-error' in config
                 and not passed):
             yaml.safe_dump(summary, f)

--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -58,7 +58,7 @@ def run_tasks(tasks, ctx):
     try:
         for taskdict in tasks:
             try:
-                ((taskname, config),) = taskdict.iteritems()
+                ((taskname, config),) = taskdict.items()
             except (ValueError, AttributeError):
                 raise RuntimeError('Invalid task definition: %s' % taskdict)
             log.info('Running task %s...', taskname)
@@ -124,7 +124,7 @@ def run_tasks(tasks, ctx):
         # causes failures with 'too many values to unpack.'  We want to
         # fail as before, but with easier to understand error indicators.
         if type(e) == ValueError:
-            if e.message == 'too many values to unpack':
+            if str(e) == 'too many values to unpack':
                 emsg = 'Possible configuration error in yaml file'
                 log.error(emsg)
                 ctx.summary['failure_info'] = emsg

--- a/teuthology/schedule.py
+++ b/teuthology/schedule.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pprint
 import yaml
 
@@ -79,8 +80,8 @@ def schedule_job(job_config, num=1):
             ttr=60 * 60 * 24,
             priority=job_config['priority'],
         )
-        print 'Job scheduled with name {name} and ID {jid}'.format(
-            name=job_config['name'], jid=jid)
+        print('Job scheduled with name {name} and ID {jid}'.format(
+            name=job_config['name'], jid=jid))
         job_config['job_id'] = str(jid)
         report.try_push_job_info(job_config, dict(status='queued'))
         num -= 1

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -28,7 +28,7 @@ def process_args(args):
         '<config_yaml>': 'base_yaml_paths',
         'filter': 'filter_in',
     }
-    for (key, value) in args.iteritems():
+    for (key, value) in args.items():
         # Translate --foo-bar to foo_bar
         key = key.lstrip('--').replace('-', '_')
         # Rename the key if necessary
@@ -107,7 +107,7 @@ def wait(name, max_job_time, upload_url):
     jobs = reporter.get_jobs(name, fields=['job_id', 'status',
                                            'description', 'log_href'])
     # dead, fail, pass : show fail/dead jobs first
-    jobs = sorted(jobs, lambda a, b: cmp(a['status'], b['status']))
+    jobs = sorted(jobs, key=lambda j: j['status'])
     for job in jobs:
         if upload_url:
             url = os.path.join(upload_url, name, job['job_id'])

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -1,5 +1,8 @@
 import logging
 import os
+# Directly imported for easy patching
+from os import listdir
+from os.path import exists, isfile, isdir
 
 from . import matrix
 
@@ -71,16 +74,16 @@ def _get_matrix(path, subset=None):
 
 
 def _build_matrix(path, mincyclicity=0, item=''):
-    if not os.path.exists(path):
+    if not exists(path):
         raise IOError('%s does not exist (abs %s)' % (path, os.path.abspath(path)))
-    if os.path.isfile(path):
+    if isfile(path):
         if path.endswith('.yaml'):
             return matrix.Base(item)
         return None
-    if os.path.isdir(path):
+    if isdir(path):
         if path.endswith('.disable'):
             return None
-        files = sorted(os.listdir(path))
+        files = sorted(listdir(path))
         if len(files) == 0:
             return None
         if '+' in files:

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -58,11 +58,11 @@ def _get_matrix(path, subset=None):
     if subset:
         (index, outof) = subset
         mat = _build_matrix(path, mincyclicity=outof)
-        first = (mat.size() / outof) * index
+        first = (mat.size() // outof) * index
         if index == outof or index == outof - 1:
             matlimit = mat.size()
         else:
-            matlimit = (mat.size() / outof) * (index + 1)
+            matlimit = (mat.size() // outof) * (index + 1)
     else:
         first = 0
         mat = _build_matrix(path)
@@ -109,7 +109,7 @@ def _build_matrix(path, mincyclicity=0, item=''):
             mat = matrix.Product(item, submats)
             if mat and mat.cyclicity() < mincyclicity:
                 mat = matrix.Cycle(
-                    (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
+                    (mincyclicity + mat.cyclicity() - 1) // mat.cyclicity(), mat
                 )
             return mat
         else:
@@ -124,7 +124,7 @@ def _build_matrix(path, mincyclicity=0, item=''):
                     continue
                 if submat.cyclicity() < mincyclicity:
                     submat = matrix.Cycle(
-                        ((mincyclicity + submat.cyclicity() - 1) /
+                        ((mincyclicity + submat.cyclicity() - 1) //
                          submat.cyclicity()),
                         submat)
                 submats.append(submat)

--- a/teuthology/suite/matrix.py
+++ b/teuthology/suite/matrix.py
@@ -41,7 +41,7 @@ class Matrix:
         A cyclicity of N means that the set represented by the Matrix
         can be chopped into N good subsets of sequential indices.
         """
-        return self.size() / self.minscanlen()
+        return self.size() // self.minscanlen()
 
     def tostr(self, depth):
         pass
@@ -156,8 +156,8 @@ class Product(Matrix):
         rsize = submats[0][0]
 
         cycles = gcd(rsize, lsize)
-        clen = (rsize * lsize) / cycles
-        off = (i / clen) % cycles
+        clen = (rsize * lsize) // cycles
+        off = (i // clen) % cycles
 
         def combine(r, s=frozenset()):
             if type(r) is frozenset:
@@ -228,14 +228,15 @@ class Sum(Matrix):
         self._pseudo_size = lcml((i.size() for i in _submats)) * len(_submats)
         self._size = sum((i.size() for i in _submats))
         self._submats = [
-            ((i, self._pseudo_size / s.size()), s) for (i, s) in \
+            ((i, self._pseudo_size // s.size()), s) for (i, s) in
             zip(range(len(_submats)), _submats)
         ]
 
-        def sm_to_pmsl(((offset, multiple), submat)):
+        def sm_to_pmsl(submat):
             """
             submat tuple to pseudo minscanlen
             """
+            ((offset, multiple), submat) = submat
             return submat.minscanlen() * multiple
 
         def index_to_pindex_generator(submats):
@@ -257,13 +258,14 @@ class Sum(Matrix):
         self._minscanlen = self.pseudo_index_to_index(
             max(map(sm_to_pmsl, self._submats)))
 
-    def pi_to_sis(self, pi, (offset, multiple)):
+    def pi_to_sis(self, pi, offset_multiple):
         """
         max(i) s.t. offset + i*multiple <= pi
         """
+        (offset, multiple) = offset_multiple
         if pi < offset:
             return -1
-        return (pi - offset) / multiple
+        return (pi - offset) // multiple
 
     def pseudo_index_to_index(self, pi):
         """

--- a/teuthology/suite/matrix.py
+++ b/teuthology/suite/matrix.py
@@ -161,7 +161,7 @@ class Product(Matrix):
         off = (i // clen) % cycles
 
         def combine(r, s=frozenset()):
-            if type(r) is frozenset:
+            if isinstance(r, frozenset):
                 return s | r
             return s | frozenset([r])
 
@@ -292,12 +292,12 @@ def generate_lists(result):
     """
     Generates a set of tuples representing paths to concatenate
     """
-    if type(result) is frozenset:
+    if isinstance(result, frozenset):
         ret = []
         for i in result:
             ret.extend(generate_lists(i))
         return frozenset(ret)
-    elif type(result) is tuple:
+    elif isinstance(result, tuple):
         ret = []
         (item, children) = result
         for f in generate_lists(children):

--- a/teuthology/suite/matrix.py
+++ b/teuthology/suite/matrix.py
@@ -1,6 +1,7 @@
 import os
 import heapq
 from fractions import gcd
+from functools import reduce
 
 def lcm(a, b):
     return a*b // gcd(a, b)
@@ -104,8 +105,8 @@ class Product(Matrix):
         self.item = item
 
         submats = sorted(
-            [((i.size(), ind), i) for (i, ind) in
-             zip(_submats, range(len(_submats)))], reverse=True)
+            [((i.size(), ind), i) for (ind, i) in
+             enumerate(_submats)], reverse=True)
         self.submats = []
         self._size = 1
         for ((size, _), submat) in submats:
@@ -229,7 +230,7 @@ class Sum(Matrix):
         self._size = sum((i.size() for i in _submats))
         self._submats = [
             ((i, self._pseudo_size // s.size()), s) for (i, s) in
-            zip(range(len(_submats)), _submats)
+            enumerate(_submats)
         ]
 
         def sm_to_pmsl(submat):
@@ -319,12 +320,13 @@ def generate_desc(joinf, result):
     """
     Generates the text description of the test represented by result
     """
-    if type(result) is frozenset:
+    if isinstance(result, frozenset):
         ret = []
-        for i in sorted(result):
+        # Go over the strings first, then tuples
+        for i in sorted(result, key=lambda x: (isinstance(x, tuple), x)):
             ret.append(generate_desc(joinf, i))
         return '{' + ' '.join(ret) + '}'
-    elif type(result) is tuple:
+    elif isinstance(result, tuple):
         (item, children) = result
         cdesc = generate_desc(joinf, children)
         return joinf(str(item), cdesc)

--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -27,7 +27,7 @@ def substitute_placeholders(input_dict, values_dict):
     input_dict = copy.deepcopy(input_dict)
 
     def _substitute(input_dict, values_dict):
-        for key, value in input_dict.items():
+        for key, value in list(input_dict.items()):
             if isinstance(value, dict):
                 _substitute(value, values_dict)
             elif isinstance(value, Placeholder):

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -470,7 +470,7 @@ class Run(object):
         if self.args.dry_run:
             log.debug("Base job config:\n%s" % self.base_config)
 
-        with open(base_yaml_path, 'w+b') as base_yaml:
+        with open(base_yaml_path, 'w') as base_yaml:
             base_yaml.write(str(self.base_config))
         self.schedule_jobs(jobs_missing_packages, jobs_to_schedule, name)
 

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -283,7 +283,7 @@ class Run(object):
                 util.strip_fragment_path(x) for x in fragment_paths
             ]
             limit = self.args.limit
-            if limit > 0 and len(jobs_to_schedule) >= limit:
+            if limit and limit > 0 and len(jobs_to_schedule) >= limit:
                 log.info(
                     'Stopped after {limit} jobs due to --limit={limit}'.format(
                         limit=limit))
@@ -315,7 +315,7 @@ class Run(object):
                 if all_filt_val:
                     continue
 
-            raw_yaml = '\n'.join([file(a, 'r').read() for a in fragment_paths])
+            raw_yaml = '\n'.join(open(a, 'r').read() for a in fragment_paths)
 
             parsed_yaml = yaml.load(raw_yaml)
             os_type = parsed_yaml.get('os_type') or self.base_config.os_type

--- a/teuthology/suite/test/test_build_matrix.py
+++ b/teuthology/suite/test/test_build_matrix.py
@@ -426,9 +426,9 @@ class TestSubset(object):
                     sub_max_facets, max_fanout,
                     max_depth - 1, namegen, top=False)
                 if subtree is not None:
-                    tree[namegen.next()] = subtree
+                    tree[next(namegen)] = subtree
                 else:
-                    tree[yamilify(namegen.next())] = None
+                    tree[yamilify(next(namegen))] = None
             random.choice([
                 lambda: tree.update({'%': None}),
                 lambda: None])()
@@ -453,7 +453,7 @@ class TestSubset(object):
     @staticmethod
     def verify_facets(tree, description_list, subset, mat, first, matlimit):
         def flatten(tree):
-            for k,v in tree.iteritems():
+            for k,v in tree.items():
                 if v is None and '.yaml' in k:
                     yield k
                 elif v is not None and '.disable' not in k:
@@ -462,7 +462,7 @@ class TestSubset(object):
 
         def pptree(tree, tabs=0):
             ret = ""
-            for k, v in tree.iteritems():
+            for k, v in tree.items():
                 if v is None:
                     ret += ('\t'*tabs) + k.ljust(10) + "\n"
                 else:
@@ -487,7 +487,7 @@ class TestSubset(object):
                     mat,
                     0,
                     mat.size())
-                for i, desc in zip(xrange(mat.size()), all_desc):
+                for i, desc in zip(range(mat.size()), all_desc):
                     if i == first:
                         print('==========')
                     print(i, desc)
@@ -496,7 +496,7 @@ class TestSubset(object):
             assert found
 
     def test_random(self):
-        for i in xrange(10000):
+        for i in range(10000):
             tree = self.generate_fake_fs(
                 self.MAX_FACETS,
                 self.MAX_FANOUT,

--- a/teuthology/suite/test/test_build_matrix.py
+++ b/teuthology/suite/test/test_build_matrix.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import random
 
 from mock import patch, MagicMock
@@ -475,12 +476,12 @@ class TestSubset(object):
                     found = True
                     break
             if not found:
-                print "tree\n{tree}\ngenerated list\n{desc}\n\nfrom matrix\n\n{matrix}\nsubset {subset} without facet {fac}".format(
+                print("tree\n{tree}\ngenerated list\n{desc}\n\nfrom matrix\n\n{matrix}\nsubset {subset} without facet {fac}".format(
                     tree=pptree(tree),
                     desc='\n'.join(description_list),
                     subset=subset,
                     matrix=str(mat),
-                    fac=facet)
+                    fac=facet))
                 all_desc = build_matrix.generate_combinations(
                     'root',
                     mat,
@@ -488,10 +489,10 @@ class TestSubset(object):
                     mat.size())
                 for i, desc in zip(xrange(mat.size()), all_desc):
                     if i == first:
-                        print '=========='
-                    print i, desc
+                        print('==========')
+                    print(i, desc)
                     if i + 1 == matlimit:
-                        print '=========='
+                        print('==========')
             assert found
 
     def test_random(self):

--- a/teuthology/suite/test/test_build_matrix.py
+++ b/teuthology/suite/test/test_build_matrix.py
@@ -20,11 +20,11 @@ class TestBuildMatrixSimple(object):
 class TestBuildMatrix(object):
 
     patchpoints = [
-        'os.path.exists',
-        'os.listdir',
-        'os.path.isfile',
-        'os.path.isdir',
-        '__builtin__.open',
+        'teuthology.suite.build_matrix.exists',
+        'teuthology.suite.build_matrix.listdir',
+        'teuthology.suite.build_matrix.isfile',
+        'teuthology.suite.build_matrix.isdir',
+        'teuthology.suite.open',
     ]
 
     def setup(self):
@@ -367,11 +367,11 @@ class TestBuildMatrix(object):
 
 class TestSubset(object):
     patchpoints = [
-        'os.path.exists',
-        'os.listdir',
-        'os.path.isfile',
-        'os.path.isdir',
-        '__builtin__.open',
+        'teuthology.suite.build_matrix.exists',
+        'teuthology.suite.build_matrix.listdir',
+        'teuthology.suite.build_matrix.isfile',
+        'teuthology.suite.build_matrix.isdir',
+        'teuthology.suite.open',
     ]
 
     def setup(self):

--- a/teuthology/suite/test/test_build_matrix.py
+++ b/teuthology/suite/test/test_build_matrix.py
@@ -410,14 +410,14 @@ class TestSubset(object):
                 x += 1
         def generate_tree(
                 max_facets, max_fanout, max_depth, namegen, top=True):
-            if max_depth is 0:
+            if max_depth == 0:
                 return None
-            if max_facets is 0:
+            if max_facets == 0:
                 return None
             items = random.choice(range(max_fanout))
-            if items is 0 and top:
+            if items == 0 and top:
                 items = 1
-            if items is 0:
+            if items == 0:
                 return None
             sub_max_facets = max_facets / items
             tree = {}

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -194,7 +194,7 @@ class TestScheduleSuite(object):
     @patch('teuthology.suite.util.has_packages_for_distro')
     @patch('teuthology.suite.util.get_package_versions')
     @patch('teuthology.suite.util.get_install_task_flavor')
-    @patch('__builtin__.file')
+    @patch('teuthology.suite.run.open', create=True)
     @patch('teuthology.suite.run.build_matrix')
     @patch('teuthology.suite.util.git_ls_remote')
     @patch('teuthology.suite.util.package_version_for_hash')
@@ -205,7 +205,7 @@ class TestScheduleSuite(object):
         m_package_version_for_hash,
         m_git_ls_remote,
         m_build_matrix,
-        m_file,
+        m_open,
         m_get_install_task_flavor,
         m_get_package_versions,
         m_has_packages_for_distro,
@@ -222,9 +222,10 @@ class TestScheduleSuite(object):
         m_build_matrix.return_value = build_matrix_output
         frag1_read_output = 'field1: val1'
         frag2_read_output = 'field2: val2'
-        m_file.side_effect = [
+        m_open.side_effect = [
             StringIO(frag1_read_output),
             StringIO(frag2_read_output),
+            contextlib.closing(StringIO())
         ]
         m_get_install_task_flavor.return_value = 'basic'
         m_get_package_versions.return_value = dict()
@@ -264,7 +265,7 @@ class TestScheduleSuite(object):
     @patch('teuthology.suite.util.has_packages_for_distro')
     @patch('teuthology.suite.util.get_package_versions')
     @patch('teuthology.suite.util.get_install_task_flavor')
-    @patch('__builtin__.file')
+    @patch('teuthology.suite.run.open', create=True)
     @patch('teuthology.suite.run.build_matrix')
     @patch('teuthology.suite.util.git_ls_remote')
     @patch('teuthology.suite.util.package_version_for_hash')
@@ -275,7 +276,7 @@ class TestScheduleSuite(object):
         m_package_version_for_hash,
         m_git_ls_remote,
         m_build_matrix,
-        m_file,
+        m_open,
         m_get_install_task_flavor,
         m_get_package_versions,
         m_has_packages_for_distro,
@@ -315,7 +316,7 @@ class TestScheduleSuite(object):
     @patch('teuthology.suite.util.has_packages_for_distro')
     @patch('teuthology.suite.util.get_package_versions')
     @patch('teuthology.suite.util.get_install_task_flavor')
-    @patch('__builtin__.file')
+    @patch('teuthology.suite.run.open', create=True)
     @patch('teuthology.suite.run.build_matrix')
     @patch('teuthology.suite.util.git_ls_remote')
     @patch('teuthology.suite.util.package_version_for_hash')
@@ -326,7 +327,7 @@ class TestScheduleSuite(object):
         m_package_version_for_hash,
         m_git_ls_remote,
         m_build_matrix,
-        m_file,
+        m_open,
         m_get_install_task_flavor,
         m_get_package_versions,
         m_has_packages_for_distro,
@@ -347,6 +348,8 @@ class TestScheduleSuite(object):
         m_build_matrix.return_value = build_matrix_output
         m_open.side_effect = [
             StringIO('field: val\n') for i in range(NUM_FAILS+1)
+        ] + [
+            contextlib.closing(StringIO())
         ]
         m_get_install_task_flavor.return_value = 'basic'
         m_get_package_versions.return_value = dict()

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -6,8 +6,8 @@ import contextlib
 
 from datetime import datetime
 from mock import patch, call, ANY, DEFAULT
-from StringIO import StringIO
 
+from teuthology.compat import PyStringIO as StringIO
 from teuthology.config import config, YamlConfig
 from teuthology.exceptions import ScheduleFailError
 from teuthology.suite import run

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import requests
 import yaml
+import contextlib
 
 from datetime import datetime
 from mock import patch, call, ANY, DEFAULT
@@ -290,11 +291,11 @@ class TestScheduleSuite(object):
             (build_matrix_desc, build_matrix_frags),
         ]
         m_build_matrix.return_value = build_matrix_output
-        m_file.side_effect = [StringIO('field: val\n') for i in xrange(11)]
+        m_open.side_effect = [StringIO('field: val\n') for i in range(11)]
         m_get_install_task_flavor.return_value = 'basic'
         m_get_package_versions.return_value = dict()
         m_has_packages_for_distro.side_effect = [
-            False for i in xrange(11)
+            False for i in range(11)
         ]
 
         m_find_git_parent.side_effect = lambda proj, sha1: sha1 + '^'
@@ -306,7 +307,7 @@ class TestScheduleSuite(object):
             runobj.schedule_suite()
         assert 'Exceeded 10 backtracks' in str(exc.value)
         m_find_git_parent.assert_has_calls(
-            [call('ceph', 'ceph_sha1' + i * '^') for i in xrange(10)]
+            [call('ceph', 'ceph_sha1' + i * '^') for i in range(10)]
         )
 
     @patch('teuthology.suite.util.find_git_parent')
@@ -344,14 +345,14 @@ class TestScheduleSuite(object):
             (build_matrix_desc, build_matrix_frags),
         ]
         m_build_matrix.return_value = build_matrix_output
-        m_file.side_effect = [
-            StringIO('field: val\n') for i in xrange(NUM_FAILS+1)
+        m_open.side_effect = [
+            StringIO('field: val\n') for i in range(NUM_FAILS+1)
         ]
         m_get_install_task_flavor.return_value = 'basic'
         m_get_package_versions.return_value = dict()
         # NUM_FAILS, then success
         m_has_packages_for_distro.side_effect = \
-            [False for i in xrange(NUM_FAILS)] + [True]
+            [False for i in range(NUM_FAILS)] + [True]
 
         m_find_git_parent.side_effect = lambda proj, sha1: sha1 + '^'
 
@@ -362,8 +363,8 @@ class TestScheduleSuite(object):
         assert count == 1
         m_has_packages_for_distro.assert_has_calls(
             [call('ceph_sha1' + '^' * i, 'ubuntu', '14.04', 'basic', {})
-             for i in xrange(NUM_FAILS+1)]
+             for i in range(NUM_FAILS+1)]
         )
         m_find_git_parent.assert_has_calls(
-            [call('ceph', 'ceph_sha1' + i * '^') for i in xrange(NUM_FAILS)]
+            [call('ceph', 'ceph_sha1' + i * '^') for i in range(NUM_FAILS)]
         )

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -315,8 +315,8 @@ def get_install_task_flavor(job_config):
     project_overrides = install_overrides.get(project, dict())
     first_install_config = dict()
     for task in tasks:
-        if task.keys()[0] == 'install':
-            first_install_config = task.values()[0] or dict()
+        if list(task)[0] == 'install':
+            first_install_config = list(task.values())[0] or dict()
             break
     first_install_config = copy.deepcopy(first_install_config)
     deep_merge(first_install_config, install_overrides)

--- a/teuthology/task/__init__.py
+++ b/teuthology/task/__init__.py
@@ -3,6 +3,8 @@ import logging
 from teuthology.misc import deep_merge
 from teuthology.orchestra.cluster import Cluster
 
+from six import string_types as basestring
+
 log = logging.getLogger(__name__)
 
 
@@ -70,10 +72,10 @@ class Task(object):
         for host_spec in host_specs:
             role_matches = self.ctx.cluster.only(host_spec)
             if len(role_matches.remotes) > 0:
-                for (remote, roles) in role_matches.remotes.iteritems():
+                for (remote, roles) in role_matches.remotes.items():
                     cluster.add(remote, roles)
             elif isinstance(host_spec, basestring):
-                for (remote, roles) in self.ctx.cluster.remotes.iteritems():
+                for (remote, roles) in self.ctx.cluster.remotes.items():
                     if remote.name.split('@')[-1] == host_spec or \
                             remote.shortname == host_spec:
                         cluster.add(remote, roles)

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -304,7 +304,7 @@ class Ansible(Task):
                 self.failure_log.name,
                 archive_path
             )
-            os.chmod(archive_path, 0664)
+            os.chmod(archive_path, 0o664)
 
     def _build_args(self):
         """

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -6,9 +6,9 @@ import pexpect
 import yaml
 import shutil
 
-from cStringIO import StringIO
 from tempfile import NamedTemporaryFile
 
+from teuthology.compat import StringIO
 from teuthology.config import config as teuth_config
 from teuthology.exceptions import CommandFailedError, AnsibleFailedError
 from teuthology.job_status import set_status
@@ -207,7 +207,7 @@ class Ansible(Task):
         """
         Actually write the hosts file
         """
-        hosts_file = NamedTemporaryFile(prefix="teuth_ansible_hosts_",
+        hosts_file = NamedTemporaryFile('w', prefix="teuth_ansible_hosts_",
                                         delete=False)
         hosts_file.write(content)
         hosts_file.flush()
@@ -222,7 +222,7 @@ class Ansible(Task):
         pb_buffer.write('---\n')
         yaml.safe_dump(self.playbook, pb_buffer)
         pb_buffer.seek(0)
-        playbook_file = NamedTemporaryFile(
+        playbook_file = NamedTemporaryFile('w+',
             prefix="teuth_ansible_playbook_",
             dir=self.repo_path,
             delete=False,

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -164,7 +164,7 @@ class Ansible(Task):
                     pb_in_repo = os.path.join(self.repo_path, playbook_path)
                     if os.path.exists(pb_in_repo):
                         playbook_path = pb_in_repo
-                self.playbook_file = file(playbook_path)
+                self.playbook_file = open(playbook_path)
                 playbook_yaml = yaml.safe_load(self.playbook_file)
                 self.playbook = playbook_yaml
             except Exception:
@@ -264,7 +264,7 @@ class Ansible(Task):
             self._handle_failure(command, status)
 
         if self.config.get('reconnect', True) is True:
-            remotes = self.cluster.remotes.keys()
+            remotes = list(self.cluster.remotes)
             log.debug("Reconnecting to %s", remotes)
             for remote in remotes:
                 remote.reconnect()
@@ -312,7 +312,7 @@ class Ansible(Task):
         """
         fqdns = [r.hostname for r in self.cluster.remotes.keys()]
         # Assume all remotes use the same username
-        user = self.cluster.remotes.keys()[0].user
+        user = list(self.cluster.remotes)[0].user
         extra_vars = dict(ansible_ssh_user=user)
         extra_vars.update(self.config.get('vars', dict()))
         args = [

--- a/teuthology/task/background_exec.py
+++ b/teuthology/task/background_exec.py
@@ -46,8 +46,8 @@ def task(ctx, config):
     testdir = misc.get_testdir(ctx)
 
     tasks = {}
-    for role, cmd in config.iteritems():
-        (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+    for role, cmd in config.items():
+        (remote,) = ctx.cluster.only(role).remotes.keys()
         log.info('Running background command on role %s host %s', role,
                  remote.name)
         if isinstance(cmd, list):
@@ -70,7 +70,7 @@ def task(ctx, config):
         yield
 
     finally:
-        for name, task in tasks.iteritems():
+        for name, task in tasks.items():
             log.info('Stopping background command on %s', name)
             task.stdin.close()
-        run.wait(tasks.itervalues())
+        run.wait(tasks.values())

--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -85,7 +85,7 @@ class CephAnsible(ansible.Ansible):
         for group in sorted(groups_to_roles.keys()):
             role_prefix = groups_to_roles[group]
             want = lambda role: role.startswith(role_prefix)
-            for (remote, roles) in self.cluster.only(want).remotes.iteritems():
+            for (remote, roles) in self.cluster.only(want).remotes.items():
                 hostname = remote.hostname
                 host_vars = self.get_host_vars(remote)
                 if group not in hosts_dict:

--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -1,10 +1,9 @@
 import json
 import os
 
-from cStringIO import StringIO
-
 from . import ansible
 
+from ..compat import StringIO
 from ..config import config as teuth_config
 from ..misc import get_scratch_devices
 

--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -31,7 +31,7 @@ def task(ctx, config):
     """
 
     log.info('Syncing clocks and checking initial clock skew...')
-    for rem in ctx.cluster.remotes.iterkeys():
+    for rem in ctx.cluster.remotes:
         ntpconf = rem.get_file('/etc/ntp.conf')
         servers = [
             l.strip().split()[1] for l in open(ntpconf, 'r').readlines()
@@ -61,7 +61,7 @@ def task(ctx, config):
 
     finally:
         log.info('Checking final clock skew...')
-        for rem in ctx.cluster.remotes.iterkeys():
+        for rem in ctx.cluster.remotes:
             rem.run(
                 args=[
                     'PATH=/usr/bin:/usr/sbin',
@@ -79,7 +79,7 @@ def check(ctx, config):
     :param config: Configuration
     """
     log.info('Checking initial clock skew...')
-    for rem in ctx.cluster.remotes.iterkeys():
+    for rem in ctx.cluster.remotes:
         rem.run(
             args=[
                 'PATH=/usr/bin:/usr/sbin',
@@ -92,7 +92,7 @@ def check(ctx, config):
 
     finally:
         log.info('Checking final clock skew...')
-        for rem in ctx.cluster.remotes.iterkeys():
+        for rem in ctx.cluster.remotes:
             rem.run(
                 args=[
                     'PATH=/usr/bin:/usr/sbin',

--- a/teuthology/task/common_fs_utils.py
+++ b/teuthology/task/common_fs_utils.py
@@ -33,7 +33,7 @@ def generic_mkfs(ctx, config, devname_rtn):
     assert isinstance(config, list) or isinstance(config, dict), \
         "task mkfs must be configured with a list or dictionary"
     if isinstance(config, dict):
-        images = config.items()
+        images = list(config.items())
     else:
         images = [(role, None) for role in config]
 
@@ -70,7 +70,7 @@ def generic_mount(ctx, config, devname_rtn):
     assert isinstance(config, list) or isinstance(config, dict), \
         "task mount must be configured with a list or dictionary"
     if isinstance(config, dict):
-        role_images = config.items()
+        role_images = list(config.items())
     else:
         role_images = [(role, None) for role in config]
 

--- a/teuthology/task/daemon-helper
+++ b/teuthology/task/daemon-helper
@@ -17,6 +17,7 @@ Usage:
     daemon-helper <signal> [--kill-group] [nostdin] COMMAND ...
 """
 
+from __future__ import print_function
 import fcntl
 import os
 import select
@@ -46,14 +47,14 @@ try:
         nostdin = True
         skip_nostdin = 1
 except IndexError:
-    print 'No command specified'
+    print('No command specified')
     sys.exit(1)
 
 
 proc = None
 if nostdin:
     if len(args) - skip_nostdin == 0:
-        print 'No command specified'
+        print('No command specified')
         sys.exit(1)
     proc = subprocess.Popen(
         args=args[skip_nostdin:],
@@ -95,18 +96,18 @@ while True:
 
 exitstatus = proc.wait()
 if exitstatus > 0:
-    print >>sys.stderr, '{me}: command failed with exit status {exitstatus:d}'.format(
+    print('{me}: command failed with exit status {exitstatus:d}'.format(
         me=os.path.basename(sys.argv[0]),
         exitstatus=exitstatus,
-        )
+        ), file=sys.stderr)
     sys.exit(exitstatus)
 elif exitstatus < 0:
     if saw_eof and exitstatus == -end_signal:
         # suppress error from the exit we intentionally caused
         pass
     else:
-        print >>sys.stderr, '{me}: command crashed with signal {signal:d}'.format(
+        print('{me}: command crashed with signal {signal:d}'.format(
             me=os.path.basename(sys.argv[0]),
             signal=-exitstatus,
-            )
+            ), file=sys.stderr)
         sys.exit(1)

--- a/teuthology/task/daemon-helper
+++ b/teuthology/task/daemon-helper
@@ -60,7 +60,7 @@ if nostdin:
         args=args[skip_nostdin:],
         )
 else:
-    with file('/dev/null', 'rb') as devnull:
+    with open('/dev/null', 'rb') as devnull:
         proc = subprocess.Popen(
             args=args,
             stdin=devnull,

--- a/teuthology/task/exec.py
+++ b/teuthology/task/exec.py
@@ -40,8 +40,8 @@ def task(ctx, config):
         roles = teuthology.all_roles(ctx.cluster)
         config = dict((id_, a) for id_ in roles)
 
-    for role, ls in config.iteritems():
-        (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+    for role, ls in config.items():
+        (remote,) = ctx.cluster.only(role).remotes.keys()
         log.info('Running commands on role %s host %s', role, remote.name)
         for c in ls:
             c.replace('$TESTDIR', testdir)

--- a/teuthology/task/full_sequential.py
+++ b/teuthology/task/full_sequential.py
@@ -25,7 +25,7 @@ def task(ctx, config):
     for entry in config:
         if not isinstance(entry, dict):
             entry = ctx.config.get(entry, {})
-        ((taskname, confg),) = entry.iteritems()
+        ((taskname, confg),) = entry.items()
         log.info('In full_sequential, running task %s...' % taskname)
         mgr = run_tasks.run_one_task(taskname, ctx=ctx, config=confg)
         if hasattr(mgr, '__enter__'):

--- a/teuthology/task/hadoop.py
+++ b/teuthology/task/hadoop.py
@@ -12,7 +12,7 @@ HADOOP_2x_URL = "http://apache.osuosl.org/hadoop/common/hadoop-2.5.2/hadoop-2.5.
 
 def dict_to_hadoop_conf(items):
     out = "<configuration>\n"
-    for key, value in items.iteritems():
+    for key, value in items.items():
         out += "  <property>\n"
         out += "    <name>" + key + "</name>\n"
         out += "    <value>" + value + "</value>\n"
@@ -171,7 +171,7 @@ def configure(ctx, config, hadoops):
         hadoop_dir = "{tdir}/hadoop/".format(tdir=testdir)
         masters = ctx.cluster.only(is_hadoop_type('master'))
         assert len(masters.remotes) == 1
-        master = masters.remotes.keys()[0]
+        master = list(masters.remotes)[0]
         master.run(
             args = [
                 hadoop_dir + "bin/hadoop",
@@ -340,7 +340,7 @@ def start_hadoop(ctx, config):
     hadoop_dir = "{tdir}/hadoop/".format(tdir=testdir)
     masters = ctx.cluster.only(is_hadoop_type('master'))
     assert len(masters.remotes) == 1
-    master = masters.remotes.keys()[0]
+    master = list(masters.remotes)[0]
 
     log.info("Stopping Hadoop daemons")
     master.run(

--- a/teuthology/task/hadoop.py
+++ b/teuthology/task/hadoop.py
@@ -1,6 +1,7 @@
-from cStringIO import StringIO
 import contextlib
 import logging
+
+from teuthology.compat import StringIO
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from ..orchestra import run

--- a/teuthology/task/iscsi.py
+++ b/teuthology/task/iscsi.py
@@ -5,7 +5,7 @@ import logging
 import contextlib
 import socket
 
-from cStringIO import StringIO
+from teuthology.compat import BytesIO, stringify
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from teuthology.task.common_fs_utils import generic_mkfs
@@ -66,8 +66,8 @@ def file_io_test(rem, file_from, lnkpath):
         'bs=1024',
         'conv=fsync',
     ])
-    proc = rem.run(args=['mktemp'], stdout=StringIO(),)
-    tfile2 = proc.stdout.getvalue().strip()
+    proc = rem.run(args=['mktemp'], stdout=BytesIO(),)
+    tfile2 = stringify(proc.stdout.getvalue().strip())
     rem.run(
         args=[
         'sudo',
@@ -86,9 +86,9 @@ def file_io_test(rem, file_from, lnkpath):
             run.Raw('|'),
             'awk',
             '{print $5}', ],
-        stdout=StringIO(),
+        stdout=BytesIO(),
         )
-    size = proc.stdout.getvalue().strip()
+    size = stringify(proc.stdout.getvalue().strip())
     rem.run(
         args=[
             'cmp',
@@ -112,8 +112,8 @@ def general_io_test(ctx, rem, image_name):
     ])
     test_phrase = 'The time has come the walrus said to speak of many things.'
     lnkpath = tgt_devname_get(ctx, image_name)
-    proc = rem.run(args=['mktemp'], stdout=StringIO(),)
-    tfile1 = proc.stdout.getvalue().strip()
+    proc = rem.run(args=['mktemp'], stdout=BytesIO(),)
+    tfile1 = stringify(proc.stdout.getvalue().strip())
     rem.run(
         args=[
             'echo',

--- a/teuthology/task/iscsi.py
+++ b/teuthology/task/iscsi.py
@@ -211,7 +211,7 @@ def task(ctx, config):
     for one image being tested at any one time.
     """
     try:
-        pairs = config.items()
+        pairs = list(config.items())
     except AttributeError:
         pairs = [('client.0', 'client.0')]
     with contextutil.nested(

--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -71,8 +71,7 @@ def normalize_config(ctx, config):
     :param config: Configuration
     """
     if not config or \
-            len(filter(lambda x: x in VERSION_KEYS + ['kdb', 'flavor'],
-                       config.keys())) == len(config.keys()):
+            len([x for x in config.keys() if x in VERSION_KEYS + ['kdb', 'flavor']]) == len(config):
         new_config = {}
         if not config:
             config = CONFIG_DEFAULT
@@ -81,7 +80,7 @@ def normalize_config(ctx, config):
         return new_config
 
     new_config = {}
-    for role, role_config in config.iteritems():
+    for role, role_config in config.items():
         if role_config is None:
             role_config = CONFIG_DEFAULT
         if '.' in role:
@@ -123,7 +122,7 @@ def normalize_and_apply_overrides(ctx, config, overrides):
         # (e.g. 'branch: foo' is overridden with 'tag: bar').  To be able to
         # use deep_merge(), drop all version keys from the original config if
         # the corresponding override has a version key.
-        for role, role_config in config.iteritems():
+        for role, role_config in config.items():
             if (role in overrides and
                     any(k in overrides[role] for k in VERSION_KEYS)):
                 for k in VERSION_KEYS:
@@ -140,7 +139,7 @@ def validate_config(ctx, config):
     :param ctx: Context
     :param config: Configuration
     """
-    for _, roles_for_host in ctx.cluster.remotes.iteritems():
+    for _, roles_for_host in ctx.cluster.remotes.items():
         kernel = None
         for role in roles_for_host:
             role_kernel = config.get(role, kernel)
@@ -227,7 +226,7 @@ def install_firmware(ctx, config):
     uri = teuth_config.linux_firmware_git_url or linux_firmware_git_upstream
     fw_dir = '/lib/firmware/updates'
 
-    for role in config.iterkeys():
+    for role in config:
         if isinstance(config[role], str) and config[role].find('distro') >= 0:
             log.info('Skipping firmware on distro kernel');
             return
@@ -312,7 +311,7 @@ def download_kernel(ctx, config):
     :param config: Configuration
     """
     procs = {}
-    for role, src in config.iteritems():
+    for role, src in config.items():
         needs_download = False
 
         if src == 'distro':
@@ -351,7 +350,7 @@ def download_kernel(ctx, config):
             proc = role_remote.run(
                 args=[
                     'python', '-c',
-                    'import shutil, sys; shutil.copyfileobj(sys.stdin, file(sys.argv[1], "wb"))',
+                    'import shutil, sys; shutil.copyfileobj(sys.stdin, open(sys.argv[1], "wb"))',
                     remote_pkg_path(role_remote),
                     ],
                 wait=False,
@@ -396,7 +395,7 @@ def download_kernel(ctx, config):
                 wait=False)
             procs[role_remote.name] = proc
 
-    for name, proc in procs.iteritems():
+    for name, proc in procs.items():
         log.debug('Waiting for download/copy to %s to complete...', name)
         proc.wait()
 
@@ -435,7 +434,7 @@ def install_and_reboot(ctx, config):
     """
     procs = {}
     kernel_title = ''
-    for role, src in config.iteritems():
+    for role, src in config.items():
         (role_remote,) = ctx.cluster.only(role).remotes.keys()
         if isinstance(src, str) and src.find('distro') >= 0:
             log.info('Installing distro kernel on {role}...'.format(role=role))
@@ -568,7 +567,7 @@ def install_and_reboot(ctx, config):
             )
         procs[role_remote.name] = proc
 
-    for name, proc in procs.iteritems():
+    for name, proc in procs.items():
         log.debug('Waiting for install on %s to complete...', name)
         proc.wait()
 
@@ -580,7 +579,7 @@ def enable_disable_kdb(ctx, config):
     :param ctx: Context
     :param config: Configuration
     """
-    for role, enable in config.iteritems():
+    for role, enable in config.items():
         (role_remote,) = ctx.cluster.only(role).remotes.keys()
         if "mira" in role_remote.name:
             serialdev = "ttyS2"
@@ -1150,7 +1149,7 @@ def task(ctx, config):
 
     remove_old_kernels(ctx)
 
-    for role, role_config in config.iteritems():
+    for role, role_config in config.items():
         # gather information about this remote
         (role_remote,) = ctx.cluster.only(role).remotes.keys()
         system_type = role_remote.os.name

--- a/teuthology/task/knfsd.py
+++ b/teuthology/task/knfsd.py
@@ -76,7 +76,7 @@ def task(ctx, config):
     elif isinstance(config, list):
         config = dict((name, None) for name in config)
 
-    clients = list(teuthology.get_clients(ctx=ctx, roles=config.keys()))
+    clients = list(teuthology.get_clients(ctx=ctx, roles=list(config)))
 
     for id_, remote in clients:
         mnt = os.path.join(teuthology.get_testdir(ctx), 'mnt.{id}'.format(id=id_))

--- a/teuthology/task/lockfile.py
+++ b/teuthology/task/lockfile.py
@@ -221,10 +221,10 @@ def lock_one(op, ctx):
     except gevent.Timeout as tout:
         if tout is not timeout:
             raise
-        if bool(op["expectfail"]):
+        if op["expectfail"]:
             result = 1
-        if result is 1:
-            if bool(op["expectfail"]):
+        if result == 1:
+            if op["expectfail"]:
                 log.info("failed as expected for op {op_}".format(op_=op))
             else:
                 raise Exception("Unexpectedly failed to lock {op_} within given timeout!".format(op_=op))
@@ -234,6 +234,6 @@ def lock_one(op, ctx):
         if proc is not None:
             proc.stdin.close()
 
-    ret = (result == 0 and not bool(op["expectfail"])) or (result == 1 and bool(op["expectfail"]))
+    ret = (result == 0 and not op["expectfail"]) or (result == 1 and op["expectfail"])
 
     return ret  #we made it through

--- a/teuthology/task/lockfile.py
+++ b/teuthology/task/lockfile.py
@@ -78,7 +78,7 @@ def task(ctx, config):
         files = set(files)
         lock_procs = list()
         for client in clients:
-            (client_remote,) = ctx.cluster.only(client).remotes.iterkeys()
+            (client_remote,) = ctx.cluster.only(client).remotes.keys()
             log.info("got a client remote")
             (_, _, client_id) = client.partition('.')
             filepath = os.path.join(testdir, 'mnt.{id}'.format(id=client_id), op["lockfile"])
@@ -111,7 +111,7 @@ def task(ctx, config):
         # create the files to run these locks on
         client = clients.pop()
         clients.add(client)
-        (client_remote,) = ctx.cluster.only(client).remotes.iterkeys()
+        (client_remote,) = ctx.cluster.only(client).remotes.keys()
         (_, _, client_id) = client.partition('.')
         file_procs = list()
         for lockfile in files:
@@ -168,7 +168,7 @@ def task(ctx, config):
                 greenlet.kill(block=True)
 
         for client in clients:
-            (client_remote,)  = ctx.cluster.only(client).remotes.iterkeys()
+            (client_remote,)  = ctx.cluster.only(client).remotes.keys()
             (_, _, client_id) = client.partition('.')
             filepath = os.path.join(testdir, 'mnt.{id}'.format(id=client_id), op["lockfile"])
             proc = client_remote.run(
@@ -190,7 +190,7 @@ def lock_one(op, ctx):
     timeout = None
     proc = None
     result = None
-    (client_remote,)  = ctx.cluster.only(op['client']).remotes.iterkeys()
+    (client_remote,)  = ctx.cluster.only(op['client']).remotes.keys()
     (_, _, client_id) = op['client'].partition('.')
     testdir = teuthology.get_testdir(ctx)
     filepath = os.path.join(testdir, 'mnt.{id}'.format(id=client_id), op["lockfile"])

--- a/teuthology/task/loop.py
+++ b/teuthology/task/loop.py
@@ -28,7 +28,7 @@ def task(ctx, config):
             for entry in config.get('body', []):
                 if not isinstance(entry, dict):
                     entry = ctx.config.get(entry, {})
-                ((taskname, confg),) = entry.iteritems()
+                ((taskname, confg),) = entry.items()
                 log.info('In sequential, running task %s...' % taskname)
                 mgr = run_tasks.run_one_task(taskname, ctx=ctx, config=confg)
                 if hasattr(mgr, '__enter__'):

--- a/teuthology/task/mpi.py
+++ b/teuthology/task/mpi.py
@@ -5,6 +5,8 @@ from StringIO import StringIO
 import logging
 import re
 
+from six import string_types as basestring
+
 from teuthology import misc as teuthology
 
 log = logging.getLogger(__name__)
@@ -94,23 +96,23 @@ def task(ctx, config):
     if 'nodes' in config:
         if isinstance(config['nodes'], basestring) and config['nodes'] == 'all':
             for role in  teuthology.all_roles(ctx.cluster):
-                (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+                (remote,) = ctx.cluster.only(role).remotes.keys()
                 ip,port = remote.ssh.get_transport().getpeername()
                 hosts.append(ip)
                 remotes.append(remote)
-            (master_remote,) = ctx.cluster.only(config['nodes'][0]).remotes.iterkeys()
+            (master_remote,) = ctx.cluster.only(config['nodes'][0]).remotes.keys()
         elif isinstance(config['nodes'], list):
             for role in config['nodes']:
-                (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+                (remote,) = ctx.cluster.only(role).remotes.keys()
                 ip,port = remote.ssh.get_transport().getpeername()
                 hosts.append(ip)
                 remotes.append(remote)
-            (master_remote,) = ctx.cluster.only(config['nodes'][0]).remotes.iterkeys()
+            (master_remote,) = ctx.cluster.only(config['nodes'][0]).remotes.keys()
     else:
         roles = ['client.{id}'.format(id=id_) for id_ in teuthology.all_roles_of_type(ctx.cluster, 'client')]
-        (master_remote,) = ctx.cluster.only(roles[0]).remotes.iterkeys()
+        (master_remote,) = ctx.cluster.only(roles[0]).remotes.keys()
         for role in roles:
-            (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+            (remote,) = ctx.cluster.only(role).remotes.keys()
             ip,port = remote.ssh.get_transport().getpeername()
             hosts.append(ip)
             remotes.append(remote)

--- a/teuthology/task/mpi.py
+++ b/teuthology/task/mpi.py
@@ -1,12 +1,12 @@
 """
 Start mpi processes (and allow commands to be run inside process)
 """
-from StringIO import StringIO
 import logging
 import re
 
 from six import string_types as basestring
 
+from teuthology.compat import BytesIO, stringify
 from teuthology import misc as teuthology
 
 log = logging.getLogger(__name__)
@@ -19,7 +19,8 @@ def _check_mpi_version(remotes):
     """
     versions = set()
     for remote in remotes:
-        version_str = remote.run(args=["mpiexec", "--version"], stdout=StringIO()).stdout.getvalue()
+        proc = remote.run(args=["mpiexec", "--version"], stdout=BytesIO())
+        version_str = stringify(proc.stdout.getvalue())
         try:
             version = re.search("^\s+Version:\s+(.+)$", version_str, re.MULTILINE).group(1)
         except AttributeError:

--- a/teuthology/task/nfs.py
+++ b/teuthology/task/nfs.py
@@ -51,7 +51,7 @@ def task(ctx, config):
     log.info('Mounting nfs clients...')
     assert isinstance(config, dict)
 
-    clients = list(teuthology.get_clients(ctx=ctx, roles=config.keys()))
+    clients = list(teuthology.get_clients(ctx=ctx, roles=list(config)))
 
     testdir = teuthology.get_testdir(ctx)
     for id_, remote in clients:

--- a/teuthology/task/parallel.py
+++ b/teuthology/task/parallel.py
@@ -51,7 +51,7 @@ def task(ctx, config):
                 # support the usual list syntax for tasks
                 if isinstance(entry, list):
                     entry = dict(sequential=entry)
-            ((taskname, confg),) = entry.iteritems()
+            ((taskname, confg),) = entry.items()
             p.spawn(_run_spawned, ctx, confg, taskname)
 
 

--- a/teuthology/task/parallel_example.py
+++ b/teuthology/task/parallel_example.py
@@ -27,11 +27,11 @@ def parallel_test(ctx, config):
         log.info('Executing command on all hosts concurrently with role "%s"' % role)
         cluster = ctx.cluster.only(role)
         nodes = {}
-        for remote in cluster.remotes.iterkeys():
+        for remote in cluster.remotes:
             """Call run for each remote host, but use 'wait=False' to have it return immediately."""
             proc = remote.run(args=['sleep', '5', run.Raw(';'), 'date', run.Raw(';'), 'hostname'], wait=False,)
             nodes[remote.name] = proc
-        for name, proc in nodes.iteritems():
+        for name, proc in nodes.items():
             """Wait for each process to finish before yielding and allowing other contextmanagers to run."""
             proc.wait()
     yield
@@ -48,7 +48,7 @@ def task(ctx, config):
                   for id_ in teuthology.all_roles_of_type(ctx.cluster, 'client')]
     if isinstance(config, list):
         config = dict.fromkeys(config)
-    clients = config.keys()
+    clients = list(config)
 
     """Run Multiple contextmanagers sequentially by nesting them."""
     with contextutil.nested(

--- a/teuthology/task/pcp.py
+++ b/teuthology/task/pcp.py
@@ -6,8 +6,9 @@ import logging
 import os
 import requests
 import time
-import urllib
-import urlparse
+
+import six.moves.urllib.parse as urllib_parse
+from six import string_types as basestring
 
 from teuthology.config import config as teuth_config
 from teuthology.orchestra import run
@@ -59,7 +60,7 @@ class PCPGrapher(PCPDataSource):
 
     def __init__(self, hosts, time_from, time_until='now'):
         super(PCPGrapher, self).__init__(hosts, time_from, time_until)
-        self.base_url = urlparse.urljoin(
+        self.base_url = urllib_parse.urljoin(
             teuth_config.pcp_host,
             self._endpoint)
 
@@ -78,7 +79,7 @@ class GrafanaGrapher(PCPGrapher):
         )
         if self.time_until:
             config['time_to'] = self._format_time(self.time_until)
-        args = urllib.urlencode(config)
+        args = urllib_parse.urlencode(config)
         template = "{base_url}?{args}"
         return template.format(base_url=self.base_url, args=args)
 
@@ -178,7 +179,7 @@ class GraphiteGrapher(PCPGrapher):
             # 'target=' arg
             'target': self.get_target_globs(metric),
         })
-        args = urllib.urlencode(config, doseq=True)
+        args = urllib_parse.urlencode(config, doseq=True)
         template = "{base_url}?{args}"
         return template.format(base_url=self.base_url, args=args)
 

--- a/teuthology/task/pexec.py
+++ b/teuthology/task/pexec.py
@@ -63,20 +63,20 @@ def _generate_remotes(ctx, config):
     """Return remote roles and the type of role specified in config"""
     if 'all' in config and len(config) == 1:
         ls = config['all']
-        for remote in ctx.cluster.remotes.iterkeys():
+        for remote in ctx.cluster.remotes:
             yield (remote, ls)
     elif 'clients' in config:
         ls = config['clients']
         for role in teuthology.all_roles_of_type(ctx.cluster, 'client'):
-            (remote,) = ctx.cluster.only('client.{r}'.format(r=role)).remotes.iterkeys()
+            (remote,) = ctx.cluster.only('client.{r}'.format(r=role)).remotes.keys()
             yield (remote, ls)
         del config['clients']
-        for role, ls in config.iteritems():
-            (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+        for role, ls in config.items():
+            (remote,) = ctx.cluster.only(role).remotes.keys()
             yield (remote, ls)
     else:
-        for role, ls in config.iteritems():
-            (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+        for role, ls in config.items():
+            (remote,) = ctx.cluster.only(role).remotes.keys()
             yield (remote, ls)
 
 def task(ctx, config):

--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -1,8 +1,7 @@
 import logging
 import os
 
-from cStringIO import StringIO
-
+from teuthology.compat import BytesIO, stringify
 from teuthology.exceptions import SELinuxError
 from teuthology.misc import get_archive_dir
 from teuthology.orchestra.cluster import Cluster
@@ -84,9 +83,9 @@ class SELinux(Task):
         for remote in self.cluster.remotes:
             result = remote.run(
                 args=['/usr/sbin/getenforce'],
-                stdout=StringIO(),
+                stdout=BytesIO(),
             )
-            modes[remote.name] = result.stdout.getvalue().strip().lower()
+            modes[remote.name] = stringify(result.stdout.getvalue().strip()).lower()
         log.debug("Existing SELinux modes: %s", modes)
         return modes
 
@@ -126,12 +125,12 @@ class SELinux(Task):
                 args=['sudo', 'grep', 'avc: .*denied',
                       '/var/log/audit/audit.log', run.Raw('|'), 'grep', '-v',
                       run.Raw(ignore_known_denials)],
-                stdout=StringIO(),
+                stdout=BytesIO(),
                 check_status=False,
             )
             output = proc.stdout.getvalue()
             if output:
-                denials = output.strip().split('\n')
+                denials = stringify(output.strip()).split('\n')
                 log.debug("%s has %s denials", remote.name, len(denials))
             else:
                 denials = []

--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -50,7 +50,7 @@ class SELinux(Task):
         """
         super(SELinux, self).filter_hosts()
         new_cluster = Cluster()
-        for (remote, roles) in self.cluster.remotes.iteritems():
+        for (remote, roles) in self.cluster.remotes.items():
             status_info = get_status(remote.name)
             if status_info and status_info.get('is_vm', False):
                 msg = "Excluding {host}: VMs are not yet supported"
@@ -81,7 +81,7 @@ class SELinux(Task):
 
         log.debug("Getting current SELinux state")
         modes = dict()
-        for remote in self.cluster.remotes.iterkeys():
+        for remote in self.cluster.remotes:
             result = remote.run(
                 args=['/usr/sbin/getenforce'],
                 stdout=StringIO(),
@@ -95,7 +95,7 @@ class SELinux(Task):
         Set the requested SELinux mode
         """
         log.info("Putting SELinux into %s mode", self.mode)
-        for remote in self.cluster.remotes.iterkeys():
+        for remote in self.cluster.remotes:
             remote.run(
                 args=['sudo', '/usr/sbin/setenforce', self.mode],
             )
@@ -121,7 +121,7 @@ class SELinux(Task):
         if se_whitelist:
             known_denials.extend(se_whitelist)
         ignore_known_denials = '\'\(' + str.join('\|', known_denials) + '\)\''
-        for remote in self.cluster.remotes.iterkeys():
+        for remote in self.cluster.remotes:
             proc = remote.run(
                 args=['sudo', 'grep', 'avc: .*denied',
                       '/var/log/audit/audit.log', run.Raw('|'), 'grep', '-v',
@@ -151,7 +151,7 @@ class SELinux(Task):
         if not set(self.old_modes.values()).difference(set([self.mode])):
             return
         log.info("Restoring old SELinux modes")
-        for remote in self.cluster.remotes.iterkeys():
+        for remote in self.cluster.remotes:
             mode = self.old_modes[remote.name]
             if mode != self.mode:
                 remote.run(
@@ -178,7 +178,7 @@ class SELinux(Task):
         """
         all_denials = self.get_denials()
         new_denials = dict()
-        for remote in self.cluster.remotes.iterkeys():
+        for remote in self.cluster.remotes:
             old_host_denials = self.old_denials[remote.name]
             all_host_denials = all_denials[remote.name]
             new_host_denials = set(all_host_denials).difference(
@@ -186,7 +186,7 @@ class SELinux(Task):
             )
             new_denials[remote.name] = list(new_host_denials)
 
-        for remote in self.cluster.remotes.iterkeys():
+        for remote in self.cluster.remotes:
             if len(new_denials[remote.name]):
                 raise SELinuxError(node=remote,
                                    denials=new_denials[remote.name])

--- a/teuthology/task/sequential.py
+++ b/teuthology/task/sequential.py
@@ -41,7 +41,7 @@ def task(ctx, config):
         for entry in config:
             if not isinstance(entry, dict):
                 entry = ctx.config.get(entry, {})
-            ((taskname, confg),) = entry.iteritems()
+            ((taskname, confg),) = entry.items()
             log.info('In sequential, running task %s...' % taskname)
             mgr = run_tasks.run_one_task(taskname, ctx=ctx, config=confg)
             if hasattr(mgr, '__enter__'):

--- a/teuthology/task/ssh_keys.py
+++ b/teuthology/task/ssh_keys.py
@@ -8,7 +8,7 @@ import paramiko
 import re
 from datetime import datetime
 
-from cStringIO import StringIO
+from teuthology.compat import StringIO
 from teuthology import contextutil
 import teuthology.misc as misc
 from ..orchestra import run

--- a/teuthology/task/ssh_keys.py
+++ b/teuthology/task/ssh_keys.py
@@ -134,7 +134,7 @@ def push_keys_to_host(ctx, config, public_key, private_key):
     # add an entry for all hosts in ctx to auth_keys_data
     auth_keys_data = ''
 
-    for inner_host in ctx.cluster.remotes.iterkeys():
+    for inner_host in ctx.cluster.remotes:
         inner_username, inner_hostname = str(inner_host).split('@')
         # create a 'user@hostname' string using our fake hostname
         fake_hostname = '{user}@{host}'.format(user=ssh_keys_user, host=str(inner_hostname))

--- a/teuthology/task/swift.py
+++ b/teuthology/task/swift.py
@@ -72,7 +72,7 @@ def create_users(ctx, config):
     users = {'': 'foo', '2': 'bar'}
     for client in config['clients']:
         testswift_conf = config['testswift_conf'][client]
-        for suffix, user in users.iteritems():
+        for suffix, user in users.items():
             _config_user(testswift_conf, '{user}.{client}'.format(user=user, client=client), user, suffix)
             ctx.cluster.only(client).run(
                 args=[
@@ -94,7 +94,7 @@ def create_users(ctx, config):
         yield
     finally:
         for client in config['clients']:
-            for user in users.itervalues():
+            for user in users.values():
                 uid = '{user}.{client}'.format(user=user, client=client)
                 ctx.cluster.only(client).run(
                     args=[
@@ -117,13 +117,13 @@ def configure(ctx, config):
     assert isinstance(config, dict)
     log.info('Configuring testswift...')
     testdir = teuthology.get_testdir(ctx)
-    for client, properties in config['clients'].iteritems():
+    for client, properties in config['clients'].items():
         log.info('client={c}'.format(c=client))
         log.info('config={c}'.format(c=config))
         testswift_conf = config['testswift_conf'][client]
         if properties is not None and 'rgw_server' in properties:
             host = None
-            for target, roles in zip(ctx.config['targets'].iterkeys(), ctx.config['roles']):
+            for target, roles in zip(ctx.config['targets'], ctx.config['roles']):
                 log.info('roles: ' + str(roles))
                 log.info('target: ' + str(target))
                 if properties['rgw_server'] in roles:
@@ -160,7 +160,7 @@ def run_tests(ctx, config):
     """
     assert isinstance(config, dict)
     testdir = teuthology.get_testdir(ctx)
-    for client, client_config in config.iteritems():
+    for client, client_config in config.items():
         args = [
                 'SWIFT_TEST_CONFIG_FILE={tdir}/archive/testswift.{client}.conf'.format(tdir=testdir, client=client),
                 '{tdir}/swift/virtualenv/bin/nosetests'.format(tdir=testdir),
@@ -225,7 +225,7 @@ def task(ctx, config):
         config = all_clients
     if isinstance(config, list):
         config = dict.fromkeys(config)
-    clients = config.keys()
+    clients = list(config)
 
     log.info('clients={c}'.format(c=clients))
 

--- a/teuthology/task/swift.py
+++ b/teuthology/task/swift.py
@@ -1,13 +1,13 @@
 """
 Test Swfit api.
 """
-from cStringIO import StringIO
 from configobj import ConfigObj
 import base64
 import contextlib
 import logging
 import os
 
+from teuthology.compat import StringIO
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from ..config import config as teuth_config

--- a/teuthology/task/tests/test_locking.py
+++ b/teuthology/task/tests/test_locking.py
@@ -7,7 +7,7 @@ class TestLocking(object):
         os_type = ctx.config.get("os_type")
         if os_type is None:
             pytest.skip('os_type was not defined')
-        for remote in ctx.cluster.remotes.iterkeys():
+        for remote in ctx.cluster.remotes:
             assert remote.os.name == os_type
 
     def test_correct_os_version(self, ctx, config):
@@ -16,10 +16,10 @@ class TestLocking(object):
             pytest.skip('os_version was not defined')
         if ctx.config.get("os_type") == "debian":
             pytest.skip('known issue with debian versions; see: issue #10878')
-        for remote in ctx.cluster.remotes.iterkeys():
+        for remote in ctx.cluster.remotes:
             assert remote.inventory_info['os_version'] == os_version
 
     def test_correct_machine_type(self, ctx, config):
         machine_type = ctx.machine_type
-        for remote in ctx.cluster.remotes.iterkeys():
+        for remote in ctx.cluster.remotes:
             assert remote.machine_type in machine_type

--- a/teuthology/task/tests/test_run.py
+++ b/teuthology/task/tests/test_run.py
@@ -34,7 +34,7 @@ class TestRun(object):
     def test_command_success(self, ctx, config):
         result = StringIO()
         ctx.cluster.run(
-            args=["python", "-c", "print 'hi'"],
+            args=["python", "-c", "print('hi')"],
             stdout=result
         )
         assert result.getvalue().strip() == "hi"

--- a/teuthology/task/tests/test_run.py
+++ b/teuthology/task/tests/test_run.py
@@ -1,8 +1,7 @@
 import logging
 import pytest
 
-from StringIO import StringIO
-
+from teuthology.compat import BytesIO
 from teuthology.exceptions import CommandFailedError
 
 log = logging.getLogger(__name__)
@@ -32,9 +31,9 @@ class TestRun(object):
             )
 
     def test_command_success(self, ctx, config):
-        result = StringIO()
+        result = BytesIO()
         ctx.cluster.run(
             args=["python", "-c", "print('hi')"],
             stdout=result
         )
-        assert result.getvalue().strip() == "hi"
+        assert result.getvalue().strip() == b"hi"

--- a/teuthology/test/fake_archive.py
+++ b/teuthology/test/fake_archive.py
@@ -71,12 +71,12 @@ class FakeArchive(object):
             archive_dir = os.path.join(run_archive_dir, str(job['job_id']))
             os.mkdir(archive_dir)
 
-            with file(os.path.join(archive_dir, 'info.yaml'), 'w') as yfile:
+            with open(os.path.join(archive_dir, 'info.yaml'), 'w') as yfile:
                 yaml.safe_dump(job['info'], yfile)
 
             if 'summary' in job:
                 summary_path = os.path.join(archive_dir, 'summary.yaml')
-                with file(summary_path, 'w') as yfile:
+                with open(summary_path, 'w') as yfile:
                     yaml.safe_dump(job['summary'], yfile)
 
     def create_fake_run(self, run_name, job_count, yaml_path, num_hung=0):

--- a/teuthology/test/fake_fs.py
+++ b/teuthology/test/fake_fs.py
@@ -1,6 +1,10 @@
 from cStringIO import StringIO
 from contextlib import closing
 
+try:
+    FileNotFoundError, NotADirectoryError
+except NameError:
+    FileNotFoundError = NotADirectoryError = OSError
 
 def make_fake_fstools(fake_filesystem):
     """
@@ -41,13 +45,13 @@ def make_fake_fstools(fake_filesystem):
         while '/' in remainder:
             next_dir, remainder = remainder.split('/', 1)
             if next_dir not in subdict:
-                raise OSError(
+                raise FileNotFoundError(
                     '[Errno 2] No such file or directory: %s' % next_dir)
             subdict = subdict.get(next_dir)
             if not isinstance(subdict, dict):
-                raise OSError('[Errno 20] Not a directory: %s' % next_dir)
+                raise NotADirectoryError('[Errno 20] Not a directory: %s' % next_dir)
             if subdict and not remainder:
-                return subdict.keys()
+                return list(subdict)
         return []
 
     def fake_isfile(path, fsdict=False):
@@ -58,7 +62,7 @@ def make_fake_fstools(fake_filesystem):
         subdict = fsdict
         for component in components:
             if component not in subdict:
-                raise OSError(
+                raise FileNotFoundError(
                     '[Errno 2] No such file or directory: %s' % component)
             subdict = subdict.get(component)
         return subdict is None or isinstance(subdict, str)

--- a/teuthology/test/fake_fs.py
+++ b/teuthology/test/fake_fs.py
@@ -1,5 +1,7 @@
-from cStringIO import StringIO
 from contextlib import closing
+
+from teuthology.compat import StringIO
+
 
 try:
     FileNotFoundError, NotADirectoryError

--- a/teuthology/test/task/__init__.py
+++ b/teuthology/test/task/__init__.py
@@ -44,7 +44,7 @@ class TestTask(object):
             end=DEFAULT,
         ):
             with self.klass(self.ctx, self.task_config) as task:
-                task_hosts = task.cluster.remotes.keys()
+                task_hosts = list(task.cluster.remotes)
                 assert len(task_hosts) == 2
                 assert sorted(host.shortname for host in task_hosts) == \
                     ['remote1', 'remote2']
@@ -77,7 +77,7 @@ class TestTask(object):
             end=DEFAULT,
         ):
             with self.klass(self.ctx, self.task_config) as task:
-                task_hosts = task.cluster.remotes.keys()
+                task_hosts = list(task.cluster.remotes)
                 assert len(task_hosts) == 1
                 assert task_hosts[0].shortname == 'remote1'
 
@@ -95,7 +95,7 @@ class TestTask(object):
             end=DEFAULT,
         ):
             with self.klass(self.ctx, self.task_config) as task:
-                task_hosts = task.cluster.remotes.keys()
+                task_hosts = list(task.cluster.remotes)
                 assert len(task_hosts) == 2
                 hostnames = [host.shortname for host in task_hosts]
                 assert sorted(hostnames) == ['remote1', 'remote3']
@@ -114,7 +114,7 @@ class TestTask(object):
             end=DEFAULT,
         ):
             with self.klass(self.ctx, self.task_config) as task:
-                task_hosts = task.cluster.remotes.keys()
+                task_hosts = list(task.cluster.remotes)
                 assert len(task_hosts) == 2
                 hostnames = [host.hostname for host in task_hosts]
                 assert sorted(hostnames) == ['remote1.example.com',
@@ -134,7 +134,7 @@ class TestTask(object):
             end=DEFAULT,
         ):
             with self.klass(self.ctx, self.task_config) as task:
-                task_hosts = task.cluster.remotes.keys()
+                task_hosts = list(task.cluster.remotes)
                 assert len(task_hosts) == 2
                 hostnames = [host.hostname for host in task_hosts]
                 assert sorted(hostnames) == ['remote1.example.com',

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -171,7 +171,7 @@ class TestAnsibleTask(TestTask):
             playbook='~/fake/playbook',
         ))
         task = self.klass(self.ctx, self.task_config)
-        with patch('teuthology.task.ansible.file', create=True) as m_file:
+        with patch('teuthology.task.ansible.open', create=True) as m_file:
             m_file.return_value = fake_playbook_obj
             task.get_playbook()
         assert task.playbook == fake_playbook
@@ -274,7 +274,7 @@ class TestAnsibleTask(TestTask):
         fake_playbook_obj.name = playbook
 
         task = self.klass(self.ctx, self.task_config)
-        with patch('teuthology.task.ansible.file', create=True) as m_file:
+        with patch('teuthology.task.ansible.open', create=True) as m_file:
             m_file.return_value = fake_playbook_obj
             task.setup()
         args = task._build_args()
@@ -339,7 +339,7 @@ class TestAnsibleTask(TestTask):
         assert args.count('--extra-vars') == 1
         vars_str = args[args.index('--extra-vars') + 1].strip("'")
         extra_vars = json.loads(vars_str)
-        assert extra_vars.keys() == ['ansible_ssh_user']
+        assert list(extra_vars) == ['ansible_ssh_user']
 
     def test_build_args_vars(self):
         extra_vars = dict(
@@ -467,7 +467,7 @@ class TestCephLabTask(TestTask):
         fake_playbook_obj.name = playbook
         task = self.klass(self.ctx, dict())
         task.repo_path = '/tmp/fake/repo'
-        with patch('teuthology.task.ansible.file', create=True) as m_file:
+        with patch('teuthology.task.ansible.open', create=True) as m_file:
             m_file.return_value = fake_playbook_obj
             task.get_playbook()
         assert task.playbook_file.name == playbook

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -4,8 +4,8 @@ import yaml
 
 from mock import patch, DEFAULT, Mock
 from pytest import raises
-from StringIO import StringIO
 
+from teuthology.compat import PyStringIO as StringIO
 from teuthology.config import config, FakeNamespace
 from teuthology.exceptions import CommandFailedError
 from teuthology.orchestra.cluster import Cluster
@@ -227,7 +227,7 @@ class TestAnsibleTask(TestTask):
         with patch.object(ansible, 'NamedTemporaryFile') as m_NTF:
             m_NTF.return_value = hosts_file_obj
             task.generate_hosts_file()
-            m_NTF.assert_called_once_with(prefix="teuth_ansible_hosts_",
+            m_NTF.assert_called_once_with('w', prefix="teuth_ansible_hosts_",
                                           delete=False)
         assert task.generated_inventory is True
         assert task.inventory == hosts_file_path
@@ -255,7 +255,7 @@ class TestAnsibleTask(TestTask):
             task.find_repo()
             task.get_playbook()
             task.generate_playbook()
-            m_NTF.assert_called_once_with(prefix="teuth_ansible_playbook_",
+            m_NTF.assert_called_once_with('w+', prefix="teuth_ansible_playbook_",
                                           dir=task.repo_path,
                                           delete=False)
         assert task.generated_playbook is True
@@ -483,7 +483,7 @@ class TestCephLabTask(TestTask):
         with patch.object(ansible, 'NamedTemporaryFile') as m_NTF:
             m_NTF.return_value = hosts_file_obj
             task.generate_hosts_file()
-            m_NTF.assert_called_once_with(prefix="teuth_ansible_hosts_",
+            m_NTF.assert_called_once_with('w', prefix="teuth_ansible_hosts_",
                                           delete=False)
         assert task.generated_inventory is True
         assert task.inventory == hosts_file_path

--- a/teuthology/test/task/test_ceph_ansible.py
+++ b/teuthology/test/task/test_ceph_ansible.py
@@ -1,7 +1,7 @@
 from mock import patch, MagicMock
 from pytest import skip
-from StringIO import StringIO
 
+from teuthology.compat import PyStringIO as StringIO
 from teuthology.config import FakeNamespace
 from teuthology.orchestra.cluster import Cluster
 from teuthology.orchestra.remote import Remote
@@ -91,7 +91,7 @@ class TestCephAnsibleTask(TestAnsibleTask):
         with patch.object(ansible, 'NamedTemporaryFile') as m_NTF:
             m_NTF.return_value = hosts_file_obj
             task.generate_hosts_file()
-            m_NTF.assert_called_once_with(prefix="teuth_ansible_hosts_",
+            m_NTF.assert_called_once_with('w', prefix="teuth_ansible_hosts_",
                                           delete=False)
         assert task.generated_inventory is True
         assert task.inventory == hosts_file_path
@@ -122,7 +122,7 @@ class TestCephAnsibleTask(TestAnsibleTask):
         with patch.object(ansible, 'NamedTemporaryFile') as m_NTF:
             m_NTF.return_value = hosts_file_obj
             task.generate_hosts_file()
-            m_NTF.assert_called_once_with(prefix="teuth_ansible_hosts_",
+            m_NTF.assert_called_once_with('w', prefix="teuth_ansible_hosts_",
                                           delete=False)
         assert task.generated_inventory is True
         assert task.inventory == hosts_file_path
@@ -152,7 +152,7 @@ class TestCephAnsibleTask(TestAnsibleTask):
         with patch.object(ansible, 'NamedTemporaryFile') as m_NTF:
             m_NTF.return_value = hosts_file_obj
             task.generate_hosts_file()
-            m_NTF.assert_called_once_with(prefix="teuth_ansible_hosts_",
+            m_NTF.assert_called_once_with('w', prefix="teuth_ansible_hosts_",
                                           delete=False)
         assert task.generated_inventory is True
         assert task.inventory == hosts_file_path

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -16,14 +16,8 @@ class TestInstall(object):
         )
         pkgs = yaml.safe_load(open(path))[project]
         if not debug:
-            pkgs['deb'] = filter(
-                lambda p: not p.endswith('-dbg'),
-                pkgs['deb']
-            )
-            pkgs['rpm'] = filter(
-                lambda p: not p.endswith('-debuginfo'),
-                pkgs['rpm']
-            )
+            pkgs['deb'] = [p for p in pkgs['deb'] if not p.endswith('-dbg')]
+            pkgs['rpm'] = [p for p in pkgs['rpm'] if not p.endswith('-debuginfo')]
         return pkgs
 
     def test_get_package_list_debug(self):

--- a/teuthology/test/task/test_pcp.py
+++ b/teuthology/test/task/test_pcp.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-from mock import patch, DEFAULT, Mock, MagicMock, call
+from mock import patch, DEFAULT, Mock, call, mock_open
 from pytest import raises
 
 import six.moves.urllib.parse as urllib_parse
@@ -171,8 +171,7 @@ class TestGraphiteGrapher(TestPCPGrapher):
             m_resp = Mock()
             m_resp.ok = True
             m_get.return_value = m_resp
-            with patch('teuthology.task.pcp.open', create=True) as m_open:
-                m_open.return_value = MagicMock(spec=file)
+            with patch('teuthology.task.pcp.open', mock_open(), create=True):
                 obj.download_graphs()
         expected_filenames = []
         for metric in obj.metrics:
@@ -200,8 +199,7 @@ class TestGraphiteGrapher(TestPCPGrapher):
             m_resp = Mock()
             m_resp.ok = True
             m_get.return_value = m_resp
-            with patch('teuthology.task.pcp.open', create=True) as m_open:
-                m_open.return_value = MagicMock(spec=file)
+            with patch('teuthology.task.pcp.open', mock_open(), create=True):
                 obj.download_graphs()
         html = obj.generate_html(mode='static')
         assert config.pcp_host not in html

--- a/teuthology/test/task/test_pcp.py
+++ b/teuthology/test/task/test_pcp.py
@@ -1,9 +1,10 @@
 import os
 import requests
-import urlparse
 
 from mock import patch, DEFAULT, Mock, MagicMock, call
 from pytest import raises
+
+import six.moves.urllib.parse as urllib_parse
 
 from teuthology.config import config, FakeNamespace
 from teuthology.orchestra.cluster import Cluster
@@ -87,7 +88,7 @@ class TestPCPGrapher(TestPCPDataSource):
         assert obj.hosts == hosts
         assert obj.time_from == time_from
         assert obj.time_until == time_until
-        expected_url = urlparse.urljoin(config.pcp_host, self.klass._endpoint)
+        expected_url = urllib_parse.urljoin(config.pcp_host, self.klass._endpoint)
         assert obj.base_url == expected_url
 
 
@@ -103,13 +104,13 @@ class TestGrafanaGrapher(TestPCPGrapher):
             time_from=time_from,
             time_until=time_until,
         )
-        base_url = urlparse.urljoin(
+        base_url = urllib_parse.urljoin(
             config.pcp_host,
             'grafana/index.html#/dashboard/script/index.js',
         )
         assert obj.base_url == base_url
         got_url = obj.build_graph_url()
-        parsed_query = urlparse.parse_qs(got_url.split('?')[1])
+        parsed_query = urllib_parse.parse_qs(got_url.split('?')[1])
         assert parsed_query['hosts'] == hosts
         assert len(parsed_query['time_from']) == 1
         assert parsed_query['time_from'][0] == time_from
@@ -212,7 +213,7 @@ class TestGraphiteGrapher(TestPCPGrapher):
             'foo.bar baz': 'foo.bar_baz',
             'foo.*.bar baz': 'foo._all_.bar_baz',
         }
-        for in_, out in sanitized_metrics.iteritems():
+        for in_, out in sanitized_metrics.items():
             assert self.klass._sanitize_metric_name(in_) == out
 
     def test_get_target_globs(self):

--- a/teuthology/test/task/test_selinux.py
+++ b/teuthology/test/task/test_selinux.py
@@ -30,6 +30,6 @@ class TestSELinux(object):
             self.ctx.cluster.add(remote2, ['role2'])
             task_config = dict()
             with SELinux(self.ctx, task_config) as task:
-                remotes = task.cluster.remotes.keys()
+                remotes = list(task.cluster.remotes)
                 assert remotes == [remote1]
 

--- a/teuthology/test/test_contextutil.py
+++ b/teuthology/test/test_contextutil.py
@@ -25,8 +25,7 @@ class TestSafeWhile(object):
                 while proceed():
                     pass
 
-        msg = error.value[0]
-        assert 'waiting for 6 seconds' in msg
+        assert 'waiting for 6 seconds' in str(error)
 
     def test_1_0_10_deal(self):
         with raises(contextutil.MaxWhileTries) as error:
@@ -37,8 +36,7 @@ class TestSafeWhile(object):
                 while proceed():
                     pass
 
-        msg = error.value[0]
-        assert 'waiting for 10 seconds' in msg
+        assert 'waiting for 10 seconds' in str(error)
 
     def test_6_1_10_deal(self):
         with raises(contextutil.MaxWhileTries) as error:
@@ -49,8 +47,7 @@ class TestSafeWhile(object):
                 while proceed():
                     pass
 
-        msg = error.value[0]
-        assert 'waiting for 105 seconds' in msg
+        assert 'waiting for 105 seconds' in str(error)
 
     def test_action(self):
         with raises(contextutil.MaxWhileTries) as error:
@@ -61,8 +58,7 @@ class TestSafeWhile(object):
                 while proceed():
                     pass
 
-        msg = error.value[0]
-        assert "'doing the thing' reached maximum tries" in msg
+        assert "'doing the thing' reached maximum tries" in str(error)
 
     def test_no_raise(self):
         with self.s_while(_raise=False, _sleeper=self.fake_sleep) as proceed:

--- a/teuthology/test/test_describe_tests.py
+++ b/teuthology/test/test_describe_tests.py
@@ -106,20 +106,19 @@ expected_rbd_features = [
 
 class TestDescribeTests(object):
 
-    patchpoints = [
-        'os.path.exists',
-        'os.listdir',
-        'os.path.isfile',
-        'os.path.isdir',
-        '__builtin__.open',
-    ]
-    fake_fns = make_fake_fstools(realistic_fs)
-
     def setup(self):
         self.mocks = dict()
         self.patchers = dict()
-        klass = self.__class__
-        for ppoint, fn in zip(klass.patchpoints, klass.fake_fns):
+        exists, listdir, isfile, isdir, open = make_fake_fstools(realistic_fs)
+        for ppoint, fn in {
+            'teuthology.describe_tests.listdir': listdir,
+            'teuthology.describe_tests.isdir': isdir,
+            'teuthology.describe_tests.open': open,
+            'teuthology.suite.build_matrix.exists': exists,
+            'teuthology.suite.build_matrix.listdir': listdir,
+            'teuthology.suite.build_matrix.isfile': isfile,
+            'teuthology.suite.build_matrix.isdir': isdir,
+        }.items():
             mockobj = MagicMock()
             patcher = patch(ppoint, mockobj)
             mockobj.side_effect = fn
@@ -223,7 +222,7 @@ class TestDescribeTests(object):
         assert rows == [['basic', 'install', 'fixed-1', 'rbd_api_tests']]
 
 
-@patch('__builtin__.open')
+@patch('teuthology.describe_tests.open')
 @patch('os.path.isdir')
 def test_extract_info_dir(m_isdir, m_open):
     simple_fs = {'a': {'b.yaml': 'meta: [{foo: c}]'}}
@@ -239,7 +238,7 @@ def test_extract_info_dir(m_isdir, m_open):
     assert info == {'foo': 'c', 'bar': ''}
 
 
-@patch('__builtin__.open')
+@patch('teuthology.describe_tests.open')
 @patch('os.path.isdir')
 def check_parse_error(fs, m_isdir, m_open):
     _, _, _, m_isdir.side_effect, m_open.side_effect = make_fake_fstools(fs)
@@ -260,7 +259,7 @@ def test_extract_info_not_a_dict():
     check_parse_error({'a.yaml': 'meta: [[a, b]]'})
 
 
-@patch('__builtin__.open')
+@patch('teuthology.describe_tests.open')
 @patch('os.path.isdir')
 def test_extract_info_empty_file(m_isdir, m_open):
     simple_fs = {'a.yaml': ''}

--- a/teuthology/test/test_describe_tests.py
+++ b/teuthology/test/test_describe_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from fake_fs import make_fake_fstools
+from .fake_fs import make_fake_fstools
 from teuthology.describe_tests import (tree_with_info, extract_info,
                                        get_combinations)
 from teuthology.exceptions import ParseError

--- a/teuthology/test/test_describe_tests.py
+++ b/teuthology/test/test_describe_tests.py
@@ -145,51 +145,53 @@ class TestDescribeTests(object):
 
     def test_single_filter(self):
         rows = tree_with_info('basic', ['desc'], False, '', [])
-        assert rows == map(list, zip(expected_tree, expected_desc))
+        assert rows == [list(exp) for exp in zip(expected_tree, expected_desc)]
 
         rows = tree_with_info('basic', ['rbd_features'], False, '', [])
-        assert rows == map(list, zip(expected_tree, expected_rbd_features))
+        assert rows == [list(exp) for exp in zip(expected_tree,
+                                                 expected_rbd_features)]
 
     def test_single_filter_with_facets(self):
         rows = tree_with_info('basic', ['desc'], True, '', [])
-        assert rows == map(list, zip(expected_tree, expected_facets,
-                                     expected_desc))
+        assert rows == [list(exp) for exp in zip(expected_tree, expected_facets,
+                                                 expected_desc)]
 
         rows = tree_with_info('basic', ['rbd_features'], True, '', [])
-        assert rows == map(list, zip(expected_tree, expected_facets,
-                                     expected_rbd_features))
+        assert rows == [list(exp) for exp in zip(expected_tree, expected_facets,
+                                                 expected_rbd_features)]
 
     def test_no_matching(self):
         rows = tree_with_info('basic', ['extra'], False, '', [])
-        assert rows == map(list, zip(expected_tree, [''] * len(expected_tree)))
+        assert rows == [list(exp) for exp in zip(expected_tree,
+                                                 [''] * len(expected_tree))]
 
         rows = tree_with_info('basic', ['extra'], True, '', [])
-        assert rows == map(list, zip(expected_tree, expected_facets,
-                                     [''] * len(expected_tree)))
+        assert rows == [list(exp) for exp in zip(expected_tree, expected_facets,
+                                                 [''] * len(expected_tree))]
 
     def test_multiple_filters(self):
         rows = tree_with_info('basic', ['desc', 'rbd_features'], False, '', [])
-        assert rows == map(list, zip(expected_tree,
-                                     expected_desc,
-                                     expected_rbd_features))
+        assert rows == [list(exp) for exp in zip(expected_tree,
+                                                 expected_desc,
+                                                 expected_rbd_features)]
 
         rows = tree_with_info('basic', ['rbd_features', 'desc'], False, '', [])
-        assert rows == map(list, zip(expected_tree,
-                                     expected_rbd_features,
-                                     expected_desc))
+        assert rows == [list(exp) for exp in zip(expected_tree,
+                                                 expected_rbd_features,
+                                                 expected_desc)]
 
     def test_multiple_filters_with_facets(self):
         rows = tree_with_info('basic', ['desc', 'rbd_features'], True, '', [])
-        assert rows == map(list, zip(expected_tree,
-                                     expected_facets,
-                                     expected_desc,
-                                     expected_rbd_features))
+        assert rows == [list(exp) for exp in zip(expected_tree,
+                                                 expected_facets,
+                                                 expected_desc,
+                                                 expected_rbd_features)]
 
         rows = tree_with_info('basic', ['rbd_features', 'desc'], True, '', [])
-        assert rows == map(list, zip(expected_tree,
-                                     expected_facets,
-                                     expected_rbd_features,
-                                     expected_desc))
+        assert rows == [list(exp) for exp in zip(expected_tree,
+                                                 expected_facets,
+                                                 expected_rbd_features,
+                                                 expected_desc)]
 
     def test_combinations_only_facets(self):
         headers, rows = get_combinations('basic', [], None, 1, None, None, True)

--- a/teuthology/test/test_ls.py
+++ b/teuthology/test/test_ls.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import patch, Mock
+from mock import patch, Mock, mock_open
 
 from teuthology import ls
 
@@ -17,14 +17,14 @@ class TestLs(object):
         assert results == ["1", "3"]
 
     @patch("yaml.safe_load_all")
-    @patch("__builtin__.file")
+    @patch("teuthology.ls.open")
     @patch("teuthology.ls.get_jobs")
     def test_ls(self, m_get_jobs, m_file, m_safe_load_all):
         m_get_jobs.return_value = ["1", "2"]
         m_safe_load_all.return_value = [{"failure_reason": "reasons"}]
         ls.ls("some/archive/div", True)
 
-    @patch("__builtin__.file")
+    @patch("teuthology.ls.open")
     @patch("teuthology.ls.get_jobs")
     def test_ls_ioerror(self, m_get_jobs, m_file):
         m_get_jobs.return_value = ["1", "2"]
@@ -32,15 +32,12 @@ class TestLs(object):
         with pytest.raises(IOError):
             ls.ls("some/archive/dir", True)
 
-    @patch("__builtin__.open")
+    @patch("teuthology.ls.open", mock_open(read_data='... some/archive/dir'))
     @patch("os.popen")
     @patch("os.path.isdir")
     @patch("os.path.isfile")
-    def test_print_debug_info(self, m_isfile, m_isdir, m_popen, m_open):
+    def test_print_debug_info(self, m_isfile, m_isdir, m_popen):
         m_isfile.return_value = True
         m_isdir.return_value = True
         m_popen.return_value = Mock()
-        cmdline = Mock()
-        cmdline.find.return_value = True
-        m_open.return_value = cmdline
         ls.print_debug_info("the_job", "job/dir", "some/archive/dir")

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -298,7 +298,7 @@ class TestMergeConfigs(object):
 
     @patch("os.path.exists")
     @patch("yaml.safe_load")
-    @patch("__builtin__.file")
+    @patch("teuthology.misc.open")
     def test_merge_configs(self, m_file, m_safe_load, m_exists):
         """ Only tests with one yaml file being passed, mainly just to test
             the loop logic.  The actual merge will be tested in subsequent

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -148,7 +148,7 @@ class TestPackaging(object):
             'python', '-c',
             'import koji; '
             'hub = koji.ClientSession("http://kojihub.com"); '
-            'print hub.getBuild(1)',
+            'print(hub.getBuild(1))',
         ]
         assert expected_args == kwargs['args']
 
@@ -180,7 +180,7 @@ class TestPackaging(object):
             'python', '-c',
             'import koji; '
             'hub = koji.ClientSession("http://kojihub.com"); '
-            'print hub.getTaskResult(1)',
+            'print(hub.getTaskResult(1))',
         ]
         assert expected_args == kwargs['args']
 

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -138,7 +138,7 @@ class TestPackaging(object):
         m_proc = Mock()
         expected = dict(foo="bar")
         m_proc.exitstatus = 0
-        m_proc.stdout.getvalue.return_value = str(expected)
+        m_proc.stdout.getvalue.return_value = b"{'foo': 'bar'}"
         m_remote = Mock()
         m_remote.run.return_value = m_proc
         result = packaging.get_koji_build_info(1, m_remote, dict())
@@ -170,7 +170,7 @@ class TestPackaging(object):
         m_proc = Mock()
         expected = dict(foo="bar")
         m_proc.exitstatus = 0
-        m_proc.stdout.getvalue.return_value = str(expected)
+        m_proc.stdout.getvalue.return_value = b"{'foo': 'bar'}"
         m_remote = Mock()
         m_remote.run.return_value = m_proc
         result = packaging.get_koji_task_result(1, m_remote, dict())
@@ -219,7 +219,7 @@ class TestPackaging(object):
         remote.os.package_type = "deb"
         proc = Mock()
         proc.exitstatus = 0
-        proc.stdout.getvalue.return_value = "2.2"
+        proc.stdout.getvalue.return_value = b"2.2"
         remote.run.return_value = proc
         result = packaging.get_package_version(remote, "apache2")
         assert result == "2.2"
@@ -237,7 +237,7 @@ class TestPackaging(object):
         remote.os.package_type = "rpm"
         proc = Mock()
         proc.exitstatus = 0
-        proc.stdout.getvalue.return_value = "2.2"
+        proc.stdout.getvalue.return_value = b"2.2"
         remote.run.return_value = proc
         result = packaging.get_package_version(remote, "httpd")
         assert result == "2.2"
@@ -255,7 +255,7 @@ class TestPackaging(object):
         remote.os.package_type = "rpm"
         proc = Mock()
         proc.exitstatus = 1
-        proc.stdout.getvalue.return_value = "not installed"
+        proc.stdout.getvalue.return_value = b"not installed"
         remote.run.return_value = proc
         result = packaging.get_package_version(remote, "httpd")
         assert result is None
@@ -268,7 +268,7 @@ class TestPackaging(object):
         remote.os.package_type = "rpm"
         proc = Mock()
         proc.exitstatus = 0
-        proc.stdout.getvalue.return_value = "not installed"
+        proc.stdout.getvalue.return_value = b"not installed"
         remote.run.return_value = proc
         result = packaging.get_package_version(remote, "httpd")
         assert result is None

--- a/teuthology/test/test_report.py
+++ b/teuthology/test/test_report.py
@@ -63,7 +63,7 @@ class TestSerializer(object):
         jobs = self.archive.create_fake_run(run_name, job_count, yaml_path)
         job = jobs[0]
 
-        with file(yaml_path) as yaml_file:
+        with open(yaml_path) as yaml_file:
             obj_from_yaml = yaml.safe_load(yaml_file)
         full_obj = obj_from_yaml.copy()
         full_obj.update(job['info'])

--- a/teuthology/test/test_report.py
+++ b/teuthology/test/test_report.py
@@ -1,6 +1,6 @@
 import yaml
 import json
-import fake_archive
+from . import fake_archive
 from .. import report
 
 

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -32,7 +32,7 @@ class TestRun(object):
 
     @patch("teuthology.run.merge_configs")
     def test_setup_config_targets_ok(self, m_merge_configs):
-        config = {"targets": range(4), "roles": range(2)}
+        config = {"targets": list(range(4)), "roles": list(range(2))}
         m_merge_configs.return_value = config
         result = run.setup_config(["some/config.yaml"])
         assert result["targets"] == [0, 1, 2, 3]
@@ -40,7 +40,7 @@ class TestRun(object):
 
     @patch("teuthology.run.merge_configs")
     def test_setup_config_targets_invalid(self, m_merge_configs):
-        config = {"targets": range(2), "roles": range(4)}
+        config = {"targets": list(range(2)), "roles": list(range(4))}
         m_merge_configs.return_value = config
         with pytest.raises(AssertionError):
             run.setup_config(["some/config.yaml"])
@@ -77,7 +77,7 @@ class TestRun(object):
         config = {"tasks": [{"kernel": "can't be here"}]}
         with pytest.raises(AssertionError) as excinfo:
             run.validate_tasks(config)
-        assert excinfo.value.message.startswith("kernel installation")
+        assert str(excinfo.value).startswith("kernel installation")
 
     def test_validate_task_no_tasks(self):
         result = run.validate_tasks({})
@@ -91,16 +91,16 @@ class TestRun(object):
     def test_validate_tasks_is_list(self):
         with pytest.raises(AssertionError) as excinfo:
             run.validate_tasks({"tasks": {"foo": "bar"}})
-        assert excinfo.value.message.startswith("Expected list")
+        assert str(excinfo.value).startswith("Expected list")
 
     def test_get_initial_tasks_invalid(self):
         with pytest.raises(AssertionError) as excinfo:
             run.get_initial_tasks(True, {"targets": "can't be here",
                                          "roles": "roles" }, "machine_type")
-        assert excinfo.value.message.startswith("You cannot")
+        assert str(excinfo.value).startswith("You cannot")
 
     def test_get_inital_tasks(self):
-        config = {"roles": range(2), "kernel": "the_kernel", "use_existing_cluster": False}
+        config = {"roles": list(range(2)), "kernel": "the_kernel", "use_existing_cluster": False}
         result = run.get_initial_tasks(True, config, "machine_type")
         assert {"internal.lock_machines": (2, "machine_type")} in result
         assert {"kernel": "the_kernel"} in result

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -45,7 +45,7 @@ class TestRun(object):
         with pytest.raises(AssertionError):
             run.setup_config(["some/config.yaml"])
 
-    @patch("__builtin__.file")
+    @patch("teuthology.run.open")
     def test_write_initial_metadata(self, m_file):
         config = {"job_id": "123", "foo": "bar"}
         run.write_initial_metadata(
@@ -121,7 +121,7 @@ class TestRun(object):
     @patch("yaml.safe_dump")
     @patch("teuthology.report.try_push_job_info")
     @patch("teuthology.run.email_results")
-    @patch("__builtin__.file")
+    @patch("teuthology.run.open")
     @patch("sys.exit")
     def test_report_outcome(self, m_sys_exit, m_file, m_email_results, m_try_push_job_info, m_safe_dump, m_nuke, m_get_status):
         config = {"nuke-on-error": True, "email-on-error": True}

--- a/teuthology/test/test_timer.py
+++ b/teuthology/test/test_timer.py
@@ -37,8 +37,7 @@ class TestTimer(object):
                 fake_time.return_value = now
                 self.timer.mark(str(i))
 
-        summed_intervals = map(lambda x: sum(intervals[:x + 1]),
-                               range(len(intervals)))
+        summed_intervals = [sum(intervals[:x + 1]) for x in range(len(intervals))]
         result_intervals = [m['interval'] for m in self.timer.data['marks']]
         assert result_intervals == summed_intervals
         assert self.timer.data['start'] == \
@@ -46,7 +45,7 @@ class TestTimer(object):
         assert self.timer.data['end'] == \
             self.timer.get_datetime_string(start_time + summed_intervals[-1])
         assert [m['message'] for m in self.timer.data['marks']] == \
-            map(str, intervals)
+            [str(i) for i in intervals]
         assert self.timer.data['elapsed'] == summed_intervals[-1]
 
     def test_write(self):

--- a/teuthology/test/test_timer.py
+++ b/teuthology/test/test_timer.py
@@ -1,6 +1,6 @@
 from teuthology import timer
 
-from mock import MagicMock, patch
+from mock import MagicMock, patch, mock_open
 from time import time
 
 
@@ -52,8 +52,7 @@ class TestTimer(object):
         _path = '/path'
         _safe_dump = MagicMock(name='safe_dump')
         with patch('teuthology.timer.yaml.safe_dump', _safe_dump):
-            with patch('teuthology.timer.file') as _file:
-                _file.return_value = MagicMock(spec=file)
+            with patch('teuthology.timer.open', mock_open(), create=True) as _file:
                 self.timer = timer.Timer(path=_path)
                 assert self.timer.path == _path
                 self.timer.write()
@@ -68,8 +67,7 @@ class TestTimer(object):
         _path = '/path'
         _safe_dump = MagicMock(name='safe_dump')
         with patch('teuthology.timer.yaml.safe_dump', _safe_dump):
-            with patch('teuthology.timer.file') as _file:
-                _file.return_value = MagicMock(spec=file)
+            with patch('teuthology.timer.open', mock_open(), create=True) as _file:
                 self.timer = timer.Timer(path=_path, sync=True)
                 assert self.timer.path == _path
                 assert self.timer.sync is True

--- a/teuthology/timer.py
+++ b/teuthology/timer.py
@@ -108,7 +108,7 @@ class Timer(object):
 
     def write(self):
         try:
-            with file(self.path, 'w') as f:
+            with open(self.path, 'w') as f:
                 yaml.safe_dump(self.data, f, default_flow_style=False)
         except Exception:
             log.exception("Failed to write timing.yaml !")

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -110,7 +110,12 @@ def main(ctx):
 
         # bury the job so it won't be re-run if it fails
         job.bury()
-        job_id = job.jid
+        try:
+            # beanstalkc
+            job_id = job.jid
+        except AttributeError:
+            # pystalkd
+            job_id = job.job_id
         log.info('Reserved job %d', job_id)
         log.info('Config is: %s', job.body)
         job_config = yaml.safe_load(job.body)

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -9,6 +9,7 @@ import yaml
 from datetime import datetime
 
 from teuthology import setup_log_file
+from teuthology.compat import stringify
 from . import beanstalk
 from . import report
 from . import safepath
@@ -247,7 +248,7 @@ def run_job(job_config, teuth_bin_path, archive_dir, verbose):
 
     with tempfile.NamedTemporaryFile(prefix='teuthology-worker.',
                                      suffix='.tmp',) as tmp:
-        yaml.safe_dump(data=job_config, stream=tmp)
+        yaml.safe_dump(data=job_config, stream=tmp, encoding='utf-8')
         tmp.flush()
         arg.append(tmp.name)
         env = os.environ.copy()
@@ -324,7 +325,7 @@ def run_with_watchdog(process, job_config):
                                            stderr=subprocess.STDOUT)
             while report_proc.poll() is None:
                 for line in report_proc.stdout.readlines():
-                    log.info(line.strip())
+                    log.info(stringify(line.strip()))
                 time.sleep(1)
             log.info("Reported results via the teuthology-report command")
         except Exception:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,23 @@
 [tox]
-envlist = docs, py27, py27-integration, flake8, openstack
+envlist = docs, py27, py27-integration, py34, flake8, openstack
 
 [testenv:py27]
+install_command = pip install --upgrade {opts} {packages}
+passenv = HOME
+sitepackages=True
+deps=
+  -r{toxinidir}/requirements.txt
+  mock
+  fudge
+  nose
+  pytest-capturelog
+  pytest-cov==1.6
+  coverage==3.7.1
+
+commands=
+    py.test --cov=teuthology --cov-report=term -v {posargs:teuthology scripts}
+
+[testenv:py34]
 install_command = pip install --upgrade {opts} {packages}
 passenv = HOME
 sitepackages=True


### PR DESCRIPTION
This pull request makes _teuthology_ compatible with Python 3.x while keeping compatibility with Python 2.x.

The most controversial part of this pull request is the [compat.py](https://github.com/BlaXpirit/teuthology/blob/wip-py3/teuthology/compat.py) module and its uses. The reason that it is needed is simple: throughout the _teuthology_ codebase bytestrings are used for text data. It is especially important to not change the existing behavior on Python 2 to Unicode strings due to assumptions outside of _teuthology_, like _ceph-qa-suite_. That's why on Python 2 the _stringify_ function leaves the bytestrings alone, and on Python 3 decodes them into Unicode strings. Same for `StringIO` - on Python 2 it's still `cStringIO` (byte-based) and on Python 3 it's `io.StringIO` (Unicode-based)

Note that I couldn't properly test these changes because _ceph-qa-suite_ is Python 2.x only at the moment. However, I made sure that unittests pass on both Python 2.x and Python 3.x, and that the number-wise stats for the unittests (passed/error/warning etc) are exactly the same as on the master branch.

Additionally, I ran a few actual tests with _teuthology_, again, in 3 configurations: _master_+_python2_, _wip-py3_+_python2_, _wip-py3_+_python3_. Details and logs [**here**](https://gist.github.com/330fe8639e75d54fba7b7dfb461bb605).
Basically, the simple _interactive_ "test" works well, the _teuthology_ test works the same in all configurations, and the _rados/cephtool_ test fails only on Python 3 because it is not compatible with Python 3.
