### PR TITLE
Add no-validate-refs option to teuthology-suite

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -71,6 +71,9 @@ Standard arguments:
                               <suite_branch> to be ignored for scheduling
                               purposes, but it will still be used for test
                               running.
+  --validate-sha1 <bool>
+                              Validate that git SHA1s passed to -S exist.
+                              [default: true]
 
 Scheduler arguments:
   --owner <owner>             Job owner

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -6,6 +6,7 @@ import logging
 import os
 import random
 import time
+from distutils.util import strtobool
 
 import teuthology
 from ..config import config, YamlConfig
@@ -56,6 +57,8 @@ def process_args(args):
             value = expand_short_repo_name(
                 value,
                 config.get_ceph_qa_suite_git_url())
+        elif key in ('validate_sha1'):
+            value = strtobool(value)
         conf[key] = value
     return conf
 

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -151,7 +151,9 @@ class Run(object):
         repo_name = self.ceph_repo_name
 
         if self.args.ceph_sha1:
-            ceph_hash = util.git_validate_sha1(repo_name, self.args.ceph_sha1)
+            ceph_hash = self.args.ceph_sha1
+            if self.args.validate_sha1:
+                ceph_hash = util.git_validate_sha1(repo_name, ceph_hash)
             if not ceph_hash:
                 exc = CommitNotFoundError(
                     self.args.ceph_sha1,


### PR DESCRIPTION
Allow users to skip validation of SHA1s passed to -S when submitting
jobs via teuthology-suite. This is useful when testing against
non-GitHub repos, since teuthology can't validate refs for a plain git
repository.

Signed-off-by: Adam Wolfe Gordon <awg@digitalocean.com>