### PR TITLE
nuke: Use pkill -KILL to unconditionally wipe out hadoop processes

### DIFF
--- a/teuthology/nuke/actions.py
+++ b/teuthology/nuke/actions.py
@@ -75,11 +75,7 @@ def shutdown_daemons(ctx):
 def kill_hadoop(ctx):
     log.info("Terminating Hadoop services...")
     ctx.cluster.run(args=[
-        "ps", "-ef",
-        run.Raw("|"), "grep", "java.*hadoop",
-        run.Raw("|"), "grep", "-v", "grep",
-        run.Raw("|"), 'awk', '{print $2}',
-        run.Raw("|"), 'xargs', 'kill', '-9',
+        "pkill", "-f", "-KILL", "java.*hadoop",
         ],
         check_status=False,
         timeout=60


### PR DESCRIPTION
In CentOS 7, the command "ps -ef | grep 'java.*hadoop' | grep -v grep | awk
'{print $2}' | xargs kill -9" produces undesirable output when no matching
processes exist.

Note: the "-f" option to pkill mimics the semantics of "ps -ef". For example,
"ps -ef | grep 'java.*hadoop'" will match a process called "sh java343hadoop",
while pkill will match that process only with the -f option:

$ ps -ef | grep "java.*hadoop" | grep -v grep
root     16165  4101  0 11:57 pts/1    00:00:00 sh java343hadoop
$ pkill -KILL "java.*hadoop"
$
$ ps -ef | grep "java.*hadoop" | grep -v grep
root     16165  4101  0 11:57 pts/1    00:00:00 sh java343hadoop
$ pkill -f -KILL "java.*hadoop"
[1]+  Killed                  sh java343hadoop

Fixes: http://tracker.ceph.com/issues/17981
Signed-off-by: Nathan Cutler <ncutler@suse.com>