### PR TITLE
Fix worker can't figure out owner of a job

### DIFF
--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -303,7 +303,7 @@ def run_with_watchdog(process, job_config):
             log.warning("Job ran longer than {max}s. Killing...".format(
                 max=teuth_config.max_job_time))
             kill_job(job_info['name'], job_info['job_id'],
-                     teuth_config.archive_base)
+                     teuth_config.archive_base, job_config['owner'])
 
         # calling this without a status just updates the jobs updated time
         report.try_push_job_info(job_info)


### PR DESCRIPTION
The patch fixes uncaught exception RuntimeError:

  I could not figure out the owner of the requested job.
  Please pass --owner <owner>.

Worker dies with unhandled exception in run_with_watchdog
if it can't figure out owner of a job, which it tries
to kill when job runs longer then given limit of time.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>