### PR TITLE
Use $ to randomly select a yaml file.

### DIFF
--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -121,15 +121,11 @@ def _build_matrix(path, mincyclicity=0, item=''):
                 fn = files[randint(0,fileslen)]
                 submat = _build_matrix(
                     os.path.join(path, fn),
-                    mincyclicity,
+                    mincyclicity=0,
                     item=fn)
                 if submat is not None:
                     submats.append(submat)
             mat = matrix.Product(item, submats)
-            if mat and mat.cyclicity() < mincyclicity:
-                mat = matrix.Cycle(
-                    (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
-                )
             return mat
         else:
             # list items

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -117,7 +117,7 @@ def _build_matrix(path, mincyclicity=0, item=''):
             files.remove('$')
             submats = []
             fileslen = len(files)
-            for fn in sorted(files):
+            for _ in range(0, fileslen):
                 fn = files[randint(0,fileslen)]
                 submat = _build_matrix(
                     os.path.join(path, fn),
@@ -125,12 +125,11 @@ def _build_matrix(path, mincyclicity=0, item=''):
                     item=fn)
                 if submat is not None:
                     submats.append(submat)
-            mat = submats
-            #mat = matrix.Product(item, submats)
-            #if mat and mat.cyclicity() < mincyclicity:
-            #    mat = matrix.Cycle(
-            #        (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
-            #    )
+            mat = matrix.Product(item, submats)
+            if mat and mat.cyclicity() < mincyclicity:
+                mat = matrix.Cycle(
+                    (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
+                )
             return mat
         else:
             # list items

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -124,8 +124,12 @@ def _build_matrix(path, mincyclicity=0, item=''):
                     mincyclicity=0,
                     item=fn)
                 if submat is not None:
-                    submats.append(submat)
+                    submats = [submat]
             mat = matrix.Product(item, submats)
+            if mat and mat.cyclicity() < mincyclicity:
+                mat = matrix.Cycle(
+                    (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
+                )
             return mat
         else:
             # list items

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from random import randint
 from . import matrix
 
 log = logging.getLogger(__name__)
@@ -100,6 +101,24 @@ def _build_matrix(path, mincyclicity=0, item=''):
             files.remove('%')
             submats = []
             for fn in sorted(files):
+                submat = _build_matrix(
+                    os.path.join(path, fn),
+                    mincyclicity=0,
+                    item=fn)
+                if submat is not None:
+                    submats.append(submat)
+            mat = matrix.Product(item, submats)
+            if mat and mat.cyclicity() < mincyclicity:
+                mat = matrix.Cycle(
+                    (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
+                )
+            return mat
+        elif '$' in files:
+            files.remove('$')
+            submats = []
+            fileslen = len(files)
+            if fileslen > 0:
+                fn = files[randint(0,fileslen)]
                 submat = _build_matrix(
                     os.path.join(path, fn),
                     mincyclicity=0,

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -117,7 +117,7 @@ def _build_matrix(path, mincyclicity=0, item=''):
             files.remove('$')
             submats = []
             fileslen = len(files)
-            for _ in range(0, len(files)):
+            for fn in sorted(files):
                 fn = files[randint(0,fileslen)]
                 submat = _build_matrix(
                     os.path.join(path, fn),

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -121,7 +121,7 @@ def _build_matrix(path, mincyclicity=0, item=''):
                 fn = files[randint(0,fileslen)]
                 submat = _build_matrix(
                     os.path.join(path, fn),
-                    mincyclicity=0,
+                    mincyclicity,
                     item=fn)
                 if submat is not None:
                     submats.append(submat)

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -117,6 +117,7 @@ def _build_matrix(path, mincyclicity=0, item=''):
             files.remove('$')
             submats = []
             fileslen = len(files)
+            print "===========" + str(fileslen) + "=============="
             for _ in range(0, fileslen):
                 fn = files[randint(0,fileslen)]
                 submat = _build_matrix(

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -117,19 +117,20 @@ def _build_matrix(path, mincyclicity=0, item=''):
             files.remove('$')
             submats = []
             fileslen = len(files)
-            if fileslen > 0:
+            for _ in range(0, len(files)):
                 fn = files[randint(0,fileslen)]
                 submat = _build_matrix(
                     os.path.join(path, fn),
                     mincyclicity=0,
                     item=fn)
                 if submat is not None:
-                    submats = [submat]
-            mat = matrix.Product(item, submats)
-            if mat and mat.cyclicity() < mincyclicity:
-                mat = matrix.Cycle(
-                    (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
-                )
+                    submats.append(submat)
+            mat = submats
+            #mat = matrix.Product(item, submats)
+            #if mat and mat.cyclicity() < mincyclicity:
+            #    mat = matrix.Cycle(
+            #        (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
+            #    )
             return mat
         else:
             # list items


### PR DESCRIPTION
Implements Feature asked for in Tracker 23208.  It runs separate tests on different yaml files specified in a directory.  The purpose here is to allow different distros to be tested without increasing the number of jobs run.

I believe that there is some code duplication with the Percent-sign magic filename code, and I think that the last few lines of the code effectively do a "multiply by one" type of computation but this feels to me to be the easiest way of implementing this.   I am open to improvements.
 