### PR TITLE
[tasks/ceph-ansible]: Add debug output for ceph-ansible runs

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -133,6 +133,7 @@ class CephAnsible(Task):
         """
 
         args = [
+            'ANSIBLE_STDOUT_CALLBACK=debug',
             'ansible-playbook', '-vv',
             '-i', 'inven.yml', 'site.yml'
         ]


### PR DESCRIPTION
As requested by Andrew and Alfredo to debug failed ansible jobs
properly

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>