### PR TITLE
Fix fetch_branch() check for BranchNotFoundError with newer git

### DIFF
--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -199,10 +199,10 @@ def fetch_branch(repo_path, branch, shallow=True):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
     if proc.wait() != 0:
-        not_found_str = "fatal: Couldn't find remote ref %s" % branch
+        not_found_str = "fatal: couldn't find remote ref %s" % branch
         out = proc.stdout.read()
         log.error(out)
-        if not_found_str in out:
+        if not_found_str in out.lower():
             raise BranchNotFoundError(branch)
         else:
             raise GitError("git fetch failed!")


### PR DESCRIPTION
With newer git versions, the string when a branch is not found
is lower case[1].
This fixes the test TestRepoUtils.test_fetch_branch_fake_branch which
was failing due to this problem.

[1] https://github.com/git/git/commit/0b9c3afdbfb629363