### PR TITLE
ceph.conf: enable debug asserts on shutdown

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -33,6 +33,7 @@
 	mon allow pool delete = true
 
 	mon cluster log file level = debug
+	debug asserts on shutdown = true
 
 [osd]
         osd journal size = 100


### PR DESCRIPTION
Signed-off-by: Greg Farnum <gfarnum@redhat.com>