### PR TITLE
[DNM]: Add misc cleanup options before we unlock the system

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -22,6 +22,7 @@ import re
 import pprint
 
 from teuthology import safepath
+from teuthology.parallel import parallel
 from teuthology.exceptions import (CommandCrashedError, CommandFailedError,
                                    ConnectionLostError)
 from .orchestra import run
@@ -1275,6 +1276,17 @@ def get_distro(ctx):
 
     # if os_type is None, return the default of ubuntu
     return os_type or "ubuntu"
+
+
+def cleanup(ctx):
+    unregister_rhel_systems(ctx)
+
+
+def unregister_rhel_systems(ctx):
+    with parallel():
+        for remote in ctx.cluster.remotes.iterkeys():
+            if remote.os.name == 'rhel':
+                remote.run(args=['sudo', 'subscription-manager', 'unregister'])
 
 
 def get_distro_version(ctx):

--- a/teuthology/task/internal/lock_machines.py
+++ b/teuthology/task/internal/lock_machines.py
@@ -150,6 +150,7 @@ def lock_machines(ctx, config):
     finally:
         # If both unlock_on_failure and nuke-on-error are set, don't unlock now
         # because we're just going to nuke (and unlock) later.
+        misc.cleanup(ctx)
         unlock_on_failure = (
             ctx.config.get('unlock_on_failure', False)
             and not ctx.config.get('nuke-on-error', False)


### PR DESCRIPTION
we are running to subscription issues as we are running out of entitlements(verified by David), unregistering before unlock should keep the count down.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>