### PR TITLE
install/rpm: wipe all zypper repos before adding repos-under-test

### DIFF
--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -120,6 +120,15 @@ def _zypper_removerepo(remote, repo_list):
             'sudo', 'zypper', '-n', 'removerepo', repo['name'],
         ])
 
+def _zypper_wipe_all_repos(remote):
+    """
+    Completely "wipe" (remove) all zypper repos
+
+    :param remote: remote node where to wipe zypper repos
+    :return:
+    """
+    log.info("Wiping zypper repos (if any)")
+    remote.sh('sudo zypper repos -upEP && sudo rm -f /etc/zypp/repos.d/*')
 
 def _downgrade_packages(ctx, remote, pkgs, pkg_version, config):
     """
@@ -185,6 +194,7 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
     if repos:
         log.debug("Adding repos: %s" % repos)
         if dist_release in ['opensuse', 'sle']:
+            _zypper_wipe_all_repos(remote)
             _zypper_addrepo(remote, repos)
         else:
             raise Exception('Custom repos were specified for %s ' % remote_os +


### PR DESCRIPTION
Our tests should be designed to not rely on any pre-existing repos. If there are
any pre-existing repos, these can potentially skew test results by causing
unexpected packages/package versions to be installed.

Therefore, wipe any pre-existing repos before adding the repos-under-test.

Signed-off-by: Nathan Cutler <ncutler@suse.com>