### PR TITLE
Task: Tolerate a missing ctx.config

### DIFF
--- a/teuthology/task/__init__.py
+++ b/teuthology/task/__init__.py
@@ -41,6 +41,8 @@ class Task(object):
         dict with the same name as this task. Override any settings in
         self.config with those overrides
         """
+        if not hasattr(self.ctx, 'config'):
+            return
         all_overrides = self.ctx.config.get('overrides', dict())
         if not all_overrides:
             return


### PR DESCRIPTION
When we initialize a ConsoleLog task during FOG reimaging, the ctx
object has no config attribute.

Signed-off-by: Zack Cerza <zack@redhat.com>