### PR TITLE
downburst: Explicitly type our user-data

### DIFF
--- a/teuthology/provision/downburst.py
+++ b/teuthology/provision/downburst.py
@@ -209,7 +209,8 @@ class Downburst(object):
         if os_type in ('ubuntu', 'fedora'):
             user_info['packages'].append('python')
         user_fd = tempfile.NamedTemporaryFile(delete=False)
-        yaml.safe_dump(user_info, user_fd)
+        user_str = "#cloud-config\n" + yaml.safe_dump(user_info)
+        user_fd.write(user_str)
         self.user_path = user_fd.name
         return True
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/21727

Tested on:
- CentOS 7.4
- CentOS 7.3
- Ubuntu 16.04
- Ubuntu 14.04