### PR TITLE
teuthology/orchestra/daemon: Check if stdin is valid

### DIFF
--- a/teuthology/orchestra/daemon/state.py
+++ b/teuthology/orchestra/daemon/state.py
@@ -110,7 +110,7 @@ class DaemonState(object):
             if not silent:
                 self.log.info('Sent signal %d', sig)
         else:
-            self.log.info('No such daemon running')
+            self.log.error('No such daemon running')
 
     def start(self, timeout=300):
         """

--- a/teuthology/orchestra/daemon/state.py
+++ b/teuthology/orchestra/daemon/state.py
@@ -103,7 +103,10 @@ class DaemonState(object):
         :param sig: signal to send
         """
         if self.running():
-            self.proc.stdin.write(struct.pack('!b', sig))
+            try:
+                self.proc.stdin.write(struct.pack('!b', sig))
+            except IOError as e:
+                log.exception('Failed to send signal %d: %s', sig, e.strerror)
             if not silent:
                 self.log.info('Sent signal %d', sig)
         else:


### PR DESCRIPTION
As there is [self.proc.stdin.close() in stop()](https://github.com/ceph/teuthology/blob/master/teuthology/orchestra/daemon/state.py#L135), there are chances
of write failing with IOError("File is closed").

Referring to the test result: http://qa-proxy.ceph.com/teuthology/jcollin-2019-07-02_09:10:36-fs-wip-daemonwatchdog-testing11-distro-basic-smithi/4087426/teuthology.log

This happened is because DaemonWatchdog sent SIGTERM signals in parallel to executing `stop_daemons_of_type()`. But however it's better to have a check here.