### PR TITLE
placeholder: update whitelist for osd slow op wrn

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -70,7 +70,7 @@ dict_templ = {
                     'debug osd': 25
                 }
             },
-            'log-whitelist': ['slow request'],
+            'log-whitelist': ['slow request', '\(SLOW_OPS\)'],
             'sha1': Placeholder('ceph_hash'),
         },
         'ceph-deploy': {


### PR DESCRIPTION
Caused by: https://github.com/ceph/ceph/pull/20660 (ea97c120d2173f2fc70d979d57a7edb2a6c5da5e)

Fixes: https://tracker.ceph.com/issues/23662

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>