### PR TITLE
teuthology/task/install/valgrind.supp: add suppression for Boost.Thread

### DIFF
--- a/teuthology/task/install/valgrind.supp
+++ b/teuthology/task/install/valgrind.supp
@@ -533,3 +533,14 @@
   fun:rte_log_init
   fun:__libc_csu_init
 }
+
+{
+  Boost.Thread fails to call tls_destructor() when the thread exists
+  Memcheck:Leak
+  match-leak-kinds: reachable
+  ...
+  fun:*boost*detail*make_external_thread_data*
+  fun:*boost*detail*add_new_tss_node*
+  fun:*boost*detail*set_tss_data*
+  ...
+}


### PR DESCRIPTION
Boost.Thread passes `tls_destructor` to `pthread_key_create()` in hope
to free the allocated memory stored in TLS key `current_thread_tls_key`,
but neither Boost.Thread nor us uses `pthread_exit()` for calling the
cleanup functions. and Boost.Thread is against `pthread_exit()`, see [0,1].

but Boost.Thread offers a preprocessor macro to define a global variable
whose destructor calls `tls_destructor()`, but per [2], this macro is
not defined by default. and per [3], this macro could cause assertion
failure in Boost. so it might be advisable to not define it, even we
could do so in BuildBoost.cmake.

and since this `Leak_StillReachable` leak is a one-shot thing. i am
adding it to the suppression file.

---
[0] https://www.boost.org/doc/libs/1_68_0/doc/html/thread/thread_management.html#thread.thread_management.tutorial.native_from._code__phrase_role__identifier__pthread_exit__phrase___code__posix_limitation
[1] https://svn.boost.org/trac10/ticket/5013
[2] https://svn.boost.org/trac10/ticket/3926
[3] https://svn.boost.org/trac10/ticket/12049

Fixes: http://tracker.ceph.com/issues/22052
Signed-off-by: Kefu Chai <kchai@redhat.com>