### PR TITLE
selinux: ignore smartd

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -121,6 +121,7 @@ class SELinux(Task):
             'scontext=system_u:system_r:syslogd_t:s0',
             'tcontext=system_u:system_r:nrpe_t:s0',
             'comm="updatedb"',
+            'comm="smartd"',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
The failures [1]:

    2019-08-22T22:11:34.747 INFO:teuthology.orchestra.run.smithi195:> sudo grep 'avc: .*denied' /var/log/audit/audit.log | grep -v '\(comm="dmidecode"\|chronyd.service\|name="cephtest"\|scontext=system_u:system_r:nrpe_t:s0\|scontext=system_u:system_r:pcp_pmlogger_t\|scontext=system_u:system_r:pcp_pmcd_t:s0\|comm="rhsmd"\|scontext=system_u:system_r:syslogd_t:s0\|tcontext=system_u:system_r:nrpe_t:s0\|comm="updatedb"\)'
    2019-08-22T22:11:34.810 INFO:teuthology.orchestra.run.smithi195.stdout:type=AVC msg=audit(1566509255.666:7592): avc:  denied  { read } for  pid=8598 comm="smartd" name="nvme0" dev="devtmpfs" ino=13028 scontext=system_u:system_r:fsdaemon_t:s0 tcontext=system_u:object_r:nvme_device_t:s0 tclass=chr_file permissive=1
    2019-08-22T22:11:34.810 INFO:teuthology.orchestra.run.smithi195.stdout:type=AVC msg=audit(1566509255.666:7592): avc:  denied  { open } for  pid=8598 comm="smartd" path="/dev/nvme0" dev="devtmpfs" ino=13028 scontext=system_u:system_r:fsdaemon_t:s0 tcontext=system_u:object_r:nvme_device_t:s0 tclass=chr_file permissive=1
    2019-08-22T22:11:34.810 INFO:teuthology.orchestra.run.smithi195.stdout:type=AVC msg=audit(1566509255.666:7593): avc:  denied  { ioctl } for  pid=8598 comm="smartd" path="/dev/nvme0" dev="devtmpfs" ino=13028 ioctlcmd=4e41 scontext=system_u:system_r:fsdaemon_t:s0 tcontext=system_u:object_r:nvme_device_t:s0 tclass=chr_file permissive=1
    2019-08-22T22:11:34.810 INFO:teuthology.orchestra.run.smithi195.stdout:type=AVC msg=audit(1566511059.828:8008): avc:  denied  { read } for  pid=8598 comm="smartd" name="nvme0" dev="devtmpfs" ino=13028 scontext=system_u:system_r:fsdaemon_t:s0 tcontext=system_u:object_r:nvme_device_t:s0 tclass=chr_file permissive=1
    2019-08-22T22:11:34.810 INFO:teuthology.orchestra.run.smithi195.stdout:type=AVC msg=audit(1566511059.828:8008): avc:  denied  { open } for  pid=8598 comm="smartd" path="/dev/nvme0" dev="devtmpfs" ino=13028 scontext=system_u:system_r:fsdaemon_t:s0 tcontext=system_u:object_r:nvme_device_t:s0 tclass=chr_file permissive=1
    2019-08-22T22:11:34.811 INFO:teuthology.orchestra.run.smithi195.stdout:type=AVC msg=audit(1566511059.828:8009): avc:  denied  { ioctl } for  pid=8598 comm="smartd" path="/dev/nvme0" dev="devtmpfs" ino=13028 ioctlcmd=4e41 scontext=system_u:system_r:fsdaemon_t:s0 tcontext=system_u:object_r:nvme_device_t:s0 tclass=chr_file permissive=1

[1] /ceph/teuthology-archive/pdonnell-2019-08-22_20:06:33-fs-wip-pdonnell-testing-20190822.163036-distro-basic-smithi/4242071/teuthology.log

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>