### PR TITLE
suite: use "suite_branch" for workunit if avaiable

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -89,6 +89,7 @@ dict_templ = {
             }
         },
         'workunit': {
+            'branch': Placeholder('suite_branch'),
             'sha1': Placeholder('suite_hash'),
         }
     },


### PR DESCRIPTION
"git clone" allows us to clone a single branch, but not a sha1, so
prefer "branch" if it's available.

Signed-off-by: Kefu Chai <kchai@redhat.com>