### PR TITLE
valgind: ignore all leaks relating to CPython code

### DIFF
--- a/teuthology/task/install/valgrind.supp
+++ b/teuthology/task/install/valgrind.supp
@@ -562,3 +562,12 @@
   fun:*boost*detail*set_tss_data*
   ...
 }
+
+{
+  ignore *all* ceph-mgr python crap.  this is overkill, but better than nothing
+  Memcheck:Leak
+  match-leak-kinds: all
+  ...
+  fun:Py*
+  ...
+}


### PR DESCRIPTION
Yes, this is a big hammer, and we are ignoring a lot.  However, it is a
HUGE step forward to what we do now, which is not check for ceph-mgr
leaks at all.

By adding this suppress I found and fixed 3 separate ceph-mgr leaks.  This
will let us prevent others (in non-Py code) from being introduced.

Signed-off-by: Sage Weil <sage@redhat.com>