### PR TITLE
Fix logging regression

### DIFF
--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -237,14 +237,11 @@ def quote(args):
 
 
 def copy_to_log(f, logger, loglevel=logging.INFO):
-    """
-    Interface to older xreadlines api.
-    """
     # Work-around for http://tracker.ceph.com/issues/8313
     if isinstance(f, ChannelFile):
         f._flags += ChannelFile.FLAG_BINARY
 
-    for line in f.readlines():
+    for line in f:
         line = line.rstrip()
         # Second part of work-around for http://tracker.ceph.com/issues/8313
         try:

--- a/teuthology/orchestra/test/integration/test_integration.py
+++ b/teuthology/orchestra/test/integration/test_integration.py
@@ -80,3 +80,15 @@ class TestIntegration():
         rem = remote.Remote(HOST)
         assert rem.os.name
         assert rem.os.version
+
+    def test_17102(self, caplog):
+        # http://tracker.ceph.com/issues/17102
+        rem = remote.Remote(HOST)
+        interval = 3
+        rem.run(args="echo before; sleep %s; echo after" % interval)
+        for record in caplog.records():
+            if record.msg == 'before':
+                before_time = record.created
+            elif record.msg == 'after':
+                after_time = record.created
+        assert int(round(after_time - before_time)) == interval


### PR DESCRIPTION
http://tracker.ceph.com/issues/17102

#914 caused a regression in logging remote command output whereby each line wasn't logged immediately as it was received. This PR reverts the regression and adds an integration test so that we can avoid making the same mistake in the future.

Note that integrations tests aren't (and can't currently be) run by Jenkins-initiated testing as they need a live machine to SSH to.