### PR TITLE
ceph-ansible: add hard-coded notario dependency

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -446,6 +446,7 @@ class CephAnsible(Task):
             'pip',
             'install',
             run.Raw('setuptools>=11.3'),
+            run.Raw('notario>=0.0.13'), # FIXME: use requirements.txt
             run.Raw(ansible_ver),
             run.Raw(';'),
             run.Raw(str_args)


### PR DESCRIPTION
ceph-ansible has some new dependencies in requirements.txt which need to be installed to avoid the error:
`[ERROR]: The python-notario library is missing. Please install it to continue.`

Fixes: http://tracker.ceph.com/issues/24230