### PR TITLE
ceph.conf: mon_clock_drift_allowed .5 -> 1.0

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -5,7 +5,7 @@
 
 	filestore xattr use omap = true
 
-	mon clock drift allowed = .500
+	mon clock drift allowed = 1.000
 
 	osd crush chooseleaf type = 0
         auth debug = true


### PR DESCRIPTION
All of the errors I see seem to be between .5 and .9s.

Signed-off-by: Sage Weil <sage@redhat.com>