### PR TITLE
docs: Mention step to setup nodes on OpenStack

### DIFF
--- a/docs/openstack_backend.rst
+++ b/docs/openstack_backend.rst
@@ -31,6 +31,10 @@ Setup
     $ cd teuthology ; ./bootstrap install
     $ source virtualenv/bin/activate
 
+* Setup the teuthology node::
+
+    $ teuthology-openstack --key-filename myself.pem --key-name myself --setup
+
 Get OpenStack credentials and test it
 -------------------------------------
 

--- a/docs/openstack_backend.rst
+++ b/docs/openstack_backend.rst
@@ -62,11 +62,6 @@ Get OpenStack credentials and test it
 Usage
 -----
 
-* Create a passwordless ssh public key::
-
-    $ openstack keypair create myself > myself.pem
-    $ chmod 600 myself.pem
-
 * Run the dummy suite. It does nothing useful but shows all works as
   expected. Note that the first time it is run, it can take a long
   time (from a few minutes to half an hour or so) because it downloads


### PR DESCRIPTION
The --setup step was missing which lead to cryptic error messages when
running the following step (calling the dummy test suite).