### PR TITLE
placeholder: whitelist MDS_ALL_DOWN by default

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -70,7 +70,10 @@ dict_templ = {
                     'debug osd': 25
                 }
             },
-            'log-whitelist': ['slow request', '\(SLOW_OPS\)'],
+            'log-whitelist': ['slow request',
+                              '\(MDS_ALL_DOWN\)',
+                              '\(MDS_UP_LESS_THAN_MAX\)',
+                              '\(SLOW_OPS\)'],
             'sha1': Placeholder('ceph_hash'),
         },
         'ceph-deploy': {


### PR DESCRIPTION
because, in ceph/qa/tasks/ceph.py, we start mon, mgr, osd, and then mds.
there is a time window where there is no mds around, but mgr is checking
mdsmap for MDS_ALL_DOWN errors. there is no way to disable this check in
this time window. so we just whitelist MDS_ALL_DOWN here.

Signed-off-by: Kefu Chai <kchai@redhat.com>