### PR TITLE
Fix cloning of ceph-ansible.

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -411,6 +411,8 @@ class CephAnsible(Task):
             'mkdir',
             run.Raw('~/ceph-ansible'),
             run.Raw(';'),
+            run.Raw('cd ~'),
+            run.Raw(';'),
             'git',
             'clone',
             run.Raw('-b %s' % branch),
@@ -436,6 +438,9 @@ class CephAnsible(Task):
             'install',
             run.Raw('setuptools>=11.3'),
             run.Raw(ansible_ver),
+        ])
+        ceph_installer.run(args=[
+            run.Raw('cd ~/ceph-ansible'),
             run.Raw(';'),
             run.Raw(str_args)
         ])


### PR DESCRIPTION
Make sure we are in the right directory when we clone ceph-ansible.
Ceph-ansible clones into ~, and the ansible playbook is run from ~/ceph_ansible
Signed-off-by: Warren Usui <wusui@redhat.com>