### PR TITLE
Change pull_directory to use a remote tar streaming to the local extract

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -19,7 +19,6 @@ import urlparse
 import yaml
 import json
 import re
-import tempfile
 import pprint
 
 from teuthology import safepath
@@ -778,33 +777,31 @@ def pull_directory(remote, remotedir, localdir):
               remote.shortname, remotedir, localdir)
     if not os.path.exists(localdir):
         os.mkdir(localdir)
-    _, local_tarfile = tempfile.mkstemp(dir=localdir)
-    remote.get_tar(remotedir, local_tarfile, sudo=True)
-    with open(local_tarfile, 'r+') as fb1:
-        tar = tarfile.open(mode='r|gz', fileobj=fb1)
-        while True:
-            ti = tar.next()
-            if ti is None:
-                break
+    r = remote.get_tar_stream(remotedir, sudo=True)
+    tar = tarfile.open(mode='r|gz', fileobj=r.stdout)
+    while True:
+        ti = tar.next()
+        if ti is None:
+            break
 
-            if ti.isdir():
-                # ignore silently; easier to just create leading dirs below
-                pass
-            elif ti.isfile():
-                sub = safepath.munge(ti.name)
-                safepath.makedirs(root=localdir, path=os.path.dirname(sub))
-                tar.makefile(ti, targetpath=os.path.join(localdir, sub))
+        if ti.isdir():
+            # ignore silently; easier to just create leading dirs below
+            # XXX this mean empty dirs are not transferred
+            pass
+        elif ti.isfile():
+            sub = safepath.munge(ti.name)
+            safepath.makedirs(root=localdir, path=os.path.dirname(sub))
+            tar.makefile(ti, targetpath=os.path.join(localdir, sub))
+        else:
+            if ti.isdev():
+                type_ = 'device'
+            elif ti.issym():
+                type_ = 'symlink'
+            elif ti.islnk():
+                type_ = 'hard link'
             else:
-                if ti.isdev():
-                    type_ = 'device'
-                elif ti.issym():
-                    type_ = 'symlink'
-                elif ti.islnk():
-                    type_ = 'hard link'
-                else:
-                    type_ = 'unknown'
-                log.info('Ignoring tar entry: %r type %r', ti.name, type_)
-    os.remove(local_tarfile)
+                type_ = 'unknown'
+            log.info('Ignoring tar entry: %r type %r', ti.name, type_)
 
 
 def pull_directory_tarball(remote, remotedir, localfile):

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -803,8 +803,7 @@ def pull_directory(remote, remotedir, localdir):
                     type_ = 'hard link'
                 else:
                     type_ = 'unknown'
-                    log.info('Ignoring tar entry: %r type %r', ti.name, type_)
-                    continue
+                log.info('Ignoring tar entry: %r type %r', ti.name, type_)
     os.remove(local_tarfile)
 
 

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -369,6 +369,24 @@ class Remote(object):
         self._sftp_get_file(remote_temp_path, to_path)
         self.remove(remote_temp_path)
 
+    def get_tar_stream(self, path, sudo=False):
+        """
+        Tar-compress a remote directory and return the RemoteProcess
+        for streaming
+        """
+        args = []
+        if sudo:
+            args.append('sudo')
+        args.extend([
+            'tar',
+            'cz',
+            '-f', '-',
+            '-C', path,
+            '--',
+            '.',
+            ])
+        return self.run(args=args, wait=False, stdout=run.PIPE)
+
     @property
     def os(self):
         if not hasattr(self, '_os'):


### PR DESCRIPTION
Avoids remote and local temp files, and subsequent read/write thrashing of local dir.  Since some of those directories are multiple tens or hundreds of gigabytes, the extra file load is important, and this should save time as well just by skipping the extra I/O thrashing (which the cephfs particularly hates)