### PR TITLE
[orchestra/systemd]: check status when daemon is restarted

### DIFF
--- a/teuthology/orchestra/daemon/systemd.py
+++ b/teuthology/orchestra/daemon/systemd.py
@@ -136,6 +136,8 @@ class SystemDState(DaemonState):
             self.remote.run(args=[run.Raw(self.start_cmd)])
         else:
             self.remote.run(args=[run.Raw(self.restart_cmd)])
+        # check status will also fail if the process hasn't restarted
+        self.check_status()
 
     def restart_with_args(self, extra_args):
         """


### PR DESCRIPTION
Also check status when daemon is restarted, any failed daemon restart will raise an error early on.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>