### PR TITLE
install: drop purge_data and related code

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -8,7 +8,6 @@ import yaml
 from teuthology import misc as teuthology
 from teuthology import contextutil, packaging
 from teuthology.parallel import parallel
-from teuthology.orchestra import run
 from teuthology.task import ansible
 
 from distutils.version import LooseVersion
@@ -63,47 +62,6 @@ def verify_package_version(ctx, config, remote):
             )
         )
 
-
-def purge_data(ctx):
-    """
-    Purge /var/lib/ceph on every remote in ctx.
-
-    :param ctx: the argparse.Namespace object
-    """
-    with parallel() as p:
-        for remote in ctx.cluster.remotes.iterkeys():
-            p.spawn(_purge_data, remote)
-
-
-def _purge_data(remote):
-    """
-    Purge /var/lib/ceph on remote.
-
-    :param remote: the teuthology.orchestra.remote.Remote object
-    """
-    log.info('Purging /var/lib/ceph on %s', remote)
-    remote.run(args=[
-        'sudo',
-        'rm', '-rf', '--one-file-system', '--', '/var/lib/ceph',
-        run.Raw('||'),
-        'true',
-        run.Raw(';'),
-        'test', '-d', '/var/lib/ceph',
-        run.Raw('&&'),
-        'sudo',
-        'find', '/var/lib/ceph',
-        '-mindepth', '1',
-        '-maxdepth', '2',
-        '-type', 'd',
-        '-exec', 'umount', '{}', ';',
-        run.Raw(';'),
-        'sudo', 'umount', '/var/lib/ceph',
-        run.Raw('||'),
-        'true',
-        run.Raw(';'),
-        'sudo',
-        'rm', '-rf', '--one-file-system', '--', '/var/lib/ceph',
-    ])
 
 def install_packages(ctx, pkgs, config):
     """
@@ -259,8 +217,6 @@ def install(ctx, config):
     finally:
         remove_packages(ctx, config, package_list)
         remove_sources(ctx, config)
-        if config.get('project', 'ceph') == 'ceph':
-            purge_data(ctx)
 
 
 def upgrade_old_style(ctx, node, remote, pkgs, system_type):

--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -348,26 +348,13 @@ def _yum_unset_check_obsoletes(remote):
 
 def _remove_sources_list(ctx, config, remote):
     """
-    Removes /etc/yum.repos.d/{proj}.repo, /var/lib/{proj}, and /var/log/{proj}
+    Removes /etc/yum.repos.d/{proj}.repo
 
     :param remote: the teuthology.orchestra.remote.Remote object
     :param proj: the project whose .repo needs removing
     """
     builder = _get_builder_project(ctx, remote, config)
     builder.remove_repo()
-    proj = builder.project
-    # FIXME
-    # There probably should be a way of removing these files that is
-    # implemented in the yum/rpm remove procedures for the ceph package.
-    # FIXME but why is this function doing these things?
-    remote.run(
-        args=['sudo', 'rm', '-r', '/var/lib/{proj}'.format(proj=proj)],
-        check_status=False,
-    )
-    remote.run(
-        args=['sudo', 'rm', '-r', '/var/log/{proj}'.format(proj=proj)],
-        check_status=False,
-    )
     if remote.os.name not in ['opensuse', 'sle']:
         _yum_unset_check_obsoletes(remote)
 


### PR DESCRIPTION
purge_data was used to remove any Ceph daemon metadata remaining after the 
teardown phase of the install task runs. In particular, the ceph task was 
known to leave OSD metadata behind in the OSD directories under /var/lib/ceph.

While the install task causes the ceph-osd package to be installed and creates
directories under /var/lib/ceph, it is the ceph task that actually
populates these directories. Thus, their "unpopulation" should be
implemented in the ceph task, and not here in the install task.

(If the directories were empty after the ceph task teardown phase, they would be
removed when the install task removes the ceph-osd package from the system. But 
the package management tool refuses to remove them when they contain files not 
owned by a package.)

Not running purge_data during the teardown phase of the install task makes it
easier to implement alternative deployment tasks (i.e. tests that deploy Ceph
clusters, but do not call ceph.py).

In the final analysis, however, this code is no longer needed now that all test
nodes (virtual and bare metal) are reimaged between runs.

This commit does not move purge_data into the ceph task because the author felt
that the ceph task should take more care to clean up after itself. For example,
nowadays there are ceph CLI commands for removing OSDs.

Aside: this commit also drops two lines of dead code that flake8 was 
complaining about.

Signed-off-by: Nathan Cutler <ncutler@suse.com>