### PR TITLE
valgrind: suppression for md_config_t string leak

### DIFF
--- a/teuthology/task/install/valgrind.supp
+++ b/teuthology/task/install/valgrind.supp
@@ -370,3 +370,14 @@
 	fun:_dl_init
 	...
 }
+{
+	strange leak of std::string memory from md_config_t seen in radosgw
+	Memcheck:Leak
+	...
+	fun:_ZNSs4_Rep9_S_createEmmRKSaIcE
+	fun:_ZNSs12_S_constructIPKcEEPcT_S3_RKSaIcESt20forward_iterator_tag
+	...
+	fun:_ZN11md_config_tC1Ev
+	fun:_ZN11CephContextC1Eji
+	...
+}


### PR DESCRIPTION
Adds a valgrind suppression for a very strange memory leak only seen in radosgw under teuthology. When it reproduces, it always complains about the same 4 std::strings under md_config_t, with sizes 28, 51, 61, and 63.

I've been trying for months to track down the root cause, without success. I wasn't able to locate an offending commit via git bisect. I haven't seen it reproduce on packages built by shaman, so I suspect it's some artifact of the gitbuilders. We really want to get the rgw suite green so that kraken backports can be verified, so we're adding valgrind suppression as a last resort.

Fixes: http://tracker.ceph.com/issues/17924