### PR TITLE
selinux: ignore updatedb failures

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -120,6 +120,7 @@ class SELinux(Task):
             'comm="rhsmd"',
             'scontext=system_u:system_r:syslogd_t:s0',
             'tcontext=system_u:system_r:nrpe_t:s0',
+            'comm="updatedb"',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
This is with RHEL 7.6.

The failure [1]:

    2019-04-17T21:06:33.388 DEBUG:teuthology.run_tasks:Exception was not quenched, exiting: SELinuxError: SELinux denials found on ubuntu@smithi088.front.sepia.ceph.com: ['type=AVC msg=audit(1555531592.378:4451): avc:  denied  { rename } for  pid=10476 comm="updatedb" name="mlocate.db.eDrUCz" dev="sda1" ino=5477 scontext=system_u:system_r:locate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1', 'type=AVC msg=audit(1555531589.705:4446): avc:  denied  { read write open } for  pid=10476 comm="updatedb" path="/var/lib/mlocate/mlocate.db.eDrUCz" dev="sda1" ino=5477 scontext=system_u:system_r:locate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1', 'type=AVC msg=audit(1555531589.705:4446): avc:  denied  { create } for  pid=10476 comm="updatedb" name="mlocate.db.eDrUCz" scontext=system_u:system_r:locate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1', 'type=AVC msg=audit(1555531589.705:4446): avc:  denied  { add_name } for  pid=10476 comm="updatedb" name="mlocate.db.eDrUCz" scontext=system_u:system_r:locate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1', 'type=AVC msg=audit(1555531591.622:4447): avc:  denied  { write } for  pid=10476 comm="updatedb" path="/var/lib/mlocate/mlocate.db.eDrUCz" dev="sda1" ino=5477 scontext=system_u:system_r:locate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1', 'type=AVC msg=audit(1555531592.377:4450): avc:  denied  { setattr } for  pid=10476 comm="updatedb" name="mlocate.db.eDrUCz" dev="sda1" ino=5477 scontext=system_u:system_r:locate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unlabeled_t:s0 tclass=file permissive=1', 'type=AVC msg=audit(1555531589.705:4446): avc:  denied  { write } for  pid=10476 comm="updatedb" name="mlocate" dev="sda1" ino=76978 scontext=system_u:system_r:locate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:unlabeled_t:s0 tclass=dir permissive=1']

[1] /ceph/teuthology-archive/pdonnell-2019-04-17_06:02:40-fs-wip-pdonnell-testing-20190417.032809-distro-basic-smithi/3856822/teuthology.log

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>