### PR TITLE
task/install: normalize python3 packages to python36 ones

### DIFF
--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -59,8 +59,14 @@ def _remove(ctx, config, remote, rpm):
 
 def _package_overrides(pkgs, os):
     """
-    Replaces some package names with their distro-specific equivalents
-    (currently "python3-*" -> "python34-*" for CentOS)
+    Replaces some package names with their distro-specific equivalents.
+
+    CentOS/RHEL-7 is not fully migrated to python3 at the time of writing,
+    we are using EPEL7 for building python3 packages. and we use the rpm
+    macro of "python3_pkgversion" as the python3 version for which we build
+    python bindings. see https://src.fedoraproject.org/cgit/rpms/python-rpm-macros.git/commit/macros.python-srpm?h=epel7 for its latest definition.
+
+    (currently "python3-*" -> "python36-*" for CentOS)
 
     :param pkgs: list of RPM package names
     :param os: the teuthology.orchestra.opsys.OS object
@@ -70,7 +76,7 @@ def _package_overrides(pkgs, os):
     for pkg in pkgs:
         if is_rhel:
             if pkg.startswith('python3-') or pkg == 'python3':
-                pkg = pkg.replace('3', '34', 1)
+                pkg = pkg.replace('python3', 'python36', 1)
         result.append(pkg)
     return result
 


### PR DESCRIPTION
EPEL7 has switched over to python3.6 as the main python3. and we started
packaging python bindings for python3.6 since
https://github.com/ceph/ceph-build/pull/1283

Signed-off-by: Kefu Chai <kchai@redhat.com>