### PR TITLE
task/install: keep the order of pkgs to be installed

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -201,7 +201,7 @@ def get_package_list(ctx, config):
         rpms = filter(lambda p: not p.endswith('-debuginfo'), rpms)
 
     def exclude(pkgs, exclude_list):
-        return list(set(pkgs).difference(set(exclude_list)))
+        return list(pkg for pkg in pkgs if pkg not in exclude_list)
 
     excluded_packages = config.get('exclude_packages', [])
     if isinstance(excluded_packages, dict):


### PR DESCRIPTION
before this change, the package list to be installed are ordered by
the hash function used by set().

after this change, the order of packages are not changed. so we can
ensure the order of package installation is the identical to that
of package list in yaml.

Signed-off-by: Kefu Chai <kchai@redhat.com>