### PR TITLE
 worker: do not pass --timeout to first-in-suite job

### DIFF
--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -114,7 +114,7 @@ def get_rerun_conf(conf):
     try:
         subset, seed = reporter.get_rerun_conf(conf.rerun)
     except IOError:
-        return None, None
+        return conf.subset, conf.seed
     if seed is None:
         return conf.subset, conf.seed
     if conf.seed < 0:

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -193,23 +193,26 @@ def run_job(job_config, teuth_bin_path, archive_dir, verbose):
     if job_config.get('first_in_suite') or job_config.get('last_in_suite'):
         if teuth_config.results_server:
             report.try_delete_jobs(job_config['name'], job_config['job_id'])
-        log.info('Generating memo/results for %s', job_config['name'])
         args = [
             os.path.join(teuth_bin_path, 'teuthology-results'),
-            '--timeout',
-            str(job_config.get('results_timeout',
-                               teuth_config.results_timeout)),
             '--archive-dir',
             os.path.join(archive_dir, safe_archive),
             '--name',
             job_config['name'],
         ]
-        if job_config.get('email'):
-            args.extend(['--email', job_config['email']])
-        if job_config.get('seed'):
-            args.extend(['--seed', job_config['seed']])
-        if job_config.get('subset'):
-            args.extend(['--subset', job_config['subset']])
+        if job_config.get('first_in_suite'):
+            log.info('Generating memo for %s', job_config['name'])
+            if job_config.get('seed'):
+                args.extend(['--seed', job_config['seed']])
+            if job_config.get('subset'):
+                args.extend(['--subset', job_config['subset']])
+        else:
+            log.info('Generating results for %s', job_config['name'])
+            timeout = job_config.get('results_timeout',
+                                     teuth_config.results_timeout)
+            args.extend(['--timeout', str(timeout)])
+            if job_config.get('email'):
+                args.extend(['--email', job_config['email']])
         # Execute teuthology-results, passing 'preexec_fn=os.setpgrp' to
         # make sure that it will continue to run if this worker process
         # dies (e.g. because of a restart)


### PR DESCRIPTION
this change fixes the --rerun feature again.