### PR TITLE
Minor bugfixes for teuthology

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -127,7 +127,7 @@ if [ -z "$NO_CLOBBER" ] || [ ! -e ./virtualenv ]; then
     if ! which virtualenv > /dev/null; then
         pip install virtualenv
     fi
-    virtualenv --setuptools virtualenv
+    virtualenv --python=python2 --setuptools virtualenv
 fi
 
 # Upgrade pip first

--- a/teuthology/describe_tests.py
+++ b/teuthology/describe_tests.py
@@ -243,6 +243,9 @@ def tree_with_info(cur_dir, fields, include_facet, prefix, rows,
     has_yamls = any([x.endswith('.yaml') for x in files])
     facet = os.path.basename(cur_dir) if has_yamls else ''
     for i, f in enumerate(files):
+        # skip any hidden files
+        if f.startswith('.'):
+            continue
         path = os.path.join(cur_dir, f)
         if i == len(files) - 1:
             file_pad = '└── '


### PR DESCRIPTION
Just a couple of small bugfixes for running teuthology commands on a modern setup. Avoid symlink loops in teuthology-describe-tests and force the usage of python2 in the bootstrap script.