### PR TITLE
Revert "packages.yaml: reflect python-ceph package split"

### DIFF
--- a/teuthology/task/packages.yaml
+++ b/teuthology/task/packages.yaml
@@ -32,8 +32,6 @@ ceph:
   - libcephfs1
   - librados2
   - librbd1
-  - python-rados
-  - python-rbd
-  - python-cephfs
+  - python-ceph
   - rbd-fuse
   - ceph-debuginfo


### PR DESCRIPTION
This reverts commit 4543fb64cedffc97c816feff7d4a69cd0456ab15.

Fixes: http://tracker.ceph.com/issues/17075
Signed-off-by: Nathan Cutler <ncutler@suse.com>