### PR TITLE
teuthology: update nuke for libcephfs2

### DIFF
--- a/teuthology/nuke/actions.py
+++ b/teuthology/nuke/actions.py
@@ -245,7 +245,8 @@ def remove_ceph_packages(ctx):
     """
     log.info("Force remove ceph packages")
     ceph_packages_to_remove = ['ceph-common', 'ceph-mon', 'ceph-osd',
-                               'libcephfs1', 'librados2', 'librgw2', 'librbd1',
+                               'libcephfs1', 'libcephfs2',
+                               'librados2', 'librgw2', 'librbd1',
                                'ceph-selinux', 'python-cephfs', 'ceph-base',
                                'python-rbd', 'python-rados', 'ceph-mds',
                                'ceph-mgr', 'libcephfs-java', 'libcephfs-jni',


### PR DESCRIPTION
try to remove libcephfs2 as well.

Signed-off-by: Kefu Chai <kchai@redhat.com>