### PR TITLE
Read test repo from file

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -235,12 +235,8 @@ def get_openstack_parser():
     parser.add_argument(
         '--test-repo',
         action='append',
-        help=('Package repository, or repositories, to be added on test nodes. '
-              'Repository to be specified as a NAME:URL pair. Multiple '
-              'repositories can be provided with multiple usage. '
-              'For example --test-repo foo:http://example.com/repo/foo '
-              '--test-repo bar:http://example.com/repo/bar specifies two '
-              'test package repositories named "foo" and "bar", respectively.'),
+        help=('Package repository to be added on test nodes, which are specified '
+              'as NAME:URL, NAME!PRIORITY:URL or @FILENAME, for details see below.'),
         default=None,
     )
     return parser
@@ -255,6 +251,90 @@ def get_parser():
         ],
         conflict_handler='resolve',
         add_help=False,
+        epilog="""test repos:
+
+Test repository can be specified using --test-repo optional argument
+with value in the following formats:  NAME:URL, NAME!PRIORITY:URL
+or @FILENAME. See examples:
+
+1) Essential usage requires to provide repo name and url:
+
+    --test-repo foo:http://example.com/repo/foo
+
+2) Repo can be prioritized by adding a number after '!' symbol
+   in the name:
+
+    --test-repo 'bar!10:http://example.com/repo/bar'
+
+3) Repo data can be taken from a file by simply adding '@' symbol
+   at the beginning argument value, for example from yaml:
+
+    --test-repo @path/to/foo.yaml
+
+  where `foo.yaml` contains one or more records like:
+
+  - name: foo
+    priority: 1
+    url: http://example.com/repo/foo
+
+4) Or from json file:
+
+    --test-repo @path/to/foo.json
+
+   where `foo.json` content is:
+
+   [{"name":"foo","priority":1,"url":"http://example.com/repo/foo"}]
+
+
+Several repos can be provided with multiple usage of --test-repo and/or
+you can provide several repos within one yaml or json file.
+The repositories are added in the order they appear in the command line or
+in the file. Example:
+
+    ---
+    # The foo0 repo will be included first, after all that have any priority,
+    # in particular after foo1 because it has lowest priority
+    - name: foo0
+      url: http://example.com/repo/foo0
+    # The foo1 will go after foo2 because it has lower priority then foo2
+    - name: foo1
+      url: http://example.com/repo/foo1
+      priority: 2
+    # The foo2 will go first because it has highest priority
+    - name: foo2
+      url: http://example.com/repo/foo2
+      priority: 1
+    # The foo3 will go after foo0 because it appears after it in this file
+    - name: foo3
+      url: http://example.com/repo/foo3
+
+Equivalent json file content below:
+
+    [
+      {
+        "name": "foo0",
+        "url": "http://example.com/repo/foo0"
+      },
+      {
+        "name": "foo1",
+        "url": "http://example.com/repo/foo1",
+        "priority": 2
+      },
+      {
+        "name": "foo2",
+        "url": "http://example.com/repo/foo2",
+        "priority": 1
+      },
+      {
+        "name": "foo3",
+        "url": "http://example.com/repo/foo3"
+      }
+    ]
+
+At the moment supported only files with extensions: .yaml, .yml, .json, .jsn.
+
+teuthology-openstack %s
+""" % teuthology.__version__,
         description="""
 Run a suite of ceph integration tests. A suite is a directory containing
 facets. A facet is a directory containing config snippets. Running a suite

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -638,9 +638,15 @@ class TeuthologyOpenStack(OpenStack):
             else:
                 argv.append(original_argv.pop(0))
         if self.args.test_repo:
-            repos = [{'name':k, 'url': v}
-                                    for k, v in [x.split(':', 1)
-                                    for x in self.args.test_repo]]
+            def repo(name, url):
+                if '!' in name:
+                    n, p = name.split('!', 1)
+                    return {'name': n, 'priority': int(p), 'url': url}
+                else:
+                    return {'name': name, 'url': url}
+            repos = [repo(k, v)
+                     for k, v in [x.split(':', 1)
+                     for x in self.args.test_repo]]
             log.info("Using repos: %s" % self.args.test_repo)
 
             overrides = {

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -692,7 +692,7 @@ class TeuthologyOpenStack(OpenStack):
                     }
                 }
             }
-            yaml_data = yaml.dump(overrides, default_flow_style=False)
+            yaml_data = yaml.safe_dump(overrides, default_flow_style=False)
             with tempfile.NamedTemporaryFile(mode='w+b',
                                              suffix='-artifact.yaml',
                                              delete=False) as f:

--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -83,10 +83,16 @@ def _zypper_addrepo(remote, repo_list):
     :return:
     """
     for repo in repo_list:
-        remote.run(args=[
-            'sudo', 'zypper', '-n', 'addrepo', '--refresh', '--no-gpgcheck',
-            '-p', '1', repo['url'], repo['name'],
-        ])
+        if 'priority' in repo:
+            remote.run(args=[
+                'sudo', 'zypper', '-n', 'addrepo', '--refresh', '--no-gpgcheck',
+                '-p', str(repo['priority']), repo['url'], repo['name'],
+            ])
+        else:
+            remote.run(args=[
+                'sudo', 'zypper', '-n', 'addrepo', '--refresh', '--no-gpgcheck',
+                repo['url'], repo['name'],
+            ])
 
 def _zypper_removerepo(remote, repo_list):
     """


### PR DESCRIPTION
Make it possible to read repositories from a file by simply adding '@' symbol
at the beginning `--test-repo` argument value, for example from yaml:
```
    ---
    # The foo0 repo will be included first, after all that have any priority,
    # in particular after foo1 because it has lowest priority
    - name: foo0
      url: http://example.com/repo/foo0
    # The foo1 will go after foo2 because it has lower priority then foo2
    - name: foo1
      url: http://example.com/repo/foo1
      priority: 2
    # The foo2 will go first because it has highest priority
    - name: foo2
      url: http://example.com/repo/foo2
      priority: 1
    # The foo3 will go after foo0 because it appears after it in this file
    - name: foo3
      url: http://example.com/repo/foo3
```
Equivalent json file content below:
```
    [
      {
        "name": "foo0",
        "url": "http://example.com/repo/foo0"
      },
      {
        "name": "foo1",
        "url": "http://example.com/repo/foo1",
        "priority": 2
      },
      {
        "name": "foo2",
        "url": "http://example.com/repo/foo2",
        "priority": 1
      },
      {
        "name": "foo3",
        "url": "http://example.com/repo/foo3"
      }
    ]
```