### PR TITLE
suite.Run: include suite_sha1 in job config

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -213,6 +213,7 @@ class Run(object):
             exc = BranchNotFoundError(suite_branch, 'ceph-qa-suite.git')
             util.schedule_fail(message=str(exc), name=self.name)
         log.info("ceph-qa-suite branch: %s %s", suite_branch, suite_hash)
+        return suite_hash
 
     def build_base_config(self):
         conf_dict = substitute_placeholders(dict_templ, self.config_input)

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -34,7 +34,8 @@ class TestRun(object):
     @patch('teuthology.suite.run.util.git_ls_remote')
     @patch('teuthology.suite.run.Run.choose_ceph_version')
     @patch('teuthology.suite.run.util.git_validate_sha1')
-    def test_email_addr(self, m_git_validate_sha1, m_choose_ceph_version, m_git_ls_remote):
+    def test_email_addr(self, m_git_validate_sha1, m_choose_ceph_version,
+                        m_git_ls_remote):
         # neuter choose_X_branch
         m_git_validate_sha1.return_value = self.args_dict['ceph_sha1']
         m_choose_ceph_version.return_value = self.args_dict['ceph_sha1']
@@ -240,9 +241,9 @@ class TestScheduleSuite(object):
         )
         frags = (frag1_read_output, frag2_read_output)
         expected_job = dict(
-            yaml = yaml.load('\n'.join(frags)),
-            sha1 = 'ceph_sha1',
-            args = [
+            yaml=yaml.load('\n'.join(frags)),
+            sha1='ceph_sha1',
+            args=[
                 '--description',
                 os.path.join(self.args.suite, build_matrix_desc),
                 '--',
@@ -256,7 +257,6 @@ class TestScheduleSuite(object):
         m_schedule_jobs.assert_has_calls(
             [call([], [expected_job], runobj.name)],
         )
-
 
     @patch('teuthology.suite.util.find_git_parent')
     @patch('teuthology.suite.run.Run.schedule_jobs')

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -236,6 +236,7 @@ class TestScheduleSuite(object):
         runobj.base_args = list()
         count = runobj.schedule_suite()
         assert(count == 1)
+        assert runobj.base_config['suite_sha1'] == 'suite_hash'
         m_has_packages_for_distro.assert_has_calls(
             [call('ceph_sha1', 'ubuntu', '14.04', 'basic', {})],
         )


### PR DESCRIPTION
This fixes the regression pointed out in http://tracker.ceph.com/issues/17211