### PR TITLE
Revert "Set ctx.cluster even when a job has no roles"

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -184,14 +184,13 @@ def get_initial_tasks(lock, config, machine_type):
         init_tasks.append({'internal.lock_machines': (
             len(config['roles']), machine_type)})
 
-    init_tasks.extend([
-        {'internal.save_config': None},
-        {'internal.check_lock': None},
-        {'internal.add_remotes': None},
-    ])
+
+    init_tasks.append({'internal.save_config': None})
 
     if 'roles' in config:
         init_tasks.extend([
+            {'internal.check_lock': None},
+            {'internal.add_remotes': None},
             {'console_log': None},
             {'internal.connect': None},
             {'internal.push_inventory': None},

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -213,11 +213,7 @@ def check_lock(ctx, config, check_up=True):
     """
     Check lock status of remote machines.
     """
-    if (
-        not teuth_config.lock_server or
-        ctx.config.get('check-locks') is False or
-        'roles' not in ctx.config
-    ):
+    if not teuth_config.lock_server or ctx.config.get('check-locks') is False:
         log.info('Lock checking disabled.')
         return
     log.info('Checking locks...')
@@ -312,10 +308,6 @@ def add_remotes(ctx, config):
     """
     Create a ctx.cluster object populated with remotes mapped to roles
     """
-    ctx.cluster = cluster.Cluster()
-    # Allow jobs to run without using nodes, for self-testing
-    if 'roles' not in ctx.config:
-        return
     remotes = []
     machs = []
     for name in ctx.config['targets'].iterkeys():
@@ -329,6 +321,7 @@ def add_remotes(ctx, config):
             pass
         rem = remote.Remote(name=t, host_key=key, keep_alive=True)
         remotes.append(rem)
+    ctx.cluster = cluster.Cluster()
     if 'roles' in ctx.config:
         for rem, roles in zip(remotes, ctx.config['roles']):
             assert all(isinstance(role, str) for role in roles), \


### PR DESCRIPTION
This reverts commit ffd14be3bd79baec5d9cafd8972d592085e0e099.

the add_remotes() change broke teuthology-nuke