### PR TITLE
misc: get_wwn_id_map: use any device name, not just wwn-*

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -808,7 +808,7 @@ def get_wwn_id_map(remote, devs):
     """
     stdout = None
     try:
-        stdout = remote.sh('ls -l /dev/disk/by-id/wwn-*')
+        stdout = remote.sh('ls -l /dev/disk/by-id/dm-name-*')
     except Exception:
         log.info('Failed to get wwn devices! Using /dev/sd* devices...')
         return dict((d, d) for d in devs)


### PR DESCRIPTION
I'm not sure what changed in the environment, but most of the smithi do not
have wwn-* items for the LVs we use for scratch.  They do have lots of other
names, though, and for our purposes let's just say they're all equally
usable!

This was *just* changed (41a13eca480e38cfeeba7a180b4516b90598c39b), but I
don't see it actually is responsible for this breakage...

In any case, I think this PR will fix things up!