### PR TITLE
orchestra/run: add omit_sudo arg used by vstart_runner

### DIFF
--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -377,6 +377,8 @@ def run(
     label=None,
     timeout=None,
     cwd=None,
+    # omit_sudo is used by vstart_runner.py
+    omit_sudo=False
 ):
     """
     Run a command remotely.  If any of 'args' contains shell metacharacters


### PR DESCRIPTION
Introduced-by: ceph/ceph.git:3e0a1361f78452d79c283f70b5dc2b865d62cb61
Fixes: https://tracker.ceph.com/issues/39554
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>