### PR TITLE
teuthology/task/sleep: be explicit about seconds

### DIFF
--- a/teuthology/task/sleep.py
+++ b/teuthology/task/sleep.py
@@ -28,5 +28,5 @@ def task(ctx, config):
         config = {}
     assert isinstance(config, dict)
     duration = int(config.get('duration', 5))
-    log.info('Sleeping for %d', duration)
+    log.info('Sleeping for {} seconds'.format(duration))
     time.sleep(duration)


### PR DESCRIPTION
Add the word "seconds" at the end of the log message, since "time.sleep()"
takes a number which is always interpreted as the number of seconds to sleep
for.

Before this commit, the log said (ambiguously):

    INFO:teuthology.task.sleep:Sleeping for 10

After:

    INFO:teuthology.task.sleep:Sleeping for 10 seconds

Signed-off-by: Nathan Cutler <ncutler@suse.com>