### PR TITLE
Don't leak console-logging processes when a job is killed

### DIFF
--- a/teuthology/exit.py
+++ b/teuthology/exit.py
@@ -1,0 +1,78 @@
+import logging
+import os
+import signal
+
+
+log = logging.getLogger(__name__)
+
+
+class Exiter(object):
+    """
+    A helper to manage any signal handlers we need to call upon receiving a
+    given signal
+    """
+    def __init__(self):
+        self.handlers = list()
+
+    def add_handler(self, signals, func):
+        """
+        Adds a handler function to be called when any of the given signals are
+        received.
+
+        The handler function should have a signature like::
+
+            my_handler(signal, frame)
+        """
+        if type(signals) is int:
+            signals = [signals]
+
+        for signal_ in signals:
+            signal.signal(signal_, self.default_handler)
+
+        handler = Handler(self, func, signals)
+        log.debug(
+            "Installing handler: %s",
+            repr(handler),
+        )
+        self.handlers.append(handler)
+        return handler
+
+    def default_handler(self, signal_, frame):
+        log.debug(
+            "Got signal %s; running %s handler%s...",
+            signal_,
+            len(self.handlers),
+            '' if len(self.handlers) == 1 else 's',
+        )
+        for handler in self.handlers:
+            handler.func(signal_, frame)
+        log.debug("Finished running handlers")
+        # Restore the default handler
+        signal.signal(signal_, 0)
+        # Re-send the signal to our main process
+        os.kill(os.getpid(), signal_)
+
+
+class Handler(object):
+    def __init__(self, exiter, func, signals):
+        self.exiter = exiter
+        self.func = func
+        self.signals = signals
+
+    def remove(self):
+        try:
+            log.debug("Removing handler: %s", self)
+            self.exiter.handlers.remove(self)
+        except ValueError:
+            pass
+
+    def __repr__(self):
+        return "{c}(exiter={e}, func={f}, signals={s})".format(
+            c=self.__class__.__name__,
+            e=self.exiter,
+            f=self.func,
+            s=self.signals,
+        )
+
+
+exiter = Exiter()

--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pexpect
+import psutil
 import subprocess
 import time
 
@@ -37,7 +38,7 @@ class PhysicalConsole():
         )
         self.conserver_master = config.conserver_master
         self.conserver_port = config.conserver_port
