### PR TITLE
[DNM] upgrade check: upgrade to same version is a noop

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -335,6 +335,11 @@ def upgrade_remote_to_config(ctx, config):
 
     return result
 
+def _upgrade_is_noop(installed_version, upgrade_version):
+    assert installed_version, "installed_version is empty"
+    assert upgrade_version, "upgrade_version is empty"
+    return LooseVersion(installed_version) == LooseVersion(upgrade_version)
+
 def _upgrade_is_downgrade(installed_version, upgrade_version):
     assert installed_version, "installed_version is empty"
     assert upgrade_version, "upgrade_version is empty"
@@ -368,6 +373,11 @@ def upgrade_common(ctx, config, deploy_style):
             i=installed_version,
             u=upgrade_version
         ))
+	if _upgrade_is_noop(installed_version, upgrade_version):
+            raise RuntimeError(
+                "Upgrade to the same version as is already installed is a "
+                " NOOP. Hint: check the test yaml."
+            )
 	if _upgrade_is_downgrade(installed_version, upgrade_version):
             raise RuntimeError(
                 "An attempt to upgrade from a higher version to a lower one "


### PR DESCRIPTION
We actually had a test that was "upgrading" from one version to the very same
version. This commit adds a check for that case.

Signed-off-by: Nathan Cutler <ncutler@suse.com>