### PR TITLE
kernel: don't use GitbuilderProject's _get_config_value_for_remote()

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -368,7 +368,7 @@ def download_kernel(ctx, config):
 
             gitbuilder = GitbuilderProject(
                 'kernel',
-                ctx.config.get('kernel'),
+                {'sha1': src},
                 ctx=ctx,
                 remote=role_remote,
             )
@@ -1219,7 +1219,7 @@ def task(ctx, config):
         else:
             gitbuilder = GitbuilderProject(
                 "kernel",
-                ctx.config.get('kernel'),
+                role_config,
                 ctx=ctx,
                 remote=role_remote,
             )


### PR DESCRIPTION
Commit a01f1e169074 ("kernel: use packaging.GitbuilderProject to talk
with gitbuilder.") switched the kernel task to GitbuilderProject, which
parses the config in an attempt to pick the "best" config value for
a given remote.  However, the kernel task does its own parsing and
supports more than GitbuilderProject currently handles, e.g.:

  kernel:
    client:
      branch: testing

The above got broken by passing the entire 'kernel:' stanza to
GitbuilderProject: _get_uri_reference() chokes on "client" and defaults
to master branch.  It also effectively disables 'overrides:' support,
used by krbd:unmap suite.  Bring these back by passing in only the role
config in task().

In download_kernel(), we already have the sha1 and just need to get the
url, so construct a {'sha1': <sha>} dict on the fly.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>