### PR TITLE
Dont set qa-suite repo during worker startup

### DIFF
--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -93,7 +93,6 @@ def main(ctx):
 
     if teuth_config.teuthology_path is None:
         fetch_teuthology('master')
-    fetch_qa_suite('master')
 
     keep_running = True
     while keep_running:


### PR DESCRIPTION
There is no need to initialize qa-suite repo during worker startup,
moreover it fails with default values trying to checkout 'master'
branch from ceph-ci.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>