### PR TITLE
task.kernel: Only show latest kernel when running rpm -q kernel

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -766,7 +766,7 @@ def need_to_install_distro(remote):
     if current in newest or current.replace('-', '_') in newest:
         return False
     log.info(
-        'Not newest distro kernel. Curent: {cur} Expected: {new}'.format(
+        'Not newest distro kernel. Current: {cur} Expected: {new}'.format(
             cur=current, new=newest))
     return newest
 
@@ -1026,6 +1026,10 @@ def get_latest_image_version_rpm(remote):
             '-q',
             'kernel',
             '--last',  # order by install time
+            run.Raw('|'),
+            'head',  # only show top/latest kernel
+            '-n',
+            '1',
         ], stdout=StringIO())
     for kernel in proc.stdout.getvalue().split():
         if kernel.startswith('kernel'):


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23381

Signed-off-by: David Galloway <dgallowa@redhat.com>