### PR TITLE
config: add parameter for config load

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -29,7 +29,13 @@ class YamlConfig(collections.MutableMapping):
         else:
             self._conf = dict()
 
-    def load(self):
+    def load(self, conf=None):
+        if conf:
+            if isinstance(conf, dict):
+                self._conf = conf
+            else:
+                self._conf = yaml.safe_load(conf)
+            return
         if os.path.exists(self.yaml_path):
             self._conf = yaml.safe_load(file(self.yaml_path))
         else:

--- a/teuthology/provision/cloud/test/test_openstack.py
+++ b/teuthology/provision/cloud/test/test_openstack.py
@@ -66,9 +66,8 @@ def get_fake_obj(mock_args=None, attributes=None):
 
 
 class TestOpenStackBase(object):
-    def setup(self):
-        config.load()
-        config.libcloud = deepcopy(test_config)
+    def setup(self, conf=dict(), test_config=test_config):
+        config.load(conf or dict(libcloud=deepcopy(test_config)))
         self.start_patchers()
 
     def start_patchers(self):


### PR DESCRIPTION
This patch makes it possible to load config file directly
from the given path or data object, for testing purposes
and allows to remove silly notification about missing
teuthology.yaml file.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>