### PR TITLE
prune: use the shortest time of -p or -r to decide on processing

### DIFF
--- a/teuthology/prune.py
+++ b/teuthology/prune.py
@@ -43,7 +43,7 @@ def prune_archive(
     Walk through the archive_dir, calling the cleanup functions to process
     directories that might be old enough
     """
-    max_days = max(pass_days, remotes_days)
+    max_days = min(pass_days, remotes_days)
     log.debug("Archive {archive} has {count} children".format(
         archive=archive_dir, count=len(os.listdir(archive_dir))))
     # Use full paths


### PR DESCRIPTION
invoking -p 7 -r 30 was only removing passed jobs 30 days or older.

Signed-off-by: Dan Mick <dan.mick@redhat.com>