### PR TITLE
[DNM] Revert kernel default

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -45,7 +45,6 @@ Standard arguments:
   -k <kernel>, --kernel <kernel>
                               The kernel branch to run against; if not
                               supplied, the installed kernel is unchanged
-                              [default: distro]
   -f <flavor>, --flavor <flavor>
                               The kernel flavor to run against: ('basic',
                               'gcov', 'notcmalloc')

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -43,7 +43,8 @@ Standard arguments:
                               either --ceph or --sha1, backtracking
                               up to <newest> commits [default: 0]
   -k <kernel>, --kernel <kernel>
-                              The kernel branch to run against
+                              The kernel branch to run against; if not
+                              supplied, the installed kernel is unchanged
                               [default: distro]
   -f <flavor>, --flavor <flavor>
                               The kernel flavor to run against: ('basic',


### PR DESCRIPTION
This is reverting 'add default' for kernel argument, which makes it is impossible to disable kernel task.

By default we do not want any kernel operations and since there no-functionality provided for disabling kernel task, it is better to revert this changes.