### PR TITLE
orchestra.run: fix generating ConnectionLostError

### DIFF
--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -380,7 +380,11 @@ def run(
                     paramiko
     """
     try:
-        (host, port) = client.get_transport().getpeername()
+        transport = client.get_transport()
+        if transport:
+            (host, port) = transport.getpeername()
+        else:
+            raise ConnectionLostError(command=quote(args), node=name)
     except socket.error:
         raise ConnectionLostError(command=quote(args), node=name)
 


### PR DESCRIPTION
Previously you could get AttributeError if
a node went away, because it tried to call
getpeername after get_transport() had
returned None.

Signed-off-by: John Spray <john.spray@redhat.com>