### PR TITLE
Dump '_defaults' to file, otherwise some functions in misc.py will use None

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -265,6 +265,9 @@ def _get_config_path():
     if not os.path.exists(TeuthologyConfig.yaml_path) and \
             os.path.exists(system_config_path):
         return system_config_path
+    elif not os.path.exists(TeuthologyConfig.yaml_path):
+        with open(TeuthologyConfig.yaml_path, 'w') as f:
+            yaml.dump(TeuthologyConfig._defaults, f)
     return TeuthologyConfig.yaml_path
 
 config = TeuthologyConfig(yaml_path=_get_config_path())


### PR DESCRIPTION
@zmc 
Signed-off-by: RonnyChen <rongyao.cry@alibaba-inc.com>