### PR TITLE
ceph.conf: prolong "mon mgr mkfs grace" to 2 minutes

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -77,6 +77,7 @@
 	debug paxos = 20
 	debug auth = 20
 	mon data avail warn = 5
+	mon mgr mkfs grace = 120
 	mon reweight min pgs per osd = 4
 	mon osd reporter subtree level = osd
 	mon osd prime pg temp = true


### PR DESCRIPTION
it might take longer than 1 minutes to:
1. create a monmap
2. create the auth keyrings
3. prepare the osd devices and activate OSDs (fdisk,mkfs.xfs,ceph-osd --mkfs)
4. prepare the monitors (mkfs), and start them
5. start mgr
6. any mgr sends a beacon to monitor.

Signed-off-by: Kefu Chai <kchai@redhat.com>