### PR TITLE
tests: use dict() instead Mock() to test config

### DIFF
--- a/teuthology/test/task/test_install.py
+++ b/teuthology/test/task/test_install.py
@@ -78,7 +78,8 @@ class TestInstall(object):
         gb.project = "ceph"
         m_gitbuilder_project.return_value = gb
         m_get_package_version.return_value = "0.89.0"
-        install.verify_package_version(Mock(), Mock(), Mock())
+        config = dict()
+        install.verify_package_version(Mock(), config, Mock())
 
     @patch("teuthology.task.install._get_builder_project")
     @patch("teuthology.task.install.packaging.get_package_version")
@@ -89,9 +90,7 @@ class TestInstall(object):
         gb.project = "ceph"
         m_gitbuilder_project.return_value = gb
         m_get_package_version.return_value = "0.89.1"
-        config = Mock()
-        # when it looks for config.get('extras') it won't find it
-        config.get.return_value = False
+        config = dict()
         with pytest.raises(RuntimeError):
             install.verify_package_version(Mock(), config, Mock())
 
@@ -105,8 +104,8 @@ class TestInstall(object):
         m_gitbuilder_project.return_value = gb
         # ceph isn't installed because ceph-deploy would install it
         m_get_package_version.return_value = None
-        config = Mock()
-        config.extras = True
+        config = dict()
+        config['extras'] = True
         install.verify_package_version(Mock(), config, Mock())
 
     def test_get_flavor_default(self):


### PR DESCRIPTION
Addresses failure in verify_package_version:
    TypeError: argument of type 'Mock' is not iterable

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>