### PR TITLE
default ansible to 2.5 as per ceph-ansible requirements

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -25,7 +25,7 @@ class CephAnsible(Task):
     - ceph-ansible:
         repo: {git_base}ceph-ansible.git
         branch: mybranch # defaults to master
-        ansible-version: 2.2 # defaults to 2.2.1
+        ansible-version: 2.4 # defaults to 2.5
         vars:
           ceph_dev: True ( default)
           ceph_conf_overrides:
@@ -408,7 +408,7 @@ class CephAnsible(Task):
         branch = 'master'
         if self.config.get('branch'):
             branch = self.config.get('branch')
-        ansible_ver = 'ansible==2.3.2'
+        ansible_ver = 'ansible==2.5'
         if self.config.get('ansible-version'):
             ansible_ver = 'ansible==' + self.config.get('ansible-version')
         ceph_installer.run(


### PR DESCRIPTION
default ansible to 2.5 as per ceph-ansible requirements for ceph master branch testing.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>