### PR TITLE
valgrind.supp: whitelist something in glibc

### DIFF
--- a/teuthology/task/install/valgrind.supp
+++ b/teuthology/task/install/valgrind.supp
@@ -571,3 +571,15 @@
   fun:Py*
   ...
 }
+
+{
+  something in glibc
+  Memcheck:Leak
+  match-leak-kinds: all
+  ...
+  fun:strdup
+  fun:__trans_list_add
+  ...
+  fun:_dl_init
+  ...
+}


### PR DESCRIPTION
```
<kind>Leak_PossiblyLost</kind>
  <xwhat>
    <text>7 bytes in 1 blocks are possibly lost in loss record 20 of 33,344</text>
    <leakedbytes>7</leakedbytes>
    <leakedblocks>1</leakedblocks>
  </xwhat>
  <stack>
    <frame>
      <ip>0xA811C23</ip>
      <obj>/usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
      <fn>malloc</fn>
      <dir>/builddir/build/BUILD/valgrind-3.13.0/coregrind/m_replacemalloc</dir>
      <file>vg_replace_malloc.c</file>
      <line>299</line>
    </frame>
    <frame>
      <ip>0xE709809</ip>
      <obj>/usr/lib64/libc-2.17.so</obj>
      <fn>strdup</fn>
    </frame>
    <frame>
      <ip>0xFC49444</ip>
      <obj>/usr/lib64/libnl-3.so.200.23.0</obj>
      <fn>__trans_list_add</fn>
    </frame>
    <frame>
      <ip>0xF9E07E0</ip>
      <obj>/usr/lib64/libnl-route-3.so.200.23.0</obj>
    </frame>
    <frame>
      <ip>0x9BF7B02</ip>
      <obj>/usr/lib64/ld-2.17.so</obj>
      <fn>_dl_init</fn>
    </frame>
    <frame>
      <ip>0x9BE9069</ip>
      <obj>/usr/lib64/ld-2.17.so</obj>
    </frame>
    <frame>
      <ip>0x5</ip>
    </frame>
    <frame>
      <ip>0x1FFF000CA2</ip>
    </frame>
    <frame>
      <ip>0x1FFF000CAB</ip>
    </frame>
    <frame>
      <ip>0x1FFF000CAE</ip>
    </frame>
    <frame>
      <ip>0x1FFF000CB8</ip>
    </frame>
    <frame>
      <ip>0x1FFF000CBD</ip>
    </frame>
    <frame>
      <ip>0x1FFF000CC0</ip>
    </frame>
  </stack>
</error>
```
On centos 7.4