### PR TITLE
Remove high level of debug logging which is not required

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -79,9 +79,6 @@ dict_templ = {
                     'log file': '/var/log/ceph/ceph-$name.$pid.log'
                 },
                 'mon': {
-                    'debug mon': 1,
-                    'debug ms': 20,
-                    'debug paxos': 20,
                     'osd default pool size': 2
                 }
             }


### PR DESCRIPTION
High levels of debug messages are not required for ceph-deploy tests, also its causing remoto to hang during get of clent.admin key

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>