### PR TITLE
teuthology/task: implement dump_ctx internal task

### DIFF
--- a/teuthology/task/dump_ctx.py
+++ b/teuthology/task/dump_ctx.py
@@ -1,0 +1,19 @@
+import logging
+import pprint
+
+log = logging.getLogger(__name__)
+pp = pprint.PrettyPrinter(indent=4)
+
+def _pprint_me(thing, prefix):
+    return prefix + "\n" + pp.pformat(thing)
+
+def task(ctx, config):
+    """
+    Dump task context and config in teuthology log/output
+
+    The intended use case is didactic - to provide an easy way for newbies, who
+    are working on teuthology tasks for the first time, to find out what
+    is inside the ctx and config variables that are passed to each task.
+    """
+    log.info(_pprint_me(ctx, "Task context:"))
+    log.info(_pprint_me(config, "Task config:"))


### PR DESCRIPTION
This task is supposed to pretty-print the ctx and config parameters that are
passed to each task.

The intended use is didactic: teaching myself and others how to use teuthology. I plan to add this to the existing "dummy" task:

https://github.com/ceph/ceph/tree/master/qa/suites/dummy

Signed-off-by: Nathan Cutler <ncutler@suse.com>