### PR TITLE
install.upgrade: add pre-upgrade sanity check (replaces #891)

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -11,6 +11,7 @@ from teuthology.parallel import parallel
 from teuthology.orchestra import run
 from teuthology.task import ansible
 
+from distutils.version import LooseVersion
 from .util import (
     _get_builder_project, get_flavor, ship_utilities,
 )
@@ -19,6 +20,10 @@ from . import rpm, deb, redhat
 
 log = logging.getLogger(__name__)
 
+def get_upgrade_version(ctx, config, remote):
+    gitbuilder = _get_gitbuilder_project(ctx, remote, config)
+    version = gitbuilder.version
+    return version
 
 def verify_package_version(ctx, config, remote):
     """
@@ -330,6 +335,10 @@ def upgrade_remote_to_config(ctx, config):
 
     return result
 
+def _upgrade_is_downgrade(installed_version, upgrade_version):
+    assert installed_version, "installed_version is empty"
+    assert upgrade_version, "upgrade_version is empty"
+    return LooseVersion(installed_version) > LooseVersion(upgrade_version)
 
 def upgrade_common(ctx, config, deploy_style):
     """
@@ -351,6 +360,20 @@ def upgrade_common(ctx, config, deploy_style):
             proj=project, system_type=system_type, pkgs=', '.join(pkgs)))
         # FIXME: again, make extra_pkgs distro-agnostic
         pkgs += extra_pkgs
+
+        installed_version = packaging.get_package_version(remote, 'ceph-common')
+        upgrade_version = get_upgrade_version(ctx, remote, node)
+        log.info("Ceph {s} upgrade from {i} to {u}".format(
+            s=system_type,
+            i=installed_version,
+            u=upgrade_version
+        ))
+	if _upgrade_is_downgrade(installed_version, upgrade_version):
+            raise RuntimeError(
+                "An attempt to upgrade from a higher version to a lower one "
+                "will always fail. Hint: check tags in the target git branch."
+            )
+
 
         deploy_style(ctx, node, remote, pkgs, system_type)
         verify_package_version(ctx, node, remote)

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -48,6 +48,17 @@ class TestInstall(object):
 
     @patch("teuthology.task.install._get_builder_project")
     @patch("teuthology.task.install.packaging.get_package_version")
+    def test_get_upgrade_version(self, m_get_package_version,
+                                         m_gitbuilder_project):
+        gb = Mock()
+        gb.version = "11.0.0"
+        gb.project = "ceph"
+        m_gitbuilder_project.return_value = gb
+        m_get_package_version.return_value = "11.0.0"
+        install.get_upgrade_version(Mock(), Mock(), Mock())
+
+    @patch("teuthology.task.install._get_gitbuilder_project")
+    @patch("teuthology.task.install.packaging.get_package_version")
     def test_verify_ceph_version_success(self, m_get_package_version,
                                          m_gitbuilder_project):
         gb = Mock()
@@ -102,9 +113,20 @@ class TestInstall(object):
         )
         assert install.get_flavor(config) == 'notcmalloc'
 
+    def test_upgrade_is_downgrade(self):
+        assert_ok_vals = [
+	    ('9.0.0', '10.0.0'),
+	    ('10.2.2-63-g8542898-1trusty', '10.2.2-64-gabcdef1-1trusty'),
+	    ('11.0.0-918.g13c13c7', '11.0.0-2165.gabcdef1')
+	]
+	for t in assert_ok_vals:
+            assert install._upgrade_is_downgrade(t[0], t[1]) == False
+
     @patch("teuthology.misc.get_system_type")
     @patch("teuthology.task.install.verify_package_version")
+    @patch("teuthology.task.install.get_upgrade_version")
     def test_upgrade_common(self,
+                            m_get_upgrade_version,
                             m_verify_package_version,
                             m_get_system_type):
         expected_system_type = 'deb'
@@ -146,6 +168,7 @@ class TestInstall(object):
                 },
             ],
         }
+	m_get_upgrade_version.return_value = "11.0.0"
         m_get_system_type.return_value = "deb"
         def upgrade(ctx, node, remote, pkgs, system_type):
             assert system_type == expected_system_type

--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -122,13 +122,15 @@ class TestInstall(object):
 	for t in assert_ok_vals:
             assert install._upgrade_is_downgrade(t[0], t[1]) == False
 
+    @patch("teuthology.packaging.get_package_version")
     @patch("teuthology.misc.get_system_type")
     @patch("teuthology.task.install.verify_package_version")
     @patch("teuthology.task.install.get_upgrade_version")
     def test_upgrade_common(self,
                             m_get_upgrade_version,
                             m_verify_package_version,
-                            m_get_system_type):
+                            m_get_system_type,
+                            m_get_package_version):
         expected_system_type = 'deb'
         def make_remote():
             remote = Mock()
@@ -169,6 +171,7 @@ class TestInstall(object):
             ],
         }
 	m_get_upgrade_version.return_value = "11.0.0"
+        m_get_package_version.return_value = "10.2.4"
         m_get_system_type.return_value = "deb"
         def upgrade(ctx, node, remote, pkgs, system_type):
             assert system_type == expected_system_type


### PR DESCRIPTION
Commits from #891 are squashed and rebased onto master. Additionally on commit to pass test suite.