### PR TITLE
orchestra/daemon: Fix proc AttributeError: 'NoneType'

### DIFF
--- a/teuthology/orchestra/daemon/state.py
+++ b/teuthology/orchestra/daemon/state.py
@@ -98,13 +98,16 @@ class DaemonState(object):
 
     def signal(self, sig, silent=False):
         """
-        Send a signal to associated remote commnad
+        Send a signal to associated remote command.
 
         :param sig: signal to send
         """
-        self.proc.stdin.write(struct.pack('!b', sig))
-        if not silent:
-            self.log.info('Sent signal %d', sig)
+        if self.running():
+            self.proc.stdin.write(struct.pack('!b', sig))
+            if not silent:
+                self.log.info('Sent signal %d', sig)
+        else:
+            self.log.info('No such daemon running')
 
     def start(self, timeout=300):
         """


### PR DESCRIPTION
Fixes the chance of calling signal() on a  daemon which is not running. 
Found `AttributeError: 'NoneType' object has no attribute 'stdin'` in: http://qa-proxy.ceph.com/teuthology/jcollin-2019-06-27_15:38:48-fs-wip-daemonwatchdog-testing11-distro-basic-smithi/4071690/teuthology.log

Signed-off-by: Jos Collin <jcollin@redhat.com>