### PR TITLE
suite: use suite_sha1 for workunits

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -89,7 +89,7 @@ dict_templ = {
             }
         },
         'workunit': {
-            'sha1': Placeholder('ceph_hash'),
+            'sha1': Placeholder('suite_hash'),
         }
     },
     'repo': Placeholder('ceph_repo'),


### PR DESCRIPTION
In the spirit of ceph.git commit 1f82b9b9446d ("qa/tasks/workunit: use
the suite repo for cloning workunit"), respect --suite-branch.

This allows combining custom workunits with named ceph branches.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>