### PR TITLE
tox: set mock version to 2.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ passenv = HOME
 sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt
-  mock
+  mock==2.0.0
   fudge
   pytest-cov==1.6
   coverage==3.7.1
@@ -21,7 +21,7 @@ passenv = HOME OS_REGION_NAME OS_AUTH_URL OS_TENANT_ID OS_TENANT_NAME OS_PASSWOR
 sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt
-  mock
+  mock==2.0.0
   fudge
   pytest-cov==1.6
   coverage==3.7.1
@@ -42,7 +42,7 @@ changedir=docs
 deps=
   -r{toxinidir}/requirements.txt
   sphinx
-  mock
+  mock==2.0.0
 commands=
     sphinx-apidoc -f -o . ../teuthology ../teuthology/test ../teuthology/orchestra/test ../teuthology/task/test
     sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
@@ -53,7 +53,7 @@ passenv = HOME OS_REGION_NAME OS_AUTH_URL OS_TENANT_ID OS_TENANT_NAME OS_PASSWOR
 sitepackages=True
 deps=
   -r{toxinidir}/requirements.txt
-  mock
+  mock==2.0.0
 
 commands=py.test -v {posargs:teuthology/openstack/test/test_openstack.py}
 basepython=python2.7
@@ -63,7 +63,7 @@ passenv = HOME OS_REGION_NAME OS_AUTH_URL OS_TENANT_ID OS_TENANT_NAME OS_PASSWOR
 basepython=python2
 deps=
     -r{toxinidir}/requirements.txt
-    mock
+    mock==2.0.0
 
 commands=
     py.test -v {posargs} teuthology/openstack/test/openstack-integration.py


### PR DESCRIPTION
After upgrade mock from 2.0.0 to 3.0.3 the TestExiter started failing
with incorrect call_count.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>