### PR TITLE
connection: key_filename can be a list

### DIFF
--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -89,7 +89,10 @@ def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,
             key_filename = opts['identityfile']
 
     if key_filename:
-        connect_args['key_filename'] = os.path.expanduser(key_filename)
+        if not isinstance(key_filename, list):
+            key_filename = [key_filename]
+        key_filename = [os.path.expanduser(f) for f in key_filename]
+        connect_args['key_filename'] = key_filename
 
     log.debug(connect_args)
 


### PR DESCRIPTION
This commit fixes 5ac7c2f and provides support for multiple identityfile,
besides paramiko.SSHClient.connect accepts list as well for key_filename,
pydoc excerpts:

key_filename:
    the filename, or list of filenames, of optional private key(s) to
    try for authentication

Fixes: https://tracker.ceph.com/issues/42543
Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>