### PR TITLE
 skip calling greenlet exception handler

### DIFF
--- a/docs/_static/worker_start.sh
+++ b/docs/_static/worker_start.sh
@@ -24,8 +24,8 @@ function start_all {
 }
  
 function main {
-    echo "$@"
-    if [[ -z "$@" ]]
+    printf '%s\n' "$*"
+    if [[ -z "$*" ]]
     then
         start_all
     elif [ ! -z "$2" ] && [ "$2" -gt "0" ]
@@ -37,4 +37,4 @@ function main {
     fi
 }
  
-main $@
+main "$@"

--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -100,10 +100,12 @@ def patch_gevent_hub_error_handler():
     Hub._origin_handle_error = Hub.handle_error
 
     def custom_handle_error(self, context, type, value, tb):
-        if not issubclass(type, Hub.SYSTEM_ERROR + Hub.NOT_ERROR):
+        if context is None or issubclass(type, Hub.SYSTEM_ERROR):
+            self.handle_system_error(type, value)
+        elif issubclass(type, Hub.NOT_ERROR):
+            pass
+        else:
             log.error("Uncaught exception (Hub)", exc_info=(type, value, tb))
-
-        self._origin_handle_error(context, type, value, tb)
 
     Hub.handle_error = custom_handle_error
 


### PR DESCRIPTION
    We print the error to teuthology log anyway. This avoids inexplicable EIO
    errors printed by the greenlet exception errors.
    
    Fixes: http://tracker.ceph.com/issues/36731
