### PR TITLE
ceph.conf: osd_debug_shutdown=true

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -43,6 +43,7 @@
 	osd recover clone overlap = true
 	osd recovery max chunk = 1048576
 
+	osd debug shutdown = true
         osd debug op order = true
         osd debug verify stray on activate = true
 


### PR DESCRIPTION
The extra logging during osd shutdown is becoming optional; enable it in
qa.

Signed-off-by: Sage Weil <sage@redhat.com>