### PR TITLE
remove blanket SLOW_OPS whitelist

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -70,10 +70,8 @@ dict_templ = {
                     'debug osd': 25
                 }
             },
-            'log-whitelist': ['slow request',
-                              '\(MDS_ALL_DOWN\)',
-                              '\(MDS_UP_LESS_THAN_MAX\)',
-                              '\(SLOW_OPS\)'],
+            'log-whitelist': ['\(MDS_ALL_DOWN\)',
+                              '\(MDS_UP_LESS_THAN_MAX\)'],
             'sha1': Placeholder('ceph_hash'),
         },
         'ceph-deploy': {


### PR DESCRIPTION
Should no longer be necessary after [1].

[1] https://github.com/ceph/ceph/pull/21684

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>