### PR TITLE
config: add option for ceph cm ansible git url

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -144,6 +144,7 @@ class TeuthologyConfig(YamlConfig):
         'ceph_git_base_url': 'https://github.com/ceph/',
         'ceph_git_url': None,
         'ceph_qa_suite_git_url': None,
+        'ceph_cm_ansible_git_url': None,
         'use_conserver': False,
         'conserver_master': 'conserver.front.sepia.ceph.com',
         'conserver_port': 3109,
@@ -188,6 +189,10 @@ class TeuthologyConfig(YamlConfig):
 
     def __init__(self, yaml_path=None):
         super(TeuthologyConfig, self).__init__(yaml_path or self.yaml_path)
+
+    def get_ceph_cm_ansible_git_url(self):
+        return (self.ceph_cm_ansible_git_url or
+                self.ceph_git_base_url + 'ceph-cm-ansible.git')
 
     def get_ceph_qa_suite_git_url(self):
         return (self.ceph_qa_suite_git_url or

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -43,6 +43,8 @@ def build_git_url(project, project_owner='ceph'):
     """
     if project == 'ceph-qa-suite':
         base = config.get_ceph_qa_suite_git_url()
+    elif project == 'ceph-cm-ansible':
+        base = config.get_ceph_cm_ansible_git_url()
     elif project == 'ceph':
         base = config.get_ceph_git_url()
     else:

--- a/teuthology/suite/test/test_util.py
+++ b/teuthology/suite/test/test_util.py
@@ -123,6 +123,12 @@ class TestUtil(object):
         m_get_ceph_git_url.return_value = url + '.git'
         assert url == util.build_git_url('ceph')
 
+    @patch('teuthology.config.TeuthologyConfig.get_ceph_cm_ansible_git_url')
+    def test_build_git_url_ceph_cm_ansible_custom(self, m_get_ceph_cm_ansible_git_url):
+        url = 'http://foo.com/some'
+        m_get_ceph_cm_ansible_git_url.return_value = url + '.git'
+        assert url == util.build_git_url('ceph-cm-ansible')
+
     @patch('teuthology.config.TeuthologyConfig.get_ceph_git_url')
     def test_git_ls_remote(self, m_get_ceph_git_url, git_repository):
         m_get_ceph_git_url.return_value = git_repository

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -411,8 +411,7 @@ class CephLab(Ansible):
         if 'playbook' not in config:
             config['playbook'] = 'cephlab.yml'
         if 'repo' not in config:
-            config['repo'] = os.path.join(teuth_config.ceph_git_base_url,
-                                          'ceph-cm-ansible.git')
+            config['repo'] = teuth_config.get_ceph_cm_ansible_git_url()
         super(CephLab, self).__init__(ctx, config)
 
     def begin(self):


### PR DESCRIPTION
This is to be able to supply a custom location without changing
the ceph git base url.

Signed-off-by: Roi Dayan <roid@mellanox.com>

Conflicts:
	teuthology/config.py
	teuthology/suite.py
	teuthology/test/test_suite.py