### PR TITLE
Add rerun capability to teuthology-suite

### DIFF
--- a/docs/intro_testers.rst
+++ b/docs/intro_testers.rst
@@ -64,3 +64,11 @@ get an email when the test run completes.
 <https://github.com/ceph/pulpito/>`__ that will display the current status of
 each job. The Sepia lab's pulpito instance is `here
 <http://pulpito.ceph.com/>`__.
+
+There may be times when, after scheduling a run containing a large number of
+jobs, that you want to reschedule only those jobs which have failed or died for
+some other reason. For that use-case, `teuthology-suite` has a `--rerun`/`-r`
+flag, and an optional `--rerun-statuses`/`-R` flag. An example of its usage
+is::
+
+    teuthology-suite -v -m vps -r teuthology-2016-10-06_05:00:03-smoke-master-testing-basic-vps -R pass,running,queued

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -7,6 +7,7 @@ from teuthology.config import config
 doc = """
 usage: teuthology-suite --help
        teuthology-suite [-v | -vv ] --suite <suite> [options] [<config_yaml>...]
+       teuthology-suite [-v | -vv ] --rerun <name>  [options] [<config_yaml>...]
 
 Run a suite of ceph integration tests. A suite is a directory containing
 facets. A facet is a directory containing config snippets. Running a suite
@@ -98,6 +99,24 @@ Scheduler arguments:
                               Useful to avoid bursts that may be too hard on
                               the underlying infrastructure or exceed OpenStack API
                               limits (server creation per minute for instance).
+  -r, --rerun <name>          Attempt to reschedule a run, selecting only those
+                              jobs whose status are mentioned by
+                              --rerun-status.
+                              Note that this is implemented by scheduling an
+                              entirely new suite and including only jobs whose
+                              descriptions match the selected ones. It does so
+                              using the same logic as --filter.
+                              Of all the flags that were passed when scheduling
+                              the original run, the resulting one will only
+                              inherit the suite value. Any others must be
+                              passed as normal while scheduling with this
+                              feature.
+ -R, --rerun-statuses <statuses>
+                              A comma-separated list of statuses to be used
+                              with --rerun. Supported statuses are: 'dead',
+                              'fail', 'pass', 'queued', 'running', 'waiting'
+                              [default: fail,dead]
+
 """.format(default_machine_type=config.default_machine_type,
            default_results_timeout=config.results_timeout)
 

--- a/teuthology/report.py
+++ b/teuthology/report.py
@@ -366,6 +366,21 @@ class ResultsReporter(object):
         response.raise_for_status()
         return response.json()
 
+    def get_run(self, run_name, fields=None):
+        """
+        Query the results server for a run
+
+        :param run_name: The name of the run
+        :param fields:   Optional. A list of fields to include in the result.
+                         Defaults to returning all fields.
+        """
+        uri = "{base}/runs/{name}".format(base=self.base_uri, name=run_name)
+        if fields:
+            uri += "?fields=" + ','.join(fields)
+        response = self.session.get(uri)
+        response.raise_for_status()
+        return response.json()
+
     def delete_job(self, run_name, job_id):
         """
         Delete a job from the results server.

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -40,6 +40,8 @@ def process_args(args):
         elif key == 'subset' and value is not None:
             # take input string '2/3' and turn into (2, 3)
             value = tuple(map(int, value.split('/')))
+        elif key in ('filter_in', 'filter_out'):
+            value = [x.strip() for x in value.split(',')]
         conf[key] = value
     return conf
 

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -293,10 +293,9 @@ class Run(object):
             # separated components to be used in searches.
             filter_in = self.args.filter_in
             if filter_in:
-                filter_list = [x.strip() for x in filter_in.split(',')]
-                if not any([x in description for x in filter_list]):
+                if not any([x in description for x in filter_in]):
                     all_filt = []
-                    for filt_samp in filter_list:
+                    for filt_samp in filter_in:
                         all_filt.extend(
                             [x.find(filt_samp) < 0 for x in base_frag_paths]
                         )
@@ -304,11 +303,10 @@ class Run(object):
                         continue
             filter_out = self.args.filter_out
             if filter_out:
-                filter_list = [x.strip() for x in filter_out.split(',')]
-                if any([x in description for x in filter_list]):
+                if any([x in description for x in filter_out]):
                     continue
                 all_filt_val = False
-                for filt_samp in filter_list:
+                for filt_samp in filter_out:
                     flist = [filt_samp in x for x in base_frag_paths]
                     if any(flist):
                         all_filt_val = True


### PR DESCRIPTION
This isn't quite done yet but is ready for testing. Feedback is welcome!

Things that should be added:
- [x] A docs section in the "intro for testers" doc ?
- [x] Docs should mention that the implementation schedules a new run and filters it
- [x] Docs should mention that the new run doesn't inherit anything from the original, and flags must be used to set things like branch and machine type

Update: I think this is ready now.