### PR TITLE
openstack: Make used private keys explicit

### DIFF
--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -15,7 +15,12 @@ def get_key_parser():
     )
     parser.add_argument(
         '--key-filename',
-        help='path to the ssh private key',
+        help='path to the ssh private key. Default: %(default)s',
+        default=[
+            os.environ['HOME'] + '/.ssh/id_rsa',
+            os.environ['HOME'] + '/.ssh/id_dsa',
+            os.environ['HOME'] + '/.ssh/id_ecdsa'
+        ]
     )
     return parser
 

--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -692,11 +692,10 @@ class TeuthologyOpenStack(OpenStack):
         self.setup_logs()
         set_config_attr(self.args)
         log.debug('Teuthology config: %s' % self.config.openstack)
-        for keyfile in [self.args.key_filename,
-                        os.environ['HOME'] + '/.ssh/id_rsa',
-                        os.environ['HOME'] + '/.ssh/id_dsa',
-                        os.environ['HOME'] + '/.ssh/id_ecdsa']:
-            if (keyfile and os.path.isfile(keyfile)):
+        key_filenames = (lambda x: x if isinstance(x, list) else [x]) \
+            (self.args.key_filename)
+        for keyfile in key_filenames:
+            if os.path.isfile(keyfile):
                 self.key_filename = keyfile
                 break
         if not self.key_filename:
@@ -918,8 +917,8 @@ class TeuthologyOpenStack(OpenStack):
         return self.ssh(command)
 
     def reminders(self):
-        if self.args.key_filename:
-            identity = '-i ' + self.args.key_filename + ' '
+        if self.key_filename:
+            identity = '-i ' + self.key_filename + ' '
         else:
             identity = ''
         if self.args.upload:


### PR DESCRIPTION
Instead of appending possible private keyfile paths internally, make
that the default for the --key-filename command line argument so users
see it when looking at the help.