### PR TITLE
ShamanProject: don't write broken repos

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -27,7 +27,7 @@ from teuthology.exceptions import (CommandCrashedError, CommandFailedError,
 from .orchestra import run
 from .config import config
 from .contextutil import safe_while
-from .packaging import DEFAULT_OS_VERSION
+from .orchestra.opsys import DEFAULT_OS_VERSION
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
We saw several cases where repo file contents were actually small HTML
files containing "502 Bad Gateway" errors. This will cause ShamanProject
to raise an exception if that happens - and not write broken repo files.

Signed-off-by: Zack Cerza <zack@redhat.com>