### PR TITLE
suite: Correct rerun behavior when no jobs match

### DIFF
--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -72,7 +72,12 @@ def main(args):
 
     if conf.rerun:
         rerun_filters = get_rerun_filters(conf.rerun, conf.rerun_statuses)
-        print rerun_filters
+        if len(rerun_filters['descriptions']) == 0:
+            log.warn(
+                "No jobs matched the status filters: %s",
+                conf.rerun_statuses,
+            )
+            return
         conf.filter_in.extend(rerun_filters['descriptions'])
         conf.suite = normalize_suite_name(rerun_filters['suite'])
 


### PR DESCRIPTION
Also remove a stray print statement

Signed-off-by: Zack Cerza <zack@redhat.com>