### PR TITLE
misc.wait_until_osds_up: prolong the timeout from 5 min to 9 min

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -917,7 +917,7 @@ def wait_until_osds_up(ctx, cluster, remote, ceph_cluster='ceph'):
     """Wait until all Ceph OSDs are booted."""
     num_osds = num_instances_of_type(cluster, 'osd', ceph_cluster)
     testdir = get_testdir(ctx)
-    with safe_while(sleep=6, tries=50) as proceed:
+    with safe_while(sleep=6, tries=90) as proceed:
         while proceed():
             daemons = ctx.daemons.iter_daemons_of_role('osd', ceph_cluster)
             for daemon in daemons:


### PR DESCRIPTION
if an node hosts 6 OSDs, it would take longer to boot. this addresses
the failure of
/a/kchai-2017-11-03_05:56:44-rados-wip-jewel-backports-reloaded-distro-basic-mira/1806380.

Signed-off-by: Kefu Chai <kchai@redhat.com>