### PR TITLE
Increase timeouts teuthology will wait for FOG provisioning

### DIFF
--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -241,7 +241,7 @@ class FOG(object):
         completed)
         """
         self.log.info("Waiting for deploy to finish")
-        with safe_while(sleep=15, tries=40) as proceed:
+        with safe_while(sleep=15, tries=60) as proceed:
             while proceed():
                 if not self.deploy_task_active(task_id):
                     break

--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -257,7 +257,7 @@ class FOG(object):
 
     def _wait_for_ready(self):
         """ Attempt to connect to the machine via SSH """
-        with safe_while(sleep=6, tries=50) as proceed:
+        with safe_while(sleep=6, tries=100) as proceed:
             while proceed():
                 try:
                     self.remote.connect()

--- a/teuthology/provision/test/test_fog.py
+++ b/teuthology/provision/test/test_fog.py
@@ -252,7 +252,7 @@ class TestFOG(object):
 
     @mark.parametrize(
         'tries',
-        [3, 45],
+        [3, 61],
     )
     def test_wait_for_deploy_task(self, tries):
         wait_results = [True for i in range(tries)] + [False]
@@ -262,7 +262,7 @@ class TestFOG(object):
             deploy_task_active=DEFAULT,
         ) as local_mocks:
             local_mocks['deploy_task_active'].side_effect = wait_results
-            if tries >= 40:
+            if tries >= 60:
                 with raises(MaxWhileTries):
                     obj.wait_for_deploy_task(9)
                 return

--- a/teuthology/provision/test/test_fog.py
+++ b/teuthology/provision/test/test_fog.py
@@ -285,13 +285,13 @@ class TestFOG(object):
 
     @mark.parametrize(
         'tries',
-        [1, 51],
+        [1, 101],
     )
     def test_wait_for_ready(self, tries):
         connect_results = [MaxWhileTries for i in range(tries)] + [True]
         obj = self.klass('name.fqdn', 'type', '1.0')
         self.mocks['m_Remote_connect'].side_effect = connect_results
-        if tries >= 50:
+        if tries >= 100:
             with raises(MaxWhileTries):
                 obj._wait_for_ready()
             return


### PR DESCRIPTION
http://sentry.ceph.com/sepia/teuthology/issues/3357/events/135936/

<dgalloway> the problem is when there are no running smith jobs and then a big run gets scheduled.  FOG gets backed up and makes the testnodes wait