### PR TITLE
RemoteProcess: command can be now executed in specified directory.

### DIFF
--- a/teuthology/orchestra/test/test_run.py
+++ b/teuthology/orchestra/test/test_run.py
@@ -86,6 +86,15 @@ class TestRun(object):
         )
         assert proc.exitstatus == 0
 
+    def test_run_cwd(self):
+        self.m_stdout_buf.channel.recv_exit_status.return_value = 0
+        run.run(
+            client=self.m_ssh,
+            args=['foo_bar_baz'],
+            cwd='/cwd/test',
+        )
+        self.m_ssh.exec_command.assert_called_with('(cd /cwd/test && exec foo_bar_baz)')
+
     def test_capture_stdout(self):
         output = 'foo\nbar'
         set_buffer_contents(self.m_stdout_buf, output)


### PR DESCRIPTION
`RemoteProcess`, a class built around Paramiko's `exec_command()`, currently lacks support for the `cwd` parameter. It specifies the directory in which the requested command should be executed. This stays in contrast to `LocalRemoteProcess` from the `vstart runner` as it wraps Python's `subprocess`, and thus naturally offers the feature. The patch unifies these two implementations.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

Related PR: https://github.com/ceph/ceph/pull/16022.