### PR TITLE
run.py: Provide --os-{type,version} values to get_initial_tasks

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -349,6 +349,13 @@ def main(args):
     if suite_repo:
         teuth_config.ceph_qa_suite_git_url = suite_repo
 
+    # overwrite the config values of os_{type,version} if corresponding 
+    # command-line arguments are provided
+    if os_type:
+        config["os_type"] = os_type
+    if os_version:
+        config["os_version"] = os_version
+
     config["tasks"] = validate_tasks(config)
 
     init_tasks = get_initial_tasks(lock, config, machine_type)
@@ -361,14 +368,6 @@ def main(args):
 
     # fetches the tasks and returns a new suite_path if needed
     config["suite_path"] = fetch_tasks_if_needed(config)
-
-    # overwrite the config value of os_type if --os-type is provided
-    if os_type:
-        config["os_type"] = os_type
-
-    # overwrite the config value of os_version if --os-version is provided
-    if os_version:
-        config["os_version"] = os_version
 
     # If the job has a 'use_shaman' key, use that value to override the global
     # config's value.


### PR DESCRIPTION
We want to be able to check the final values of os_type and os_version
in get_initial_tasks, so move the command-line override up to before
the get_initial_tasks() method call.

Signed-off-by: Nathan Cutler <ncutler@suse.com>