### PR TITLE
task.selinux: Whitelist rhsmd denials

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -114,6 +114,7 @@ class SELinux(Task):
             'scontext=system_u:system_r:nrpe_t:s0',
             'scontext=system_u:system_r:pcp_pmlogger_t',
             'scontext=system_u:system_r:pcp_pmcd_t:s0',
+            'comm="rhsmd"',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
These started showing up once we added RHEL to Sepia.

Fixes: https://tracker.ceph.com/issues/23343#note-5

Signed-off-by: David Galloway <dgallowa@redhat.com>