### PR TITLE
orchestra: fix retry and socket timeout misconception

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -61,7 +61,7 @@ class Remote(object):
         self.ssh = connection.connect(**args)
         return self.ssh
 
-    def reconnect(self, timeout=None):
+    def reconnect(self, timeout=None, socket_timeout=None, sleep_time=30):
         """
         Attempts to re-establish connection. Returns True for success; False
         for failure.
@@ -69,17 +69,16 @@ class Remote(object):
         if self.ssh is not None:
             self.ssh.close()
         if not timeout:
-            return self._reconnect(timeout=timeout)
+            return self._reconnect(timeout=socket_timeout)
         start_time = time.time()
         elapsed_time = lambda: time.time() - start_time
         while elapsed_time() < timeout:
-            success = self._reconnect()
+            success = self._reconnect(timeout=socket_timeout)
             if success:
                 break
-            default_sleep_val = 30
             # Don't let time_remaining be < 0
             time_remaining = max(0, timeout - elapsed_time())
-            sleep_val = min(time_remaining, default_sleep_val)
+            sleep_val = min(time_remaining, sleep_time)
             time.sleep(sleep_val)
         return success
 


### PR DESCRIPTION
Fix retry and socket timeouts misconception for reconnect.
Add default sleep time as argument to the signature.

Signed-off-by: Kyr <kyrylo.shatskyy@gmail.com>