### PR TITLE
Revert "ceph.conf: debug monc = 1"

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -27,8 +27,6 @@
 
 	osd default data pool replay window = 5
 
-	debug monc = 1
-
 [osd]
         osd journal size = 100
 
@@ -52,7 +50,6 @@
 
 	filestore ondisk finisher threads = 3
 	filestore apply finisher threads = 3
-
 
 [mon]
 	debug ms = 1


### PR DESCRIPTION
This reverts commit 5137d3c6cfd065c69fe7e3bb570ef0fc795febcb.

Fixes: http://tracker.ceph.com/issues/17605

Signed-off-by: Loic Dachary <ldachary@redhat.com>