### PR TITLE
suite: add filter-all parameter

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -118,6 +118,9 @@ Scheduler arguments:
   --filter-out KEYWORDS       Do not run jobs whose description contains any of
                               the keywords in the comma separated keyword
                               string specified.
+  --filter-all KEYWORDS       Only run jobs whose description contains each one
+                              of the keywords in the comma separated keyword
+                              string specified.
   --archive-upload RSYNC_DEST Rsync destination to upload archives.
   --archive-upload-url URL    Public facing URL where archives are uploaded.
   --throttle SLEEP            When scheduling, wait SLEEP seconds between jobs.

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -65,7 +65,7 @@ def process_args(args):
         elif key == 'subset' and value is not None:
             # take input string '2/3' and turn into (2, 3)
             value = tuple(map(int, value.split('/')))
-        elif key in ('filter_in', 'filter_out', 'rerun_statuses'):
+        elif key in ('filter_all', 'filter_in', 'filter_out', 'rerun_statuses'):
             if not value:
                 value = []
             else:

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -379,6 +379,10 @@ class Run(object):
                 if any(f in path for path in base_frag_paths):
                     return True
                 return False
+            filter_all = self.args.filter_all
+            if filter_all:
+                if not all(matches(f) for f in filter_all):
+                    continue
             filter_in = self.args.filter_in
             if filter_in:
                 if not any(matches(f) for f in filter_in):


### PR DESCRIPTION
Add --filter-all parameter to suite to make it possible
precise test case selection, since --filter-in and
--filter-out do not allow narrow test case selection
using AND with filter list.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>