### PR TITLE
Wip wusui2

### DIFF
--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -100,8 +100,6 @@ def _build_matrix(path, mincyclicity=0, item=''):
             return matrix.Concat(item, submats)
         elif path.endswith('$'):
             # pick a random item -- make sure we don't pick any magic files
-            import pdb; pdb.set_trace()
-            files.remove('%')
             submats = []
             for fn in sorted(files):
                 submat = _build_matrix(

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -98,6 +98,20 @@ def _build_matrix(path, mincyclicity=0, item=''):
                 if submat is not None:
                     submats.append(submat)
             return matrix.Concat(item, submats)
+        elif path.endswith('$'):
+            # pick a random item -- make sure we don't pick any magic files
+            import pdb; pdb.set_trace()
+            files.remove('$')
+            files.remove('%')
+            submats = []
+            for fn in sorted(files):
+                submat = _build_matrix(
+                    os.path.join(path, fn),
+                    mincyclicity,
+                    fn)
+                if submat is not None:
+                    submats.append(submat)
+            return matrix.PickRandom(item, submats)
         elif '%' in files:
             # convolve items
             files.remove('%')
@@ -115,19 +129,6 @@ def _build_matrix(path, mincyclicity=0, item=''):
                     (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
                 )
             return mat
-        elif path.endswith('$'):
-            # pick a random item -- make sure we don't pick any magic files
-            files.remove('$')
-            files.remove('%')
-            submats = []
-            for fn in sorted(files):
-                submat = _build_matrix(
-                    os.path.join(path, fn),
-                    mincyclicity,
-                    fn)
-                if submat is not None:
-                    submats.append(submat)
-            return matrix.PickRandom(item, submats)
         else:
             # list items
             submats = []

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -34,7 +34,7 @@ def build_matrix(path, subset=None):
     for each item in the directory, and then do a product to generate
     a result list with all combinations (A Product).
 
-    For a directory with a magic '$' file, we generate a list of all
+    For a directory whose name ends in '$', we generate a list of all
     items that we will randomly choose from.
 
     The final description (after recursion) for each item will look
@@ -115,9 +115,10 @@ def _build_matrix(path, mincyclicity=0, item=''):
                     (mincyclicity + mat.cyclicity() - 1) / mat.cyclicity(), mat
                 )
             return mat
-        elif '$' in files:
-            # pick a random item
+        elif path.endswith('$'):
+            # pick a random item -- make sure we don't pick any magic files
             files.remove('$')
+            files.remove('%')
             submats = []
             for fn in sorted(files):
                 submat = _build_matrix(

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -101,7 +101,6 @@ def _build_matrix(path, mincyclicity=0, item=''):
         elif path.endswith('$'):
             # pick a random item -- make sure we don't pick any magic files
             import pdb; pdb.set_trace()
-            files.remove('$')
             files.remove('%')
             submats = []
             for fn in sorted(files):

--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -100,6 +100,8 @@ def _build_matrix(path, mincyclicity=0, item=''):
             return matrix.Concat(item, submats)
         elif path.endswith('$'):
             # pick a random item -- make sure we don't pick any magic files
+            if '%' in files:
+                files.remove('%')
             submats = []
             for fn in sorted(files):
                 submat = _build_matrix(


### PR DESCRIPTION
This change implements the 'choose a random yaml file' behavior for directory names and is not keyed on having a $ file in the directory.  The following is an example of how it should be used:

foo is a directory containing distro definitions -- yaml files that define os_type and os_version.  The files in foo are:
          %
          ubuntu.yaml
          centos.yaml
          rhel.yaml

A suite that links distros to foo will run a test for ubuntu, centos, and rhel.

A suite that links distros$ to foo will run a test, randomly selecting from ubuntu, centos and rhel.

This would allow a suite of n combinations of tests to run roughly n/3 tests on each distro when distro$ is used as the name of the symbolic link.  When distro is the name of the symbolic link 3*n tests will be run (once for each yaml file).