### PR TITLE
Enable FOG reimage by default for all machine types

### DIFF
--- a/teuthology/lock/ops.py
+++ b/teuthology/lock/ops.py
@@ -80,8 +80,7 @@ def lock_many(ctx, num, machine_type, user=None, description=None,
         # Only query for os_type/os_version if non-vps and non-libcloud, since
         # in that case we just create them.
         vm_types = ['vps'] + teuthology.provision.cloud.get_types()
-        reimage_types = teuthology.provision.fog.get_types()
-        if machine_type not in vm_types + reimage_types:
+        if machine_type not in vm_types:
             if os_type:
                 data['os_type'] = os_type
             if os_version:
@@ -110,7 +109,7 @@ def lock_many(ctx, num, machine_type, user=None, description=None,
                         unlock_one(ctx, machine, user)
                     ok_machs = keys.do_update_keys(ok_machs.keys())[1]
                 return ok_machs
-            elif machine_type in reimage_types:
+            else:
                 reimaged = dict()
                 console_log_conf = dict(
                     logfile_name='{shortname}_reimage.log',


### PR DESCRIPTION
Can be enabled for multi queue without any additional bookkeeping.

the downside: you can't control from teuthology.yaml what
machines can be enabled for FOG but that is fine.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>