### PR TITLE
downburst: Decrease disk size to 100GB

### DIFF
--- a/teuthology/provision/downburst.py
+++ b/teuthology/provision/downburst.py
@@ -170,7 +170,7 @@ class Downburst(object):
             'distro': os_type,
             'distroversion': self.os_version,
             'additional-disks': 4,
-            'additional-disks-size': '200G',
+            'additional-disks-size': '100G',
             'arch': 'x86_64',
         }
         fqdn = self.name.split('@')[1]


### PR DESCRIPTION
The first VPS on every VPSHOST runs off the VPSHOST root drive.  Because
of this, the root drive is filling up due to the addition of another OSD
drive: https://github.com/ceph/teuthology/pull/1099

This not only results in nagios alerts but could also result in needless
job failures.  OSD drives/partitions are already only 100G on smithi so
this should be fine.

Signed-off-by: David Galloway <dgallowa@redhat.com>