### PR TITLE
Drop web.py from setup.py install_requires and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,6 @@ markupsafe==1.0           # via jinja2
 monotonic==1.3            # via oslo.utils
 more-itertools==4.3.0     # via pytest
 msgpack-python==0.4.8     # via oslo.serialization
-mysqlclient==1.4.2
 ndg-httpsclient==0.4.2
 netaddr==0.7.19           # via oslo.config, oslo.utils, python-neutronclient
 netifaces==0.10.5         # via oslo.utils
@@ -107,6 +106,8 @@ unicodecsv==0.14.1        # via cliff
 urllib3==1.25.3           # via botocore, requests
 virtualenv==15.1.0        # via tox
 warlock==1.2.0            # via python-glanceclient
-web.py==0.38
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
 xmltodict==0.12.0
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.6.0        # via pip-tools, pytest

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
                       'nose', # for qa/tasks/rgw_multisite_tests.py',
                       'requests != 2.13.0',
                       'raven',
-                      'web.py',
                       'docopt',
                       'psutil >= 2.1.0',
                       'configparser',


### PR DESCRIPTION
It's not used anywhere. requirements.txt got updated with
"pip-compile".