### PR TITLE
task/hadoop: update hadoop 2.5.2 url

### DIFF
--- a/teuthology/task/hadoop.py
+++ b/teuthology/task/hadoop.py
@@ -8,7 +8,7 @@ from ..exceptions import UnsupportedPackageTypeError
 
 log = logging.getLogger(__name__)
 
-HADOOP_2x_URL = "http://apache.osuosl.org/hadoop/common/hadoop-2.5.2/hadoop-2.5.2.tar.gz"
+HADOOP_2x_URL = "https://archive.apache.org/dist/hadoop/core/hadoop-2.5.2/hadoop-2.5.2.tar.gz"
 
 def dict_to_hadoop_conf(items):
     out = "<configuration>\n"


### PR DESCRIPTION
hadoop v2.5.2 is pretty old now, and is removed from the hadoop/common
directory. but it can be found in archive.

Signed-off-by: Kefu Chai <kchai@redhat.com>