### PR TITLE
[task/ceph-ansible]: Add required radosgw_interface due to ceph-ansible upstream changes

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -248,6 +248,8 @@ class CephAnsible(Task):
             host_vars['devices'] = get_scratch_devices(remote)[0:dev_needed]
         if 'monitor_interface' not in extra_vars:
             host_vars['monitor_interface'] = remote.interface
+        if 'radosgw_interface' not in extra_vars:
+            host_vars['radosgw_interface'] = remote.interface
         if 'public_network' not in extra_vars:
             host_vars['public_network'] = remote.cidr
         return host_vars

--- a/teuthology/test/task/test_ceph_ansible.py
+++ b/teuthology/test/task/test_ceph_ansible.py
@@ -79,6 +79,7 @@ class TestCephAnsibleTask(TestTask):
             vars=dict(
                 osd_auto_discovery=True,
                 monitor_interface='eth0',
+                radosgw_interface='eth0',
                 public_network='172.21.0.0/20',
             ),
         ))
@@ -110,6 +111,7 @@ class TestCephAnsibleTask(TestTask):
             playbook=[],
             vars=dict(
                 monitor_interface='eth0',
+                radosgw_interface='eth0',
                 public_network='172.21.0.0/20',
             ),
         ))
@@ -157,11 +159,11 @@ class TestCephAnsibleTask(TestTask):
         hosts_file_obj.seek(0)
         assert hosts_file_obj.read() == '\n'.join([
             '[mdss]',
-            "remote2 monitor_interface='eth0' public_network='172.21.0.0/20'",
+            "remote2 monitor_interface='eth0' public_network='172.21.0.0/20' radosgw_interface='eth0'",
             '',
             '[mons]',
-            "remote1 monitor_interface='eth0' public_network='172.21.0.0/20'",
+            "remote1 monitor_interface='eth0' public_network='172.21.0.0/20' radosgw_interface='eth0'",
             '',
             '[osds]',
-            "remote3 monitor_interface='eth0' public_network='172.21.0.0/20'",
+            "remote3 monitor_interface='eth0' public_network='172.21.0.0/20' radosgw_interface='eth0'",
         ])


### PR DESCRIPTION
radosgw_interface is now required to run rgw playbook.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>