### PR TITLE
purge cluster during teardown

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -212,6 +212,34 @@ class CephAnsible(Task):
         os.remove(self.inventory)
         os.remove(self.playbook_file)
         os.remove(self.extra_vars_file)
+        # run purge-cluster that teardowns the cluster
+        args = [
+            'ANSIBLE_STDOUT_CALLBACK=debug',
+            'ansible-playbook', '-vv',
+            '-e', 'ireallymeanit=yes',
+            '-i', 'inven.yml', 'infrastructure-playbooks/purge-cluster.yml'
+        ]
+        log.debug("Running %s", args)
+        str_args = ' '.join(args)
+        installer_node = self.ceph_installer
+        if self.config.get('rhbuild'):
+            installer_node.run(
+                args=[
+                    run.Raw('cd ~/ceph-ansible'),
+                    run.Raw(';'),
+                    run.Raw(str_args)
+                ]
+            )
+        else:
+            installer_node.run(
+                args=[
+                    run.Raw('cd ~/ceph-ansible'),
+                    run.Raw(';'),
+                    run.Raw('source venv/bin/activate'),
+                    run.Raw(';'),
+                    run.Raw(str_args)
+                ]
+            )
 
     def wait_for_ceph_health(self):
         with contextutil.safe_while(sleep=15, tries=6,

--- a/teuthology/test/task/test_ceph_ansible.py
+++ b/teuthology/test/task/test_ceph_ansible.py
@@ -41,6 +41,11 @@ class TestCephAnsibleTask(TestTask):
         )
         self.patcher_get_scratch_devices.start()
 
+        self.patcher_teardown = patch(
+            'teuthology.task.ceph_ansible.CephAnsible.teardown',
+        )
+        self.patcher_teardown.start()
+
         def fake_set_iface_and_cidr(self):
             self._interface = 'eth0'
             self._cidr = '172.21.0.0/20'
@@ -54,6 +59,7 @@ class TestCephAnsibleTask(TestTask):
     def stop_patchers(self):
         self.patcher_get_scratch_devices.stop()
         self.patcher_remote.stop()
+        self.patcher_teardown.stop()
 
     def test_playbook_none(self):
         skip(SKIP_IRRELEVANT)


### PR DESCRIPTION
It achieves 2 things
a) tests out purge-cluster and iron out any issues as we find them
b) can make ceph-ansible tests run on any nodes in lab (smithi, mira etc)

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>