### PR TITLE
task/internal/syslog: blacklist log from ceph-create-keys

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -128,6 +128,8 @@ def syslog(ctx, config):
                     run.Raw('|'),
                     'grep', '-v', 'ceph-create-keys: INFO',
                     run.Raw('|'),
+                    'grep', '-v', 'INFO:ceph-create-keys',
+                    run.Raw('|'),
                     'head', '-n', '1',
                 ],
                 stdout=StringIO(),


### PR DESCRIPTION
the log format of ceph-create-keys is "$level:$name:$message"

Fixes: http://tracker.ceph.com/issues/20171
Signed-off-by: Kefu Chai <kchai@redhat.com>