### PR TITLE
spawn_sol_log: use sys.executable to find bin/python

### DIFF
--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -3,6 +3,7 @@ import os
 import pexpect
 import psutil
 import subprocess
+import sys
 import time
 
 from teuthology import lockstatus as ls
@@ -282,8 +283,12 @@ class PhysicalConsole():
 
         def start():
             console_cmd = self._console_command()
+            # use sys.executable to find python rather than /usr/bin/env.
+            # The latter relies on PATH, which is set in a virtualenv
+            # that's been activated, but is not set when binaries are
+            # run directly from the virtualenv's bin/ directory.
             python_cmd = [
-                '/usr/bin/env', 'python', '-c',
+                sys.executable, '-c',
                 pexpect_templ.format(
                     cmd=console_cmd,
                     log=dest_path,


### PR DESCRIPTION
An activated virtualenv has PATH set to find Python with /usr/bin/env.
A binary run from virtualenv/bin doesn't set PATH.  Use sys.executable
to handle both invocation methods.

Fixes: http://tracker.ceph.com/issues/17986
Signed-off-by: Dan Mick <dan.mick@redhat.com>