### PR TITLE
[tasks/ceph-ansible]: use site.yml from the ceph-ansible repo

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -286,7 +286,14 @@ class CephAnsible(Task):
         ceph_installer = self.ceph_installer
         args = self.args
         if ceph_installer.os.package_type == 'rpm':
-            # install crypto packages for ansible
+            # handle selinux init issues during purge-cluster
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1364703
+            ceph_installer.run(
+                args=[
+                    'sudo', 'yum', 'remove', '-y', 'libselinux-python'
+                ]
+            )
+            # install crypto/selinux packages for ansible
             ceph_installer.run(args=[
                 'sudo',
                 'yum',
@@ -294,7 +301,8 @@ class CephAnsible(Task):
                 '-y',
                 'libffi-devel',
                 'python-devel',
-                'openssl-devel'
+                'openssl-devel',
+                'libselinux-python'
             ])
         else:
             ceph_installer.run(args=[
@@ -303,6 +311,7 @@ class CephAnsible(Task):
                 'install',
                 '-y',
                 'libssl-dev',
+                'python-openssl',
                 'libffi-dev',
                 'python-dev'
             ])

--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -336,6 +336,7 @@ class CephAnsible(Task):
             run.Raw('cd ~/ceph-ansible'),
             run.Raw(';'),
             'virtualenv',
+            run.Raw('--system-site-packages'),
             'venv',
             run.Raw(';'),
             run.Raw('source venv/bin/activate'),

--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -310,7 +310,7 @@ class CephAnsible(Task):
         branch = 'master'
         if self.config.get('branch'):
             branch = self.config.get('branch')
-        ansible_ver = 'ansible==2.2.1'
+        ansible_ver = 'ansible==2.3.2'
         if self.config.get('ansible-version'):
             ansible_ver = 'ansible==' + self.config.get('ansible-version')
         ceph_installer.run(


### PR DESCRIPTION
we have been using custome site.yml from within the task which is not
accurate when compared to the file provided by ceph-ansible repo, instead
use the sample file as the main playbook for tests.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>