### PR TITLE
teuthology/ceph.conf.template: do not warn on TOO_FEW_OSDS

### DIFF
--- a/teuthology/ceph.conf.template
+++ b/teuthology/ceph.conf.template
@@ -25,6 +25,7 @@
 	mon warn on crush straw calc version zero = false
 	mon warn on no sortbitwise = false
 	mon warn on osd down out interval zero = false
+	mon warn on too few osds = false
 
         osd pool default erasure code profile = "plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd crush-failure-domain=osd"
 


### PR DESCRIPTION
NOTE: merge after the following two PRs are merged:

- [x] mimic https://github.com/ceph/ceph/pull/30180 (merged)
- [x] luminous https://github.com/ceph/ceph/pull/30298 (merged)

---

This is a manual backport of ceph/ceph.git SHA1 0483c1c3e7ffdfa6a6f65c5ef000c45d2f096428
that is needed for mimic.

RATIONALE: The mimic release uses this file in teuthology,
whereas as of nautilus 1ab352dd3105d320bd7ad2c0b37e5de750879dd5 the file
qa/tasks/ceph.conf.template is being used.

See also @neha-ojha 's comment https://github.com/ceph/ceph/pull/30180#issuecomment-528607730