### PR TITLE
Pull in libcephfs2 instead of libcephfs1

### DIFF
--- a/teuthology/nuke/actions.py
+++ b/teuthology/nuke/actions.py
@@ -245,8 +245,9 @@ def remove_ceph_packages(ctx):
     """
     log.info("Force remove ceph packages")
     ceph_packages_to_remove = ['ceph-common', 'ceph-mon', 'ceph-osd',
-                               'libcephfs1', 'librados2', 'librgw2', 'librbd1',
-                               'ceph-selinux', 'python-cephfs', 'ceph-base',
+                               'libcephfs1', 'libcephfs2', 'librados2',
+                               'librgw2', 'librbd1', 'ceph-selinux',
+                               'python-cephfs', 'ceph-base',
                                'python-rbd', 'python-rados', 'ceph-mds',
                                'ceph-mgr', 'libcephfs-java', 'libcephfs-jni',
                                'ceph-deploy', 'libapache2-mod-fastcgi'

--- a/teuthology/task/packages.yaml
+++ b/teuthology/task/packages.yaml
@@ -8,7 +8,7 @@ ceph:
   - ceph-test
   - radosgw
   - python-ceph
-  - libcephfs1
+  - libcephfs2
   - libcephfs-java
   - libcephfs-jni
   - librados2
@@ -19,7 +19,7 @@ ceph:
   - ceph-common-dbg
   - ceph-fuse-dbg
   - radosgw-dbg
-  - libcephfs1-dbg
+  - libcephfs2-dbg
   - librados2-dbg
   - librbd1-dbg
   rpm:
@@ -29,7 +29,7 @@ ceph:
   - ceph-fuse
   - cephfs-java
   - libcephfs_jni1
-  - libcephfs1
+  - libcephfs2
   - librados2
   - librbd1
   - python-ceph


### PR DESCRIPTION
Companion pull request for the ceph one here:

https://github.com/ceph/ceph/pull/11647

...and the ceph-qa-suite one here:

https://github.com/ceph/ceph-qa-suite/pull/1223

Mostly just ripple effects of the package rename.