### PR TITLE
ansible.py: Write "foo" to ~/.vault_pass.txt instead of touching

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -416,12 +416,13 @@ class CephLab(Ansible):
         super(CephLab, self).__init__(ctx, config)
 
     def begin(self):
-        # Emulate 'touch ~/.vault_pass.txt' to avoid ansible failing;
-        # in almost all cases we don't need the actual vault password
+        # Write foo to ~/.vault_pass.txt if it's missing.
+        # In almost all cases we don't need the actual vault password.
+        # Touching an empty file broke as of Ansible 2.4
         vault_pass_path = os.path.expanduser('~/.vault_pass.txt')
         if not os.path.exists(vault_pass_path):
-            with open(vault_pass_path, 'a'):
-                pass
+            with open(vault_pass_path, 'w') as f:
+                f.write('foo')
         super(CephLab, self).begin()
 
     def _set_status(self, status):


### PR DESCRIPTION
ansible-playbook will not run with an empty vault password file.  It
will run if the password file has something in it even if it doesn't get
used.

Multiple ansible vault identities won't be fixed until at least 2.5 (https://github.com/ansible/ansible/issues/38146) so this is probably our safest bet for now.

Signed-off-by: David Galloway <dgallowa@redhat.com>