### PR TITLE
Revert "Pin ansible to <2.2.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
                       'pytest-capturelog',
                       'mock',
                       'fudge',
-                      'ansible<2.2.0',
+                      'ansible>=2.0',
                       'pyopenssl>=0.13',
                       'ndg-httpsclient',
                       'pyasn1',


### PR DESCRIPTION
This reverts commit f2576e7a719a129a3c8be603bd9993d2b1ec94f2.

We finally heeded all the deprecation warnings.

Signed-off-by: Zack Cerza <zack@redhat.com>