### PR TITLE
[DNM] packaging: abstract package manager commands in install task

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -69,10 +69,20 @@ def install_package(package, remote):
                   'install',
                   '{package}'.format(package=package)]
     elif flavor == 'rpm':
+        if remote.os.name != 'opensuse':
+            pkg_mng_cmd = 'yum'
+            pkg_mng_opts = '-y'
+            pkg_mng_subcommand_opts = ''
+        else:
+            pkg_mng_cmd = 'zypper'
+            pkg_mng_opts = '-n'
+            pkg_mng_subcommand_opts = '--capability'
+
         pkgcmd = ['sudo',
-                  'yum',
-                  '-y',
+                  pkg_mng_cmd,
+                  pkg_mng_opts,
                   'install',
+                  pkg_mng_subcommand_opts,
                   '{package}'.format(package=package)]
     else:
         log.error('install_package: bad flavor ' + flavor + '\n')
@@ -94,10 +104,19 @@ def remove_package(package, remote):
                   'purge',
                   '{package}'.format(package=package)]
     elif flavor == 'rpm':
+        if remote.os.name != 'opensuse':
+            pkg_mng_cmd = 'yum'
+            pkg_mng_opts = '-y'
+            pkg_mng_action = 'erase'
+        else:
+            pkg_mng_cmd = 'zypper'
+            pkg_mng_opts = '-n'
+            pkg_mng_action = 'remove'
+
         pkgcmd = ['sudo',
-                  'yum',
-                  '-y',
-                  'erase',
+                  pkg_mng_cmd,
+                  pkg_mng_opts,
+                  pkg_mng_action,
                   '{package}'.format(package=package)]
     else:
         log.error('remove_package: bad flavor ' + flavor + '\n')

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -123,6 +123,34 @@ def remove_package(package, remote):
         return False
     return remote.run(args=pkgcmd)
 
+def clean_repo_caches(clean_args, remote):
+    """
+    Clean repository cache
+    """
+    flavor = remote.os.package_type
+    if flavor == 'deb':
+        pkgcmd = ['DEBIAN_FRONTEND=noninteractive',
+                  'sudo',
+                  'apt-get',
+                  '-y',
+                  'clean']
+    elif flavor == 'rpm':
+        if remote.os.name != 'opensuse':
+            pkg_mng_cmd = 'yum'
+            pkg_mng_opts = '-y'
+        else:
+            pkg_mng_cmd = 'zypper'
+            pkg_mng_opts = '-n'
+
+        pkgcmd = ['sudo',
+                  pkg_mng_cmd,
+                  pkg_mng_opts,
+                  'clean',
+                  clean_args]
+    else:
+        log.error('clean_repo_caches: bad flavor ' + flavor + '\n')
+        return False
+    return remote.run(args=pkgcmd)
 
 def get_koji_task_result(task_id, remote, ctx):
     """

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -82,6 +82,22 @@ class TestPackaging(object):
             'yum',
             '-y',
             'install',
+            '',
+            'httpd'
+        ]
+        packaging.install_package('httpd', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    def test_install_package_rpm_opensuse(self):
+        m_remote = Mock()
+        m_remote.os.package_type = "rpm"
+        m_remote.os.name = "opensuse"
+        expected = [
+            'sudo',
+            'zypper',
+            '-n',
+            'install',
+            '--capability',
             'httpd'
         ]
         packaging.install_package('httpd', m_remote)
@@ -110,6 +126,20 @@ class TestPackaging(object):
             'yum',
             '-y',
             'erase',
+            'httpd'
+        ]
+        packaging.remove_package('httpd', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    def test_remove_package_rpm_opensuse(self):
+        m_remote = Mock()
+        m_remote.os.package_type = "rpm"
+        m_remote.os.name = "opensuse"
+        expected = [
+            'sudo',
+            'zypper',
+            '-n',
+            'remove',
             'httpd'
         ]
         packaging.remove_package('httpd', m_remote)

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -145,6 +145,46 @@ class TestPackaging(object):
         packaging.remove_package('httpd', m_remote)
         m_remote.run.assert_called_with(args=expected)
 
+    def test_clean_repo_caches_deb(self):
+        m_remote = Mock()
+        m_remote.os.package_type = "deb"
+        expected = [
+            'DEBIAN_FRONTEND=noninteractive',
+            'sudo',
+            'apt-get',
+            '-y',
+            'clean'
+        ]
+        packaging.clean_repo_caches('', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    def test_clean_repo_caches_rpm(self):
+        m_remote = Mock()
+        m_remote.os.package_type = "rpm"
+        expected = [
+            'sudo',
+            'yum',
+            '-y',
+            'clean',
+            'all'
+        ]
+        packaging.clean_repo_caches('all', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
+    def test_clean_repo_caches_rpm_opensuse(self):
+        m_remote = Mock()
+        m_remote.os.package_type = "rpm"
+        m_remote.os.name = 'opensuse'
+        expected = [
+            'sudo',
+            'zypper',
+            '-n',
+            'clean',
+            '-a'
+        ]
+        packaging.clean_repo_caches('-a', m_remote)
+        m_remote.run.assert_called_with(args=expected)
+
     def test_get_koji_package_name(self):
         build_info = dict(version="3.10.0", release="123.20.1")
         result = packaging.get_koji_package_name("kernel", build_info)


### PR DESCRIPTION
In this PR we use the functions from the packaging.py module to abstract the different package managers commands present in the install task.

This PR depends on the changes in PR #953 
I'll yank the first two commits from this PR as soon as #953 is merged.
