### PR TITLE
Revert "suite: Implement --sleep-before-teardown option"

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -191,10 +191,5 @@ and analyze results.
         '--ceph-qa-suite-git-url',
         help=("git clone url for ceph-qa-suite"),
     )
-    parser.add_argument(
-        '--sleep-before-teardown',
-        help='Number of seconds to sleep before tearing down the target VMs',
-        default=0
-    )
 
     return parser.parse_args(argv)

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -71,11 +71,6 @@ Standard arguments:
                               <suite_branch> to be ignored for scheduling
                               purposes, but it will still be used for test
                               running.
-  --sleep-before-teardown <seconds>
-                              Number of seconds to sleep before tearing down
-                              the test cluster(s). Use with care, as this
-                              applies to all jobs in the run.
-                              [default: 0]
 
 Scheduler arguments:
   --owner <owner>             Job owner

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -177,7 +177,6 @@ class TeuthologyConfig(YamlConfig):
                 'size': 1,
             },
         },
-        'sleep_before_teardown': 0,
     }
 
     def __init__(self, yaml_path=None):

--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -95,7 +95,6 @@ dict_templ = {
         }
     },
     'repo': Placeholder('ceph_repo'),
-    'sleep_before_teardown': 0,
     'suite': Placeholder('suite'),
     'suite_repo': Placeholder('suite_repo'),
     'suite_relpath': Placeholder('suite_relpath'),

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -273,8 +273,6 @@ class Run(object):
             job_config.email = self.args.email
         if self.args.owner:
             job_config.owner = self.args.owner
-        if self.args.sleep_before_teardown:
-            job_config.sleep_before_teardown = int(self.args.sleep_before_teardown)
         return job_config
 
     def build_base_args(self):


### PR DESCRIPTION
This reverts commit c81ee9618faa6aeb56a4cc741e9f937b287b065e, which
broke the sequential and parallel tasks.

Fixes: https://tracker.ceph.com/issues/36230
Signed-off-by: Nathan Cutler <ncutler@suse.com>