### PR TITLE
[tasks/ceph-ansible]: remove python-openssl

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -322,7 +322,6 @@ class CephAnsible(Task):
                 'install',
                 '-y',
                 'libssl-dev',
-                'python-openssl',
                 'libffi-dev',
                 'python-dev'
             ])


### PR DESCRIPTION
Anyway this didn't solve the problem , since it gets installed later due to dependency from one of the ceph packages, so either we move to zesty or update this package from zesty.

http://pulpito.ceph.com/vasu-2017-09-28_01:59:39-ceph-ansible-master-distro-basic-ovh/

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>