### PR TITLE
kernel: fix reboot into the new kernel on xenial

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -596,10 +596,18 @@ def install_and_reboot(ctx, config):
                 'rm',
                 remote_pkg_path(role_remote),
                 run.Raw('&&'),
+                # work around a systemd issue, where network gets shut down
+                # before ssh can close its session
+                run.Raw('('),
+                'sleep',
+                '1',
+                run.Raw('&&'),
                 'sudo',
                 'shutdown',
                 '-r',
                 'now',
+                run.Raw('&'),
+                run.Raw(')'),
                 ],
             wait=False,
             )


### PR DESCRIPTION
shutdown is a symlink to systemctl on xenial, and on "shutdown -r now"
network gets shut down before ssh has a chance to close gracefully.
There have been multiple complaints about this and some distantly
related fixes have made it into recent systemds [1].

This doesn't seem to happen on centos, probably because of different
systemd versions or sshd configuration, so this band-aid is for ubuntu
only.  "systemctl --no-block reboot" is nicer, but not available on
trusty.

[1] https://github.com/systemd/systemd/issues/2390

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>