### PR TITLE
Increase log level to 'info' of run config

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -332,7 +332,7 @@ def main(args):
         assert lock, \
             'the --block option is only supported with the --lock option'
 
-    log.debug(
+    log.info(
         '\n  '.join(['Config:', ] + yaml.safe_dump(
             config, default_flow_style=False).splitlines()))
 


### PR DESCRIPTION
Make run config visible in the logs even if -v option is not passed.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>