### PR TITLE
task/install: populate "downgrade_packages" to nested_config

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -621,6 +621,7 @@ def task(ctx, config):
                 sha1=config.get('sha1'),
                 debuginfo=config.get('debuginfo'),
                 flavor=flavor,
+                downgrade_packages=config.get('downgrade_packages', []),
                 extra_packages=config.get('extra_packages', []),
                 extra_system_packages=config.get('extra_system_packages', []),
                 exclude_packages=config.get('exclude_packages', []),

--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -121,6 +121,8 @@ def _downgrade_packages(ctx, remote, pkgs, pkg_version, config):
     downgrade_pkgs = config.get('downgrade_packages', [])
     if not downgrade_pkgs:
         return pkgs
+    log.info('Downgrading packages: {pkglist}'.format(
+        pkglist=', '.join(downgrade_pkgs)))
     # assuming we are going to downgrade packages with the same version
     first_pkg = downgrade_pkgs[0]
     installed_version = packaging.get_package_version(remote, first_pkg)
@@ -128,8 +130,7 @@ def _downgrade_packages(ctx, remote, pkgs, pkg_version, config):
     assert LooseVersion(installed_version) < LooseVersion(pkg_version)
     # to compose package name like "librados2-0.94.10-87.g116a558.el7"
     pkgs_opt = ['-'.join([pkg, pkg_version]) for pkg in downgrade_pkgs]
-    downgrade_cmd = 'sudo yum -y downgrade {}'.format(' '.join(pkgs_opt))
-    remote.run(args=downgrade_cmd.format(pkgs=pkgs_opt))
+    remote.run(args='sudo yum -y downgrade {}'.format(' '.join(pkgs_opt)))
     return [pkg for pkg in pkgs if pkg not in downgrade_pkgs]
 
 


### PR DESCRIPTION
- populate "downgrade_packages" to `nested_config` in `task()`.
  otherwise, the "downgrade_packages" is invisible to the `install()`
  function.
- also print logging message before downgrading packages.
- cleanup rpm._downgrade_packages(), no need to format `downgrade_cmd`.
  it's already formated.

Signed-off-by: Kefu Chai <kchai@redhat.com>