### PR TITLE
using put_file method instead of python shutil.copyfileobj so it works for python 2 and python 3 both

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -342,17 +342,7 @@ def download_kernel(ctx, config):
             # local package - src is path
             log.info('Copying kernel package {path} to {role}...'.format(
                 path=src, role=role))
-            f = open(src, 'r')
-            proc = role_remote.run(
-                args=[
-                    'python', '-c',
-                    'import shutil, sys; shutil.copyfileobj(sys.stdin, open(sys.argv[1], "wb"))',
-                    remote_pkg_path(role_remote),
-                    ],
-                wait=False,
-                stdin=f
-                )
-            procs[role_remote.name] = proc
+            role_remote.put_file(src,remote_pkg_path(role_remote))
         else:
             # gitbuilder package - src is sha1
             log.info('Downloading kernel {sha1} on {role}...'.format(


### PR DESCRIPTION
Signed-off-by: Rachana Patel <racpatel@redhat.com>