### PR TITLE
scripts/suite.py: use distro kernel as default for all tests

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -43,6 +43,7 @@ Standard arguments:
   -k <kernel>, --kernel <kernel>
                               The kernel branch to run against; if not
                               supplied, the installed kernel is unchanged
+                              [default: distro]
   -f <flavor>, --flavor <flavor>
                               The kernel flavor to run against: ('basic',
                               'gcov', 'notcmalloc')


### PR DESCRIPTION
Avoids using existing kernel on test nodes and always installs distro kernel if no option provided

Fixes: http://tracker.ceph.com/issues/20203

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>