### PR TITLE
ceph.conf: set min rweight min bytes per osd = 10

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -57,6 +57,7 @@
 	mon reweight min pgs per osd = 4
 	mon osd reporter subtree level = osd
 	mon osd prime pg temp = true
+	mon reweight min bytes per osd = 10
 
 [mds]
         mds debug scatterstat = true


### PR DESCRIPTION
This lets the reweight-by-utilization command work even after mons are
restarted (ceph_manager is currently setting this via injectargs, but that
is not persistent).

Signed-off-by: Sage Weil <sage@redhat.com>