### PR TITLE
Drop libvirt from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
                       # a dependency but we need it anyway.
                       'python-neutronclient',
                       'prettytable',
-                      'libvirt-python',
                       'python-dateutil',
                       'manhole',
                       'apache-libcloud',


### PR DESCRIPTION
Having an unversioned libvirt-python in setup.py started causing
problems with tox, since it uses an sdist archive as a basis for
installing teuthology in its virtualenvs. Removing it is consistent with
best practices. We'll still keep it in requirements.txt.

Signed-off-by: Zack Cerza <zack@redhat.com>