### PR TITLE
New cli teuthology-reimage-fog to reimage FOG provisioned nodes

### DIFF
--- a/scripts/reimage_fog.py
+++ b/scripts/reimage_fog.py
@@ -1,0 +1,22 @@
+import docopt
+
+from teuthology.misc import reimage_fog
+import sys
+
+doc = """
+usage: teuthology-reimage-fog -h
+       teuthology-reimage-fog --nodes node1,node2 --os-type distro --os-version version
+
+Reimage nodes using FOG without locking the nodes
+
+standard arguments:
+  -h, --help                           Show this help message and exit
+  --nodes node1,node2                  List of nodes to reimage
+  --os-type <os-type>                  Distribution type eg: rhel, ubuntu
+  --os-version <os-version>            OS version eg: 7.6, 16.04 etc
+"""
+
+
+def main(argv=sys.argv[1:]):
+    args = docopt.docopt(doc, argv=argv)
+    reimage_fog(args)

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setup(
             'teuthology-queue = scripts.queue:main',
             'teuthology-prune-logs = scripts.prune_logs:main',
             'teuthology-describe-tests = scripts.describe_tests:main',
+            'teuthology-reimage-fog = scripts.reimage_fog:main'
             ],
         },
 

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -20,6 +20,8 @@ import yaml
 import json
 import re
 import pprint
+import parallel
+
 
 from netaddr.strategy.ipv4 import valid_str as _is_ipv4
 from netaddr.strategy.ipv6 import valid_str as _is_ipv6
@@ -1371,6 +1373,21 @@ def is_in_dict(searchkey, searchval, d):
         return True
     else:
         return searchval == val
+
+
+def reimage_fog(args):
+    """
+    Reimage FOG nodes with options specified
+    """
+    machines = args['--nodes']
+    nodes = machines.rstrip(',').split(',')
+    ctx = argparse.Namespace()
+    ctx.os_type = args['--os-type']
+    ctx.os_version = args['--os-version']
+    from teuthology.provision import reimage
+    with parallel() as p:
+        for node in nodes:
+            p.spawn(reimage, ctx, node)
 
 
 def sh(command, log_limit=1024):

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ commands=py.test --cov=teuthology --cov-report=term -v {posargs:teuthology/test/
 basepython=python2.7
 
 [testenv:flake8]
+ignore=F632
 install_command = pip install --upgrade {opts} {packages}
 deps=
   flake8


### PR DESCRIPTION
add new cli teuthology-reimage-fog to reimage FOG provisioned nodes without actually
locking the nodes.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>