### PR TITLE
rgw/pubsub: add dependencies needed for pubsub tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,9 @@ setup(
                       'apache-libcloud',
                       # For apache-libcloud when using python < 2.7.9
                       'backports.ssl_match_hostname',
+                      # For bucket notification testing in multisite
+                      'xmltodict',
+                      'boto3',
                       ],
 
 


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>

This is needed for adding the tests in this PR: https://github.com/ceph/ceph/pull/27838
