### PR TITLE
task/internal/syslog: blacklist openstack datasource log

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -130,6 +130,8 @@ def syslog(ctx, config):
                     run.Raw('|'),
                     'grep', '-v', 'INFO:ceph-create-keys',
                     run.Raw('|'),
+                    'grep', '-v', 'Loaded datasource DataSourceOpenStack',
+                    run.Raw('|'),
                     'head', '-n', '1',
                 ],
                 stdout=StringIO(),


### PR DESCRIPTION
Caused OVH node jobs to fail when it shouldn't have

Signed-off-by: David Galloway <dgallowa@redhat.com>