### PR TITLE
rgw: add nose dependency for rgw_multisite_tests task

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
                       'httplib2',
                       'paramiko',
                       'pexpect',
+                      'nose', # for qa/tasks/rgw_multisite_tests.py',
                       'requests != 2.13.0',
                       'raven',
                       'web.py',


### PR DESCRIPTION
nose is a dependency for https://github.com/ceph/ceph/pull/14688, which builds a qa suite around the existing rgw multisite tests in `src/test/rgw/test_multi.py`. those tests need to be invoked by the teuthology task itself, because they run `radosgw-admin` commands on different nodes, start/stop daemons, etc