### PR TITLE
openstack: encode instance name with the full IP

### DIFF
--- a/teuthology/describe_tests.py
+++ b/teuthology/describe_tests.py
@@ -198,7 +198,7 @@ def extract_info(file_name, fields):
         return empty_result
 
     with open(file_name, 'r') as f:
-        parsed = yaml.load(f)
+        parsed = yaml.safe_load(f)
 
     if not isinstance(parsed, dict):
         return empty_result

--- a/teuthology/openstack/openstack-centos-6.5-user-data.txt
+++ b/teuthology/openstack/openstack-centos-6.5-user-data.txt
@@ -3,7 +3,7 @@ bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
  - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-eth0
- - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | sed -e 's/.*\.\(.*\)\.\(.*\)/\1 \2/') ) | tee /etc/hostname
+ - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - yum install -y yum-utils && yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/6/x86_64/ && yum install --nogpgcheck -y epel-release && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6 && rm /etc/yum.repos.d/dl.fedoraproject.org*
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config

--- a/teuthology/openstack/openstack-centos-7.0-user-data.txt
+++ b/teuthology/openstack/openstack-centos-7.0-user-data.txt
@@ -3,7 +3,7 @@ bootcmd:
  - echo nameserver {nameserver} | tee /etc/resolv.conf
  - echo search {lab_domain} | tee -a /etc/resolv.conf
  - sed -ie 's/PEERDNS="yes"/PEERDNS="no"/' /etc/sysconfig/network-scripts/ifcfg-eth0
- - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | sed -e 's/.*\.\(.*\)\.\(.*\)/\1 \2/') ) | tee /etc/hostname
+ - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - ( echo ; echo "MaxSessions 1000" ) >> /etc/ssh/sshd_config
 # See https://github.com/ceph/ceph-cm-ansible/blob/master/roles/cobbler/templates/snippets/cephlab_user

--- a/teuthology/openstack/openstack-debian-8.0-user-data.txt
+++ b/teuthology/openstack/openstack-debian-8.0-user-data.txt
@@ -4,7 +4,7 @@ bootcmd:
  - echo 'prepend domain-name-servers {nameserver};' | sudo tee -a /etc/dhcp/dhclient.conf
  - echo 'supersede domain-name "{lab_domain}";' | sudo tee -a /etc/dhcp/dhclient.conf
  - ifdown eth0 ; ifup eth0
- - ( wget -q -O - http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d.{lab_domain}" $(wget -q -O - http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | sed -e 's/.*\.\(.*\)\.\(.*\)/\1 \2/') ) | tee /etc/hostname
+ - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - echo "MaxSessions 1000" >> /etc/ssh/sshd_config
 preserve_hostname: true

--- a/teuthology/openstack/openstack-ubuntu-12.04-user-data.txt
+++ b/teuthology/openstack/openstack-ubuntu-12.04-user-data.txt
@@ -4,7 +4,7 @@ bootcmd:
  - echo 'prepend domain-name-servers {nameserver};' | sudo tee -a /etc/dhcp/dhclient.conf
  - echo 'supersede domain-name "{lab_domain}";' | sudo tee -a /etc/dhcp/dhclient.conf
  - ifdown eth0 ; ifup eth0
- - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | sed -e 's/.*\.\(.*\)\.\(.*\)/\1 \2/') ) | tee /etc/hostname
+ - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - echo "MaxSessions 1000" >> /etc/ssh/sshd_config
 preserve_hostname: true

--- a/teuthology/openstack/openstack-ubuntu-14.04-user-data.txt
+++ b/teuthology/openstack/openstack-ubuntu-14.04-user-data.txt
@@ -4,7 +4,7 @@ bootcmd:
  - echo 'prepend domain-name-servers {nameserver};' | sudo tee -a /etc/dhcp/dhclient.conf
  - echo 'supersede domain-name "{lab_domain}";' | sudo tee -a /etc/dhcp/dhclient.conf
  - ifdown eth0 ; ifup eth0
- - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | sed -e 's/.*\.\(.*\)\.\(.*\)/\1 \2/') ) | tee /etc/hostname
+ - ( curl --silent http://169.254.169.254/2009-04-04/meta-data/hostname | sed -e 's/[\.-].*//' ; eval printf "%03d%03d%03d%03d.{lab_domain}" $(curl --silent http://169.254.169.254/2009-04-04/meta-data/local-ipv4 | tr . ' ' ) ) | tee /etc/hostname
  - hostname $(cat /etc/hostname)
  - echo "MaxSessions 1000" >> /etc/ssh/sshd_config
 preserve_hostname: true

--- a/teuthology/openstack/setup-openstack.sh
+++ b/teuthology/openstack/setup-openstack.sh
@@ -349,7 +349,7 @@ function subnet_names_and_ips() {
     local subnet=$1
     python -c 'import netaddr; print "\n".join([str(i) for i in netaddr.IPNetwork("'$subnet'")])' |
     sed -e 's/\./ /g' | while read a b c d ; do
-        printf "target%03d%03d " $c $d
+        printf "target%03d%03d%03d%03d " $a $b $c $d
         echo $a.$b.$c.$d
     done
 }

--- a/teuthology/provision/openstack.py
+++ b/teuthology/provision/openstack.py
@@ -97,10 +97,10 @@ class ProvisionOpenStack(OpenStack):
     @staticmethod
     def ip2name(prefix, ip):
         """
-        return the instance name suffixed with the /16 part of the IP.
+        return the instance name suffixed with the IP address.
         """
-        digits = map(int, re.findall('.*\.(\d+)\.(\d+)', ip)[0])
-        return prefix + "%03d%03d" % tuple(digits)
+        digits = map(int, re.findall('(\d+)\.(\d+)\.(\d+)\.(\d+)', ip)[0])
+        return prefix + "%03d%03d%03d%03d" % tuple(digits)
 
     def create(self, num, os_type, os_version, arch, resources_hint):
         """

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -252,7 +252,7 @@ class TestScheduleSuite(object):
         )
         frags = (frag1_read_output, frag2_read_output)
         expected_job = dict(
-            yaml=yaml.load('\n'.join(frags)),
+            yaml=yaml.safe_load('\n'.join(frags)),
             sha1='ceph_sha1',
             args=[
                 '--description',

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -77,7 +77,7 @@ class TestRun(object):
         config = {"tasks": [{"kernel": "can't be here"}]}
         with pytest.raises(AssertionError) as excinfo:
             run.validate_tasks(config)
-        assert excinfo.value.message.startswith("kernel installation")
+        assert excinfo.value.args[0].startswith("kernel installation")
 
     def test_validate_task_no_tasks(self):
         result = run.validate_tasks({})
@@ -91,13 +91,13 @@ class TestRun(object):
     def test_validate_tasks_is_list(self):
         with pytest.raises(AssertionError) as excinfo:
             run.validate_tasks({"tasks": {"foo": "bar"}})
-        assert excinfo.value.message.startswith("Expected list")
+        assert excinfo.value.args[0].startswith("Expected list")
 
     def test_get_initial_tasks_invalid(self):
         with pytest.raises(AssertionError) as excinfo:
             run.get_initial_tasks(True, {"targets": "can't be here",
                                          "roles": "roles" }, "machine_type")
-        assert excinfo.value.message.startswith("You cannot")
+        assert excinfo.value.args[0].startswith("You cannot")
 
     def test_get_inital_tasks(self):
         config = {"roles": range(2), "kernel": "the_kernel", "use_existing_cluster": False}


### PR DESCRIPTION
Using only the last two numbers is problematic when mixing multiple
OpenStack clusters.

Signed-off-by: Loic Dachary <ldachary@redhat.com>
Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>

Conflicts:
	teuthology/provision.py