### PR TITLE
Handle branch names containing slashes

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -74,7 +74,7 @@ class Run(object):
                 user, str(timestamp), self.args.suite, self.args.ceph_branch,
                 self.args.kernel_branch or '-', self.args.kernel_flavor, worker
             ]
-        )
+        ).replace('/', ':')
 
     def create_initial_config(self):
         """


### PR DESCRIPTION
A branch name containing a slash is perfectly legal in git, but
teuthology uses branch names verbatim in run names, which causes POSTs
to fail when submitting runs to paddles. Replace all '/' in run names
with ':' to allow for branches with slashes in their names.

Signed-off-by: Adam Wolfe Gordon <awg@digitalocean.com>