### PR TITLE
suite/run: add support 'none' for kernel branch parameter

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -43,7 +43,8 @@ Standard arguments:
                               either --ceph or --sha1, backtracking
                               up to <newest> commits [default: 0]
   -k <kernel>, --kernel <kernel>
-                              The kernel branch to run against
+                              The kernel branch to run against,
+                              use 'none' to bypass kernel task.
                               [default: distro]
   -f <flavor>, --flavor <flavor>
                               The kernel flavor to run against: ('basic',

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -119,8 +119,9 @@ class Run(object):
         # Put together a stanza specifying the kernel hash
         if self.args.kernel_branch == 'distro':
             kernel_hash = 'distro'
-        # Skip the stanza if no -k given
-        elif self.args.kernel_branch is None:
+        # Skip the stanza if '-k none' is given
+        elif self.args.kernel_branch is None or \
+             self.args.kernel_branch.lower() == 'none':
             kernel_hash = None
         else:
             kernel_hash = util.get_gitbuilder_hash(


### PR DESCRIPTION
This is can be useful when one wants to disable kernel hash

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>