### PR TITLE
task: reformat the docstring for sphinx

### DIFF
--- a/teuthology/provision/cloud/util.py
+++ b/teuthology/provision/cloud/util.py
@@ -38,7 +38,7 @@ def selective_update(a, b, func):
     pairs in the second dict and merges them into the first dict if func()
     returns a "Truthy" value.
 
-    Example:
+    Example::
 
         >>> a = dict(x=0, y=1, z=3)
         >>> b = dict(x=1, y=2, z=0)

--- a/teuthology/task/background_exec.py
+++ b/teuthology/task/background_exec.py
@@ -25,7 +25,7 @@ def task(ctx, config):
 
     If the command a list, we simply join it with ;'s.
 
-    Example:
+    Example::
 
        tasks:
        - install:

--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -17,12 +17,12 @@ def task(ctx, config):
     This will initially sync the clocks.  Eventually it should let us also
     skew by some number of seconds.
 
-    example:
+    example::
 
-    tasks:
-    - clock:
-    - ceph:
-    - interactive:
+        tasks:
+        - clock:
+        - ceph:
+        - interactive:
 
     to sync.
 

--- a/teuthology/task/full_sequential.py
+++ b/teuthology/task/full_sequential.py
@@ -14,10 +14,10 @@ def task(ctx, config):
     Run a set of tasks to completion in order.  __exit__ is called on a task
     before __enter__ on the next
 
-    example:
-    - full_sequential:
-       - tasktest:
-       - tasktest:
+    example::
+        - full_sequential:
+           - tasktest:
+           - tasktest:
 
     :param ctx: Context
     :param config: Configuration

--- a/teuthology/task/lockfile.py
+++ b/teuthology/task/lockfile.py
@@ -25,17 +25,19 @@ def task(ctx, config):
     Optional entries are the "offset" and "length" of the lock. You can also specify a
     "maxwait" timeout period which fails if the executable takes longer
     to complete, and an "expectfail".
-    An example:
-    tasks:
-    - ceph:
-    - ceph-fuse: [client.0, client.1]
-    - lockfile:
-      [{client:client.0, file:testfile, holdtime:10},
-      {client:client.1, file:testfile, holdtime:0, maxwait:0, expectfail:true},
-      {client:client.1, file:testfile, holdtime:0, maxwait:15, expectfail:false},
-      10,
-      {client: client.1, lockfile: testfile, holdtime: 5},
-      {client: client.2, lockfile: testfile, holdtime: 5, maxwait: 1, expectfail: True}]
+
+    An example::
+
+        tasks:
+        - ceph:
+        - ceph-fuse: [client.0, client.1]
+        - lockfile:
+          [{client:client.0, file:testfile, holdtime:10},
+          {client:client.1, file:testfile, holdtime:0, maxwait:0, expectfail:true},
+          {client:client.1, file:testfile, holdtime:0, maxwait:15, expectfail:false},
+          10,
+          {client: client.1, lockfile: testfile, holdtime: 5},
+          {client: client.2, lockfile: testfile, holdtime: 5, maxwait: 1, expectfail: True}]
 
 
     In the past this test would have failed; there was a bug where waitlocks weren't

--- a/teuthology/task/loop.py
+++ b/teuthology/task/loop.py
@@ -12,12 +12,13 @@ def task(ctx, config):
     """
     Loop a sequential group of tasks
 
-    example:
-    - loop:
-       count: 10
-       body:
-         - tasktest:
-         - tasktest:
+    example::
+
+        - loop:
+           count: 10
+           body:
+             - tasktest:
+             - tasktest:
 
     :param ctx: Context
     :param config: Configuration

--- a/teuthology/task/parallel.py
+++ b/teuthology/task/parallel.py
@@ -14,28 +14,29 @@ def task(ctx, config):
     """
     Run a group of tasks in parallel.
 
-    example:
-    - parallel:
-       - tasktest:
-       - tasktest:
+    example::
+
+        - parallel:
+           - tasktest:
+           - tasktest:
 
     You can also define tasks in a top-level section outside of
     'tasks:', and reference them here.
 
     The referenced section must contain a list of tasks to run
     sequentially, or a single task as a dict. The latter is only
-    available for backwards compatibility with existing suites:
+    available for backwards compatibility with existing suites::
 
-    tasks:
-    - parallel:
-      - tasktest: # task inline
-      - foo       # reference to top-level 'foo' section
-      - bar       # reference to top-level 'bar' section
-    foo:
-    - tasktest1:
-    - tasktest2:
-    bar:
-      tasktest: # note the list syntax from 'foo' is preferred
+        tasks:
+        - parallel:
+          - tasktest: # task inline
+          - foo       # reference to top-level 'foo' section
+          - bar       # reference to top-level 'bar' section
+        foo:
+        - tasktest1:
+        - tasktest2:
+        bar:
+          tasktest: # note the list syntax from 'foo' is preferred
 
     That is, if the entry is not a dict, we will look it up in the top-level
     config.

--- a/teuthology/task/sequential.py
+++ b/teuthology/task/sequential.py
@@ -13,20 +13,21 @@ def task(ctx, config):
     """
     Sequentialize a group of tasks into one executable block
 
-    example:
-    - sequential:
-       - tasktest:
-       - tasktest:
+    example::
 
-    You can also reference the job from elsewhere:
+        - sequential:
+           - tasktest:
+           - tasktest:
 
-    foo:
-      tasktest:
-    tasks:
-    - sequential:
-      - tasktest:
-      - foo
-      - tasktest:
+    You can also reference the job from elsewhere::
+
+        foo:
+          tasktest:
+        tasks:
+        - sequential:
+          - tasktest:
+          - foo
+          - tasktest:
 
     That is, if the entry is not a dict, we will look it up in the top-level
     config.

--- a/teuthology/task/tasktest.py
+++ b/teuthology/task/tasktest.py
@@ -15,16 +15,16 @@ def task(ctx, config):
     destroyed/cleaned up.  This task was used to test parallel and
     sequential task options.
 
-    example:
+    example::
 
-    tasks:
-    - sequential:
+        tasks:
+        - sequential:
+            - tasktest:
+                - id: 'foo'
+            - tasktest:
+                - id: 'bar'
+                - delay:5
         - tasktest:
-            - id: 'foo'
-        - tasktest:
-            - id: 'bar'
-            - delay:5
-    - tasktest:
 
     The above yaml will sequentially start a test task named foo and a test
     task named bar.  Bar will take 5 seconds to complete.  After foo and bar

--- a/teuthology/task/tests/__init__.py
+++ b/teuthology/task/tests/__init__.py
@@ -5,10 +5,10 @@ the current directory.  Each test that is discovered will be passed the
 teuthology ctx and config args that each teuthology task usually gets.
 This allows the tests to operate against the cluster.
 
-An example:
+An example::
 
-tasks
-  - tests:
+    tasks
+      - tests:
 
 """
 import logging

--- a/teuthology/task/timer.py
+++ b/teuthology/task/timer.py
@@ -15,13 +15,13 @@ def task(ctx, config):
     Measure the time that this set of tasks takes and save that value in the summary file.
     Config is a description of what we are timing.
 
-    example:
+    example::
 
-    tasks:
-    - ceph:
-    - foo:
-    - timer: "fsx run"
-    - fsx:
+        tasks:
+        - ceph:
+        - foo:
+        - timer: "fsx run"
+        - fsx:
 
     """
     start = datetime.datetime.now()


### PR DESCRIPTION
the code block should start with `::`, and should be indented.

Signed-off-by: Kefu Chai <kchai@redhat.com>