### PR TITLE
packaging: pass --force-yes to allow for unsigned deb packages

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -74,6 +74,7 @@ def install_package(package, remote):
                   '-E',
                   'apt-get',
                   '-y',
+                  '--force-yes',
                   'install',
                   '{package}'.format(package=package)]
     elif flavor == 'rpm':

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -68,6 +68,7 @@ class TestPackaging(object):
             '-E',
             'apt-get',
             '-y',
+            '--force-yes',
             'install',
             'apache2'
         ]


### PR DESCRIPTION
rbd_fio task has been switched to {install,remove}_package().  This
commit mirrors ceph.git commit d14f2da437a3 ("task/rbd_fio: allow for
unsigned packages"):

"Similar to what the teuthology install.py task does, add --force-yes to
the apt-get install so that unsigned packages are successfully
installed. It is needed when the buildpackages task is used to create
packages on the fly."

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>