-        conserver_client_found = subprocess.Popen(
+        conserver_client_found = psutil.Popen(
             'which console',
             shell=True,
             stdout=subprocess.PIPE,
@@ -273,7 +274,7 @@ class PhysicalConsole():
         Using the subprocess module, spawn an ipmitool process using 'sol
         activate' and redirect its output to a file.
 
-        :returns: a subprocess.Popen object
+        :returns: a psutil.Popen object
         """
         pexpect_templ = \
             "import pexpect; " \
@@ -288,7 +289,7 @@ class PhysicalConsole():
                     log=dest_path,
                 ),
             ]
-            return subprocess.Popen(
+            return psutil.Popen(
                 python_cmd,
                 env=os.environ,
             )

--- a/teuthology/orchestra/test/test_console.py
+++ b/teuthology/orchestra/test/test_console.py
@@ -88,15 +88,16 @@ class TestPhysicalConsole(TestConsole):
 
     def test_spawn_log_conserver(self):
         with patch(
-            'teuthology.orchestra.console.subprocess.Popen',
+            'teuthology.orchestra.console.psutil.subprocess.Popen',
             autospec=True,
         ) as m_popen:
+            m_popen.return_value.pid = 42
+            m_popen.return_value.returncode = 0
             m_popen.return_value.wait.return_value = 0
             cons = self.klass(self.hostname)
             assert cons.has_conserver is True
             m_popen.reset_mock()
             m_popen.return_value.poll.return_value = None
-            m_popen.poll.return_value = None
             cons.spawn_sol_log('/fake/path')
             assert m_popen.call_count == 1
             call_args = m_popen.call_args_list[0][0][0]
@@ -106,9 +107,11 @@ class TestPhysicalConsole(TestConsole):
 
     def test_spawn_log_ipmi(self):
         with patch(
-            'teuthology.orchestra.console.subprocess.Popen',
+            'teuthology.orchestra.console.psutil.subprocess.Popen',
             autospec=True,
         ) as m_popen:
+            m_popen.return_value.pid = 42
+            m_popen.return_value.returncode = 1
             m_popen.return_value.wait.return_value = 1
             cons = self.klass(self.hostname)
             assert cons.has_conserver is False
@@ -123,9 +126,11 @@ class TestPhysicalConsole(TestConsole):
 
     def test_spawn_log_fallback(self):
         with patch(
-            'teuthology.orchestra.console.subprocess.Popen',
+            'teuthology.orchestra.console.psutil.subprocess.Popen',
             autospec=True,
         ) as m_popen:
+            m_popen.return_value.pid = 42
+            m_popen.return_value.returncode = 0
             m_popen.return_value.wait.return_value = 0
             cons = self.klass(self.hostname)
             assert cons.has_conserver is True
@@ -141,9 +146,11 @@ class TestPhysicalConsole(TestConsole):
 
     def test_get_console_conserver(self):
         with patch(
-            'teuthology.orchestra.console.subprocess.Popen',
+            'teuthology.orchestra.console.psutil.subprocess.Popen',
             autospec=True,
         ) as m_popen:
+            m_popen.return_value.pid = 42
+            m_popen.return_value.returncode = 0
             m_popen.return_value.wait.return_value = 0
             cons = self.klass(self.hostname)
         assert cons.has_conserver is True
@@ -158,9 +165,11 @@ class TestPhysicalConsole(TestConsole):
 
     def test_get_console_ipmitool(self):
         with patch(
-            'teuthology.orchestra.console.subprocess.Popen',
+            'teuthology.orchestra.console.psutil.subprocess.Popen',
             autospec=True,
         ) as m_popen:
+            m_popen.return_value.pid = 42
+            m_popen.return_value.returncode = 0
             m_popen.return_value.wait.return_value = 0
             cons = self.klass(self.hostname)
         assert cons.has_conserver is True
@@ -175,9 +184,11 @@ class TestPhysicalConsole(TestConsole):
 
     def test_get_console_fallback(self):
         with patch(
-            'teuthology.orchestra.console.subprocess.Popen',
+            'teuthology.orchestra.console.psutil.subprocess.Popen',
             autospec=True,
         ) as m_popen:
+            m_popen.return_value.pid = 42
+            m_popen.return_value.returncode = 0
             m_popen.return_value.wait.return_value = 0
             cons = self.klass(self.hostname)
         assert cons.has_conserver is True
@@ -195,9 +206,11 @@ class TestPhysicalConsole(TestConsole):
 
     def test_disable_conserver(self):
         with patch(
-            'teuthology.orchestra.console.subprocess.Popen',
+            'teuthology.orchestra.console.psutil.subprocess.Popen',
             autospec=True,
         ) as m_popen:
+            m_popen.return_value.pid = 42
+            m_popen.return_value.returncode = 0
             m_popen.return_value.wait.return_value = 0
             teuth_config.use_conserver = False
             cons = self.klass(self.hostname)

--- a/teuthology/test/task/test_console_log.py
+++ b/teuthology/test/task/test_console_log.py
@@ -74,6 +74,6 @@ class TestConsoleLog(TestTask):
     def test_end(self, m_pconsole):
         with self.klass(self.ctx, self.task_config) as task:
             pass
-        for proc in task.processes:
+        for proc in task.processes.values():
             assert proc.terminate.called_once_with()
             assert proc.kill.called_once_with()

--- a/teuthology/test/test_exit.py
+++ b/teuthology/test/test_exit.py
@@ -1,0 +1,93 @@
+import os
+import random
+import signal
+
+from mock import patch, Mock
+
+from teuthology import exit
+
+
+class TestExiter(object):
+    klass = exit.Exiter
+
+    def setup(self):
+        self.pid = os.getpid()
+
+        # Below, we patch os.kill() in such a way that the first time it is
+        # invoked it does actually send the signal. Any subsequent invocation
+        # won't send any signal - this is so we don't kill the process running
+        # our unit tests!
+        self.patcher_kill = patch(
+            'teuthology.exit.os.kill',
+            wraps=os.kill,
+        )
+
+        self.m_kill = self.patcher_kill.start()
+
+        def m_kill_unwrap(pid, sig):
+            # Setting return_value of a mocked object disables the wrapping
+            if self.m_kill.call_count > 1:
+                self.m_kill.return_value = None
+
+        self.m_kill.side_effect = m_kill_unwrap
+
+    def teardown(self):
+        self.patcher_kill.stop()
+        del self.m_kill
+
+    def test_noop(self):
+        sig = 15
+        obj = self.klass()
+        assert len(obj.handlers) == 0
+        assert signal.getsignal(sig) == 0
+
+    def test_basic(self):
+        sig = 15
+        obj = self.klass()
+        m_func = Mock()
+        obj.add_handler(sig, m_func)
+        assert len(obj.handlers) == 1
+        os.kill(self.pid, sig)
+        assert m_func.call_count == 1
+        assert self.m_kill.call_count == 2
+        for arg_list in self.m_kill.call_args_list:
+            assert arg_list[0] == (self.pid, sig)
+
+    def test_remove_handlers(self):
+        sig = [1, 15]
+        send_sig = random.choice(sig)
+        n = 3
+        obj = self.klass()
+        handlers = list()
+        for i in range(n):
+            m_func = Mock(name="handler %s" % i)
+            handlers.append(obj.add_handler(sig, m_func))
+        assert obj.handlers == handlers
+        for handler in handlers:
+            handler.remove()
+        assert obj.handlers == list()
+        os.kill(self.pid, send_sig)
+        assert self.m_kill.call_count == 2
+        for handler in handlers:
+            assert handler.func.call_count == 0
+
+    def test_n_handlers(self, n=10, sig=11):
+        if type(sig) is int:
+            send_sig = sig
+        else:
+            send_sig = random.choice(sig)
+        obj = self.klass()
+        handlers = list()
+        for i in range(n):
+            m_func = Mock(name="handler %s" % i)
+            handlers.append(obj.add_handler(sig, m_func))
+        assert obj.handlers == handlers
+        os.kill(self.pid, send_sig)
+        for i in range(n):
+            assert handlers[i].func.call_count == 1
+        assert self.m_kill.call_count == 2
+        for arg_list in self.m_kill.call_args_list:
+            assert arg_list[0] == (self.pid, send_sig)
+
+    def test_multiple_signals(self):
+        self.test_n_handlers(n=3, sig=[1, 6, 11, 15])


### PR DESCRIPTION
This PR first adds a framework for installing and removing signal handlers, allowing small tasks to be queued for execution when teuthology receives a given signal, or set of signals.

We then tell the ``console_log`` task to use this feature to ensure that the processes it spawns to log serial console output are killed when teuthology gets a ``SIGTERM``.