### PR TITLE
cloud.openstack: Also retry on BaseHTTPError

### DIFF
--- a/teuthology/provision/cloud/openstack.py
+++ b/teuthology/provision/cloud/openstack.py
@@ -7,7 +7,7 @@ import urllib
 import yaml
 
 from copy import deepcopy
-from libcloud.common.exceptions import RateLimitReachedError
+from libcloud.common.exceptions import RateLimitReachedError, BaseHTTPError
 
 from paramiko import AuthenticationException
 from paramiko.ssh_exception import NoValidConnectionsError
@@ -23,7 +23,7 @@ from teuthology.provision.cloud.base import Provider
 log = logging.getLogger(__name__)
 
 
-RETRY_EXCEPTIONS = (RateLimitReachedError, )
+RETRY_EXCEPTIONS = (RateLimitReachedError, BaseHTTPError)
 
 
 def retry(function, *args, **kwargs):


### PR DESCRIPTION
We attach volumes immediately after creating them; sometimes they are
still momentarily in the 'creating' state, causing the attach call to
throw a BaseHTTPError. When that happens, simply retry the request
instead of failing node creation, starting the entire cycle all over
again.

Signed-off-by: Zack Cerza <zack@redhat.com>