### PR TITLE
task/ceph-ansible: copy purge-cluster to top-level directory for it to work

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -185,11 +185,20 @@ class CephAnsible(Task):
             'ANSIBLE_STDOUT_CALLBACK=debug',
             'ansible-playbook', '-vv',
             '-e', 'ireallymeanit=yes',
-            '-i', 'inven.yml', 'infrastructure-playbooks/purge-cluster.yml'
+            '-i', 'inven.yml', 'purge-cluster.yml'
         ]
         log.debug("Running %s", args)
         str_args = ' '.join(args)
         installer_node = self.ceph_installer
+        # copy purge-cluster playbook from infra dir to top level dir
+        # as required by ceph-ansible
+        installer_node.run(
+            args=[
+                'cp',
+                run.Raw('~/ceph-ansible/infrastructure-playbooks/purge-cluster.yml'),
+                run.Raw('~/ceph-ansible/'),
+            ]
+        )
         if self.config.get('rhbuild'):
             installer_node.run(
                 args=[


### PR DESCRIPTION
set ANSIBLE_LIBRARY environment variable for purge cluster playbook to work properly.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>