### PR TITLE
teuthology/lock: ignore none 200 jobs in node_job_is_active()

### DIFF
--- a/teuthology/lock/query.py
+++ b/teuthology/lock/query.py
@@ -123,6 +123,8 @@ def find_stale_locks(owner=None):
         url = os.path.join(config.results_server, 'runs', name, 'jobs', job_id,
                            '')
         resp = requests.get(url)
+        if not resp.ok:
+            return False
         job_info = resp.json()
         if job_info['status'] in ('running', 'waiting'):
             cache.add(description)


### PR DESCRIPTION
there is chance that we will have 404 when accessing a job's URI.

Signed-off-by: Kefu Chai <kchai@redhat.com>