### PR TITLE
openstack: use ssh identity as key_filename by default

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -528,7 +528,13 @@ class TeuthologyOpenStack(OpenStack):
         """
         self.setup_logs()
         set_config_attr(self.args)
-        self.key_filename = self.args.key_filename
+        for keyfile in [self.args.key_filename,
+                        os.environ['HOME'] + '/.ssh/id_rsa',
+                        os.environ['HOME'] + '/.ssh/id_dsa',
+                        os.environ['HOME'] + '/.ssh/id_ecdsa']:
+            if (keyfile and os.path.isfile(keyfile)):
+                self.key_filename = keyfile
+                break
         self.verify_openstack()
         self.setup()
         exit_code = 0


### PR DESCRIPTION
Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>