### PR TITLE
install/rpm: fix use the 'zypper addrepo' command

### DIFF
--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -104,7 +104,9 @@ def _zypper_wipe_all_repos(remote):
     :return:
     """
     log.info("Wiping zypper repos (if any)")
-    remote.sh('sudo zypper repos -upEP && sudo rm -f /etc/zypp/repos.d/*')
+    remote.sh('sudo zypper repos -upEP && '
+              'sudo rm -f /etc/zypp/repos.d/* || '
+              'true')
 
 def _downgrade_packages(ctx, remote, pkgs, pkg_version, config):
     """


### PR DESCRIPTION
The 74034fe0348b94aedb247910f0d1c88842f4c3ac instroduced a failure:

  Warning: No repositories defined.
  Use the 'zypper addrepo' command to add one or more repositories.

The wipe command returns exit code 6 if there is no repos in the system.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>