### PR TITLE
teuthology: set cluster log level to debug

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -30,6 +30,8 @@
 
 	mon allow pool delete = true
 
+	mon cluster log file level = debug
+
 [osd]
         osd journal size = 100
 


### PR DESCRIPTION
Since we're testing, we always want the full thing.  This
used to not really matter because almost everything was
going to the clog at info level, but as of luminous things like
the cluster map version echos are at debug level.

Signed-off-by: John Spray <john.spray@redhat.com>