### PR TITLE
Supprted for CentOS

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -35,7 +35,7 @@ Linux)
             fi
         fi
         ;;
-    RedHatEnterpriseWorkstation|RedHatEnterpriseServer)
+    RedHatEnterpriseWorkstation|RedHatEnterpriseServer|CentOS)
         for package in python-pip python-virtualenv mariadb-devel libev-devel libvirt-devel libffi-devel; do
 	    if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
 		missing="${missing:+$missing }$package"

--- a/bootstrap
+++ b/bootstrap
@@ -36,7 +36,7 @@ Linux)
         fi
         ;;
     RedHatEnterpriseWorkstation|RedHatEnterpriseServer|CentOS)
-        for package in python-pip python-virtualenv mariadb-devel libev-devel libvirt-devel libffi-devel; do
+        for package in python2-pip python-virtualenv mariadb-devel libev-devel libvirt-devel libffi-devel; do
 	    if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
 		missing="${missing:+$missing }$package"
 	    fi
@@ -55,7 +55,7 @@ Linux)
 	fi
 	;;
     Fedora)
-        for package in python-pip python2-virtualenv libev-devel libvirt-devel mysql-community-devel libffi-devel; do
+        for package in python2-pip python2-virtualenv libev-devel libvirt-devel mysql-community-devel libffi-devel; do
 	    if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
 		missing="${missing:+$missing }$package"
 	    fi


### PR DESCRIPTION
1. Supported for CentOS.
2. Update the rpm package of pyton2-pip for redhat family.