### PR TITLE
task/internal/syslog: make kern.log and misc.log world-writable

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -46,7 +46,7 @@ def syslog(ctx, config):
         for rem in ctx.cluster.remotes.iterkeys():
             log_context = 'system_u:object_r:var_log_t:s0'
             for log_path in (kern_log, misc_log):
-                rem.run(args='touch %s' % log_path)
+                rem.run(args=['install', '-m', '666', '/dev/null', log_path])
                 rem.chcon(log_path, log_context)
             misc.sudo_write_file(
                 remote=rem,


### PR DESCRIPTION
kern.log and misc.log weren't getting written to on ubuntu machines.
On centos chcon is saving the day.

Fixes: http://tracker.ceph.com/issues/16835
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>