### PR TITLE
selinux: ignore nagios denial

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -119,6 +119,7 @@ class SELinux(Task):
             'scontext=system_u:system_r:pcp_pmcd_t:s0',
             'comm="rhsmd"',
             'scontext=system_u:system_r:syslogd_t:s0',
+            'tcontext=system_u:system_r:nrpe_t:s0',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
Got this in RHEL 7.6 testing.

Fixes: https://tracker.ceph.com/issues/38519
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>