### PR TITLE
suite: use "suite_hash" as the default sha1 for workunit

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -345,6 +345,9 @@ def main(args):
     ceph_repo = config.get('repo')
     if ceph_repo:
         teuth_config.ceph_git_url = ceph_repo
+    suite_repo = config.get('suite_repo')
+    if suite_repo:
+        teuth_config.ceph_qa_suite_git_url = suite_repo
 
     config["tasks"] = validate_tasks(config)
 

--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -89,7 +89,7 @@ dict_templ = {
             }
         },
         'workunit': {
-            'sha1': Placeholder('ceph_hash'),
+            'sha1': Placeholder('suite_hash'),
         }
     },
     'repo': Placeholder('ceph_repo'),


### PR DESCRIPTION
as "workunits" reside in ceph/qa/workunits, it's more intuitive to
respect suite-branch option when cloning workunits.

Signed-off-by: Kefu Chai <kchai@redhat.com>