### PR TITLE
valgrind: add suppression for libunwind in libtcmalloc.so.4.2.6

### DIFF
--- a/teuthology/task/valgrind.supp
+++ b/teuthology/task/valgrind.supp
@@ -88,6 +88,21 @@
    fun:_ZN8tcmalloc8PageHeap3NewEm
 }
 {
+   tcmalloc: msync heap allocation points to uninit bytes (rhel7 #2)
+   Memcheck:Param
+   msync(start)
+   obj:/usr/lib64/libpthread-2.17.so
+   obj:/usr/lib64/libunwind.so.8.0.1
+   obj:/usr/lib64/libunwind.so.8.0.1
+   obj:/usr/lib64/libunwind.so.8.0.1
+   obj:/usr/lib64/libunwind.so.8.0.1
+   fun:_ULx86_64_step
+   obj:/usr/lib64/libtcmalloc.so.4.2.6
+   fun:_Z13GetStackTracePPvii
+   fun:_ZN8tcmalloc8PageHeap8GrowHeapEm
+   fun:_ZN8tcmalloc8PageHeap3NewEm
+}
+{
    tcmalloc: msync heap allocation points to uninit bytes (wheezy)
    Memcheck:Param
    msync(start)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17035
Signed-off-by: Kefu Chai <kchai@redhat.com>