### PR TITLE
teuthology-describe-tests: add --summary command

### DIFF
--- a/scripts/describe_tests.py
+++ b/scripts/describe_tests.py
@@ -37,12 +37,23 @@ optional arguments:
 options only for describing combinations represented by a suite:
   -c, --combinations                 Describe test combinations rather than
                                      individual yaml fragments
-  --filter <keywords>                Only list jobs whose filenames contain at
-                                     least one of the keywords in the comma
-                                     separated keyword string specified.
-  --filter-out <keywords>            Do not list jobs whose filenames contain
+  -s, --summary                      Print summary
+  --filter <keywords>                Only list tests whose description contains
+                                     at least one of the keywords in the comma
+                                     separated keyword string specified
+  --filter-out <keywords>            Do not list tests whose description contains
                                      any of the keywords in the comma separated
-                                     keyword string specified.
+                                     keyword string specified
+  --filter-all <keywords>            Only list tests whose description contains
+                                     each of the keywords in the comma separated
+                                     keyword string specified
+  -F, --filter-fragments             Check fragments additionaly to descriptions
+                                     using keywords specified with 'filter',
+                                     'filter-out' and 'filter-all' options.
+  -D, --print-description            Print job descriptions for the suite,
+                                     used only in combination with 'summary'
+  -L, --print-fragments              Print file list inovolved for each facet,
+                                     used only in combination with 'summary'
   -l <jobs>, --limit <jobs>          List at most this many jobs
                                      [default: 0]
   --subset <index/outof>             Instead of listing the entire
@@ -54,6 +65,11 @@ options only for describing combinations represented by a suite:
                                      2/<outof> ... <outof>-1/<outof>
                                      will list all jobs in the
                                      suite (many more than once).
+  -S <seed>, --seed <seed>           Used for pseudo-random tests generation
+                                     involving facet whose path ends with '$'
+                                     operator, where negative value used for
+                                     a random seed
+                                     [default: -1]
 """
 
 

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -122,6 +122,11 @@ Scheduler arguments:
   --filter-all KEYWORDS       Only run jobs whose description contains each one
                               of the keywords in the comma separated keyword
                               string specified.
+  -F, --filter-fragments <bool>
+                              Check yaml fragments too if job description
+                              does not match the filters provided with
+                              options --filter, --filter-out, and --filter-all.
+                              [default: false]
   --archive-upload RSYNC_DEST Rsync destination to upload archives.
   --archive-upload-url URL    Public facing URL where archives are uploaded.
   --throttle SLEEP            When scheduling, wait SLEEP seconds between jobs.

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -75,7 +75,8 @@ Standard arguments:
                               assembling jobs from yaml fragments. This causes
                               <suite_branch> to be ignored for scheduling
                               purposes, but it will still be used for test
-                              running.
+                              running. The <suite_dir> must have `qa/suite`
+                              sub-directory.
   --validate-sha1 <bool>
                               Validate that git SHA1s passed to -S exist.
                               [default: true]

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -78,7 +78,7 @@ def process_args(args):
             value = expand_short_repo_name(
                 value,
                 config.get_ceph_qa_suite_git_url())
-        elif key in ('validate_sha1'):
+        elif key in ('validate_sha1', 'filter_fragments'):
             value = strtobool(value)
         conf[key] = value
     return conf


### PR DESCRIPTION
Add --summary argument to teuthology-describe-tests for estimating run capacity, printing descriptions, dumping matrix,  yaml fragments.