### PR TITLE
setup.py: disallow requests 2.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
                       'httplib2',
                       'paramiko',
                       'pexpect',
-                      'requests',
+                      'requests != 2.13.0',
                       'raven',
                       'web.py',
                       'docopt',


### PR DESCRIPTION
python-cinderclient and/or keystoneauth1 apparently don't want
requests 2.13.0, so make it illegal for now

Signed-off-by: Dan Mick <dan.mick@redhat.com>