### PR TITLE
Fix ipv4 and ipv6 address logging for Remote.run

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -7,6 +7,7 @@ from . import run
 from .opsys import OS
 import connection
 from teuthology import misc
+from teuthology.misc import host_shortname
 import time
 import re
 import logging
@@ -45,7 +46,7 @@ class Remote(object):
             # should work on any unix system
             self.user = pwd.getpwuid(os.getuid()).pw_name
             hostname = name
-        self._shortname = shortname or hostname.split('.')[0]
+        self._shortname = shortname or host_shortname(hostname)
         self._host_key = host_key
         self.keep_alive = keep_alive
         self._console = console
@@ -149,7 +150,7 @@ class Remote(object):
     @property
     def shortname(self):
         if self._shortname is None:
-            self._shortname = self.hostname.split('.')[0]
+            self._shortname = host_shortname(self.hostname)
         return self._shortname
 
     @property
@@ -468,10 +469,8 @@ def getShortName(name):
     """
     Extract the name portion from remote name strings.
     """
-    hn = name.split('@')[-1]
-    p = re.compile('([^.]+)\.?.*')
-    return p.match(hn).groups()[0]
-
+    hostname = name.split('@')[-1]
+    return host_shortname(hostname)
 
 def getRemoteConsole(name, ipmiuser=None, ipmipass=None, ipmidomain=None,
                      logfile=None, timeout=20):

--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -75,7 +75,7 @@ class RemoteProcess(object):
         if hostname:
             self.hostname = hostname
         else:
-            (self.hostname, port) = client.get_transport().getpeername()
+            (self.hostname, port) = client.get_transport().getpeername()[0:2]
 
         self.greenlets = []
         self.stdin, self.stdout, self.stderr = (None, None, None)
@@ -407,7 +407,7 @@ def run(
     try:
         transport = client.get_transport()
         if transport:
-            (host, port) = transport.getpeername()
+            (host, port) = transport.getpeername()[0:2]
         else:
             raise ConnectionLostError(command=quote(args), node=name)
     except socket.error:


### PR DESCRIPTION
The Remote class does not respect ip addresses
when it comes to define shortnames. As a result,
the hostname is not shown correctly in the log.
For ipv4 it only shows first number of the octet.
For ipv6 it even does not allow to proceed,
and raises exception in orchestra.run.