### PR TITLE
Improve exception logging

### DIFF
--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -80,3 +80,16 @@ def setup_log_file(log_path):
     handler.setFormatter(formatter)
     root_logger.addHandler(handler)
     root_logger.info('teuthology version: %s', __version__)
+
+
+def install_except_hook():
+    """
+    Install an exception hook that first logs any uncaught exception, then
+    raises it.
+    """
+    def log_exception(exc_type, exc_value, exc_traceback):
+        if not issubclass(exc_type, KeyboardInterrupt):
+            log.critical("Uncaught exception", exc_info=(exc_type, exc_value,
+                                                         exc_traceback))
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+    sys.excepthook = log_exception

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -4,9 +4,9 @@ import StringIO
 import contextlib
 import sys
 import logging
-from traceback import format_tb
 
 import teuthology
+from teuthology import install_except_hook
 from . import report
 from .job_status import get_status
 from .misc import get_user, merge_configs
@@ -31,18 +31,6 @@ def set_up_logging(verbose, archive):
         teuthology.setup_log_file(os.path.join(archive, 'teuthology.log'))
 
     install_except_hook()
-
-
-def install_except_hook():
-    def log_exception(exception_class, exception, traceback):
-        logging.critical(''.join(format_tb(traceback)))
-        if not exception.message:
-            logging.critical(exception_class.__name__)
-            return
-        logging.critical('{0}: {1}'.format(
-            exception_class.__name__, exception))
-
-    sys.excepthook = log_exception
 
 
 def write_initial_metadata(archive, config, name, description, owner):

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -8,7 +8,7 @@ import yaml
 
 from datetime import datetime
 
-from teuthology import setup_log_file
+from teuthology import setup_log_file, install_except_hook
 from . import beanstalk
 from . import report
 from . import safepath
@@ -56,19 +56,6 @@ def load_config(ctx=None):
             ))
         else:
             teuth_config.archive_base = ctx.archive_dir
-
-
-def install_except_hook():
-    """
-    Install an exception hook that first logs any uncaught exception, then
-    raises it.
-    """
-    def log_exception(exc_type, exc_value, exc_traceback):
-        if not issubclass(exc_type, KeyboardInterrupt):
-            log.critical("Uncaught exception", exc_info=(exc_type, exc_value,
-                                                         exc_traceback))
-        sys.__excepthook__(exc_type, exc_value, exc_traceback)
-    sys.excepthook = log_exception
 
 
 def main(ctx):


### PR DESCRIPTION
The first commit just takes the superior excepthook from the worker module and lets the run module use it.

The second commit should make sure we can at least see uncaught exceptions in gevent greenlets in job logs.