### PR TITLE
console: force existing connections into spy mode if !readonly

### DIFF
--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -82,10 +82,10 @@ class PhysicalConsole():
 
     def _console_command(self, readonly=True):
         if self.has_conserver:
-            return 'console -M {master} -p {port} {ro}{host}'.format(
+            return 'console -M {master} -p {port} {mode} {host}'.format(
                 master=self.conserver_master,
                 port=self.conserver_port,
-                ro='-s ' if readonly else '',
+                mode='-s' if readonly else '-f',
                 host=self.shortname,
             )
         else:

--- a/teuthology/orchestra/test/test_console.py
+++ b/teuthology/orchestra/test/test_console.py
@@ -12,7 +12,7 @@ class TestConsole(object):
 class TestPhysicalConsole(TestConsole):
     klass = console.PhysicalConsole
     ipmi_cmd_templ = 'ipmitool -H {h}.{d} -I lanplus -U {u} -P {p} {c}'
-    conserver_cmd_templ = 'console -M {m} -p {p} {ro}{h}'
+    conserver_cmd_templ = 'console -M {m} -p {p} {mode} {h}'
 
     def setup(self):
         self.hostname = 'host'
@@ -42,14 +42,14 @@ class TestPhysicalConsole(TestConsole):
         assert console_cmd == self.conserver_cmd_templ.format(
             m=teuth_config.conserver_master,
             p=teuth_config.conserver_port,
-            ro='-s ',
+            mode='-s',
             h=self.hostname,
         )
         console_cmd = cons._console_command(readonly=False)
         assert console_cmd == self.conserver_cmd_templ.format(
             m=teuth_config.conserver_master,
             p=teuth_config.conserver_port,
-            ro='',
+            mode='-f',
             h=self.hostname,
         )
 


### PR DESCRIPTION
If someone watching the console didn't think of using "console -s", we
end up power cycling the node in an attempt to get the login prompt.
This is futile -- if the watcher is still there after the node comes
back up, our connection will get dropped to spy mode again.

Use -f to temporarily force existing connections into spy mode when we
attach to save a power cycle.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>