### PR TITLE
teuthology/task/install/valgrind.supp: add suppression for dlopen()

### DIFF
--- a/teuthology/task/install/valgrind.supp
+++ b/teuthology/task/install/valgrind.supp
@@ -486,7 +486,7 @@
   dlopen() with -lceph-common https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=700899
   Memcheck:Leak
   match-leak-kinds: reachable
-  fun:calloc
+  fun:*alloc
   ...
   fun:_dlerror_run
   fun:dlopen@@GLIBC_2.2.5


### PR DESCRIPTION
should cover the case of malloc() in addition to calloc()

Fixes: http://tracker.ceph.com/issues/22438
Signed-off-by: Kefu Chai <kchai@redhat.com>