### PR TITLE
teuthology/task/install/valgrind.supp: add suppression for dlopen()

### DIFF
--- a/teuthology/task/install/valgrind.supp
+++ b/teuthology/task/install/valgrind.supp
@@ -481,3 +481,13 @@
    fun:PyEval_CallObjectWithKeywords
    fun:PyEval_EvalFrameEx
 }
+
+{
+  dlopen() with -lceph-common https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700899
+  Memcheck:Leak
+  match-leak-kinds: reachable
+  fun:calloc
+  ...
+  fun:_dlerror_run
+  fun:dlopen@@GLIBC_2.2.5
+}


### PR DESCRIPTION
the analysis in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700899
also applies to ceph-common.

Fixes: http://tracker.ceph.com/issues/22438
Signed-off-by: Kefu Chai <kchai@redhat.com>
  