### PR TITLE
task/install: should pass `node` as `config` to get_upgrade_version()

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -362,7 +362,7 @@ def upgrade_common(ctx, config, deploy_style):
         pkgs += extra_pkgs
 
         installed_version = packaging.get_package_version(remote, 'ceph-common')
-        upgrade_version = get_upgrade_version(ctx, remote, node)
+        upgrade_version = get_upgrade_version(ctx, node, remote)
         log.info("Ceph {s} upgrade from {i} to {u}".format(
             s=system_type,
             i=installed_version,


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>