### PR TITLE
task/install: str.replace() does not keyword args

### DIFF
--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -76,7 +76,7 @@ def _package_overrides(pkgs, os):
     for pkg in pkgs:
         if is_rhel:
             if pkg.startswith('python3-') or pkg == 'python3':
-                pkg = pkg.replace('3', '34', count=1)
+                pkg = pkg.replace('3', '34', 1)
         result.append(pkg)
     return result
 


### PR DESCRIPTION
In [8]: ?s.replace
Docstring:
S.replace(old, new[, count]) -> str

Signed-off-by: Kefu Chai <kchai@redhat.com>