### PR TITLE
teuthology-suite: no default value for suite branch

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -68,7 +68,6 @@ Standard arguments:
                               [default: qa]
   --suite-branch <suite_branch>
                               Use this suite branch instead of the ceph branch
-                              [default: {default_suite_branch}]
   --suite-dir <suite_dir>     Use this alternative directory as-is when
                               assembling jobs from yaml fragments. This causes
                               <suite_branch> to be ignored for scheduling
@@ -144,7 +143,6 @@ Scheduler arguments:
     default_suite_repo=defaults('--suite-repo',
                             config.get_ceph_qa_suite_git_url()),
     default_ceph_branch=defaults('--ceph-branch', 'master'),
-    default_suite_branch=defaults('--suite-branch', 'master'),
     default_teuthology_branch=defaults('--teuthology-branch', 'master'),
 )
 

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -54,6 +54,8 @@ def process_args(args):
         key = key.lstrip('--').replace('-', '_')
         # Rename the key if necessary
         key = rename_args.get(key) or key
+        if key == 'suite_branch':
+            value = value or override_arg_defaults('--suite-branch', None)
         if key == 'suite' and value is not None:
             value = normalize_suite_name(value)
         if key == 'suite_relpath' and value is None:


### PR DESCRIPTION
By default suite branch must be equal to ceph one.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>