### PR TITLE
Update the default archive_base path

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -128,7 +128,7 @@ class TeuthologyConfig(YamlConfig):
     """
     yaml_path = os.path.join(os.path.expanduser('~/.teuthology.yaml'))
     _defaults = {
-        'archive_base': '/var/lib/teuthworker/archive',
+        'archive_base': '/home/teuthworker/archive',
         'archive_upload': None,
         'archive_upload_key': None,
         'archive_upload_url': None,


### PR DESCRIPTION
None of our labs are using /var/lib/teuthworker/archive anymore. The
incorrect default could trip up users.

Signed-off-by: Zack Cerza <zack@redhat.com>