### PR TITLE
Change to use task 'clock' instead of 'clock.check'

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -234,7 +234,7 @@ def get_initial_tasks(lock, config, machine_type):
             {'pcp': None},
             {'selinux': None},
             {'ansible.cephlab': None},
-            {'clock.check': None}
+            {'clock': None}
         ])
 
     return init_tasks

--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -54,7 +54,7 @@ def task(ctx, config):
             'PATH=/usr/bin:/usr/sbin',
             'ntpdc', '-p',
         ])
-        rem.run(args)
+        rem.run(args=args)
 
     try:
         yield


### PR DESCRIPTION
See commit comments, but, clock will force a sync with ntpdate, which is probably the better path.

Tested with a local teuthology run and a small suite excerpt (look for "Syncing clocks"):

http://pulpito.ceph.com/dmick-2017-01-18_13:39:43-rados-kraken---basic-mira/