### PR TITLE
Set ctx.cluster even when a job has no roles

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -184,13 +184,15 @@ def get_initial_tasks(lock, config, machine_type):
         init_tasks.append({'internal.lock_machines': (
             len(config['roles']), machine_type)})
 
-
     init_tasks.append({'internal.save_config': None})
 
     if 'roles' in config:
+        init_tasks.append({'internal.check_lock': None})
+
+    init_tasks.append({'internal.add_remotes': None})
+
+    if 'roles' in config:
         init_tasks.extend([
-            {'internal.check_lock': None},
-            {'internal.add_remotes': None},
             {'console_log': None},
             {'internal.connect': None},
             {'internal.push_inventory': None},

--- a/teuthology/task/internal.py
+++ b/teuthology/task/internal.py
@@ -308,6 +308,10 @@ def add_remotes(ctx, config):
     """
     Create a ctx.cluster object populated with remotes mapped to roles
     """
+    ctx.cluster = cluster.Cluster()
+    # Allow jobs to run without using nodes, for self-testing
+    if 'roles' not in ctx.config and 'targets' not in ctx.config:
+        return
     remotes = []
     machs = []
     for name in ctx.config['targets'].iterkeys():
@@ -321,7 +325,6 @@ def add_remotes(ctx, config):
             pass
         rem = remote.Remote(name=t, host_key=key, keep_alive=True)
         remotes.append(rem)
-    ctx.cluster = cluster.Cluster()
     if 'roles' in ctx.config:
         for rem, roles in zip(remotes, ctx.config['roles']):
             assert all(isinstance(role, str) for role in roles), \


### PR DESCRIPTION
This is a re-work of #954 without the "break ``teuthology-nuke``" feature.

I've already tested nuke and I just scheduled:
✅ http://pulpito.ceph.com/zack-2016-09-21_10:06:35-teuthology-master-distro-basic-smithi/