### PR TITLE
internal/syslog: whitelist ceph-crash daemon messages

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -134,6 +134,8 @@ def syslog(ctx, config):
                     run.Raw('|'),
                     'grep', '-v', 'container-storage-setup: INFO: Volume group backing root filesystem could not be determined',  # noqa
                     run.Raw('|'),
+                    'grep', '-v', 'ceph-crash',
+                    run.Raw('|'),
                     'head', '-n', '1',
                 ],
                 stdout=StringIO(),


### PR DESCRIPTION
None of these should cause test failures.

Signed-off-by: Dan Mick <dan.mick@redhat.com>