### PR TITLE
If we're going to fail, fail sooner

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -911,6 +911,9 @@ def wait_until_osds_up(ctx, cluster, remote, ceph_cluster='ceph'):
     testdir = get_testdir(ctx)
     with safe_while(sleep=6, tries=50) as proceed:
         while proceed():
+            daemons = ctx.daemons.iter_daemons_of_role('osd', ceph_cluster)
+            for daemon in daemons:
+                daemon.check_status()
             r = remote.run(
                 args=[
                     'adjust-ulimits',

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -49,8 +49,11 @@ def test_sh_progress(caplog):
     t2 = datetime.strptime(records[2].asctime.split(',')[0], "%Y-%m-%d %H:%M:%S")
     assert (t2 - t1).total_seconds() > 2
 
+
 def test_wait_until_osds_up():
     ctx = argparse.Namespace()
+    ctx.daemons = Mock()
+    ctx.daemons.iter_daemons_of_role.return_value = list()
     remote = FakeRemote()
 
     class r():


### PR DESCRIPTION
The change to `misc.wait_until_osds_up()` is the follow-up to #1056, #1045 and #1033.

The change to `parallel` fixes a very longstanding bug that prevented jobs from failing properly. If one of the parallel greenlets encountered an exception, it did not interrupt any others. In certain common situations, e.g. the `rados` task running `ceph_test_rados`, it meant the job kept running until it hit the global timeout and was killed - without any useful error message.

An example of this in action:
[This upgrade run using teuthology master](http://pulpito.ceph.com/zack-2017-03-23_14:08:11-upgrade:hammer-jewel-x-kraken---basic-ovh/) timed out.
[This run](http://pulpito.ceph.com/zack-2017-04-05_12:19:17-upgrade:hammer-jewel-x-kraken---basic-ovh/), which is otherwise identical, failed very quickly and with a much more useful error message: ``Command failed on ovh011 with status 1: 'sudo [...] ceph-osd -f --cluster ceph -i 0'``