### PR TITLE
worker: Archive job config for further reference

### DIFF
--- a/teuthology/describe_tests.py
+++ b/teuthology/describe_tests.py
@@ -198,7 +198,7 @@ def extract_info(file_name, fields):
         return empty_result
 
     with open(file_name, 'r') as f:
-        parsed = yaml.load(f)
+        parsed = yaml.safe_load(f)
 
     if not isinstance(parsed, dict):
         return empty_result

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -252,7 +252,7 @@ class TestScheduleSuite(object):
         )
         frags = (frag1_read_output, frag2_read_output)
         expected_job = dict(
-            yaml=yaml.load('\n'.join(frags)),
+            yaml=yaml.safe_load('\n'.join(frags)),
             sha1='ceph_sha1',
             args=[
                 '--description',

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -77,7 +77,7 @@ class TestRun(object):
         config = {"tasks": [{"kernel": "can't be here"}]}
         with pytest.raises(AssertionError) as excinfo:
             run.validate_tasks(config)
-        assert excinfo.value.message.startswith("kernel installation")
+        assert excinfo.value.args[0].startswith("kernel installation")
 
     def test_validate_task_no_tasks(self):
         result = run.validate_tasks({})
@@ -91,13 +91,13 @@ class TestRun(object):
     def test_validate_tasks_is_list(self):
         with pytest.raises(AssertionError) as excinfo:
             run.validate_tasks({"tasks": {"foo": "bar"}})
-        assert excinfo.value.message.startswith("Expected list")
+        assert excinfo.value.args[0].startswith("Expected list")
 
     def test_get_initial_tasks_invalid(self):
         with pytest.raises(AssertionError) as excinfo:
             run.get_initial_tasks(True, {"targets": "can't be here",
                                          "roles": "roles" }, "machine_type")
-        assert excinfo.value.message.startswith("You cannot")
+        assert excinfo.value.args[0].startswith("You cannot")
 
     def test_get_inital_tasks(self):
         config = {"roles": range(2), "kernel": "the_kernel", "use_existing_cluster": False}

--- a/teuthology/test/test_worker.py
+++ b/teuthology/test/test_worker.py
@@ -61,7 +61,7 @@ class TestWorker(object):
     @patch("os.environ")
     @patch("os.mkdir")
     @patch("yaml.safe_dump")
-    @patch("tempfile.NamedTemporaryFile")
+    @patch("__builtin__.open")
     def test_run_job_with_watchdog(self, m_tempfile, m_safe_dump, m_mkdir,
                                    m_environ, m_popen, m_t_config,
                                    m_run_watchdog):
@@ -110,7 +110,7 @@ class TestWorker(object):
     @patch("os.environ")
     @patch("os.mkdir")
     @patch("yaml.safe_dump")
-    @patch("tempfile.NamedTemporaryFile")
+    @patch("__builtin__.open")
     def test_run_job_no_watchdog(self, m_tempfile, m_safe_dump, m_mkdir,
                                  m_environ, m_popen, m_t_config, m_symlink_log,
                                  m_sleep):

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -2,7 +2,6 @@ import logging
 import os
 import subprocess
 import sys
-import tempfile
 import time
 import yaml
 
@@ -253,11 +252,10 @@ def run_job(job_config, teuth_bin_path, archive_dir, verbose):
         arg.extend(['--description', job_config['description']])
     arg.append('--')
 
-    with tempfile.NamedTemporaryFile(prefix='teuthology-worker.',
-                                     suffix='.tmp',) as tmp:
-        yaml.safe_dump(data=job_config, stream=tmp)
-        tmp.flush()
-        arg.append(tmp.name)
+    with open(job_config['archive_path'] + '/job-config.yaml', 'w') as job_config_file:
+        yaml.safe_dump(data=job_config, stream=job_config_file)
+        job_config_file.flush()
+        arg.append(job_config_file.name)
         env = os.environ.copy()
         python_path = env.get('PYTHONPATH', '')
         python_path = ':'.join([suite_path, python_path]).strip(':')


### PR DESCRIPTION
When worker runs teuthology it provides job config as temporary file
which will be deleted after job finished.
This patch makes it possible to save the config in the job log archive
directory and is useful when debugging the job and for the reference.

Signed-off-by: Kyr <kyrylo.shatskyy@suse.com>