### PR TITLE
Pre-support for colocated suite

### DIFF
--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -267,14 +267,21 @@ def fetch_repo(url, branch, bootstrap=None, lock=True):
     return dest_path
 
 
-def fetch_qa_suite(branch, lock=True):
+def fetch_qa_suite(branch, lock=True, colocated_suite=False):
     """
     Make sure ceph-qa-suite is checked out.
 
-    :param branch: The branch to fetch
-    :returns:      The destination path
+    :param branch:           The branch to fetch
+    :param lock:             See fetch_repo()
+    :param colocated_suite:  Whether to fetch the ceph repo instead of
+                             ceph-qa-suite
+    :returns:                The destination path
     """
-    return fetch_repo(config.get_ceph_qa_suite_git_url(),
+    if colocated_suite:
+        suite_url = config.get_ceph_git_url()
+    else:
+        suite_url = config.get_ceph_qa_suite_git_url()
+    return fetch_repo(suite_url,
                       branch, lock=lock)
 
 

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -164,7 +164,13 @@ def prep_job(job_config, log_file_path, archive_dir):
         # last-in-suite jobs don't have suite_branch or branch set.
         ceph_branch = job_config.get('branch', 'master')
         suite_branch = job_config.get('suite_branch', ceph_branch)
-        job_config['suite_path'] = fetch_qa_suite(suite_branch)
+        job_config['suite_path'] = os.path.normpath(os.path.join(
+            fetch_qa_suite(
+                suite_branch,
+                colocated_suite=job_config.get('colocated_suite', False)
+            ),
+            job_config.get('colocated_suite_path', ''),
+        ))
     except BranchNotFoundError as exc:
         log.exception("Branch not found; marking job as dead")
         report.try_push_job_info(


### PR DESCRIPTION
We want to be able to move the contents of `ceph-qa-suite.git` into `ceph.git`. This PR adds the functionality needed to test the remaining changes that are required for that support.

@liewegas: This is built around the user only having to supply a single argument to `teuthology-suite`: `-C` or `--colocated-suite <relpath>`; in your case you'd use `-C qa` to point inside the subdir.