### PR TITLE
Fix fetch_binaries_for_coredumps

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -304,7 +304,7 @@ def fetch_binaries_for_coredumps(path, remote):
             dump_path = os.path.join(coredump_path, dump)
             dump_info = subprocess.Popen(['file', dump_path],
                                          stdout=subprocess.PIPE)
-            dump_out = dump_info.communicate()
+            dump_out = dump_info.communicate()[0]
 
             # Parse file output to get program, Example output:
             # 1422917770.7450.core: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, \


### PR DESCRIPTION
Addresses error message:

  AttributeError: 'tuple' object has no attribute 'split'