### PR TITLE
Added Pelagos provisioning service support

### DIFF
--- a/teuthology/lock/cli.py
+++ b/teuthology/lock/cli.py
@@ -11,6 +11,7 @@ import teuthology.parallel
 import teuthology.provision
 from teuthology import misc
 from teuthology.config import set_config_attr
+from teuthology.config import config
 
 from teuthology.lock import (
     ops,
@@ -148,7 +149,11 @@ def main(ctx):
                 ctx.machine_type, ctx.os_type, ctx.os_version):
             log.error('Invalid os-type or version detected -- lock failed')
             return 1
-        reimage_types = teuthology.provision.fog.get_types()
+        reimage_types = None
+        if config.get('provision_system', 'FOG') == 'pelagos':
+            reimage_types = teuthology.provision.pelagos.get_types()
+        else:
+            reimage_types = teuthology.provision.fog.get_types()
         reimage_machines = list()
         updatekeys_machines = list()
         for machine in machines:

--- a/teuthology/lock/ops.py
+++ b/teuthology/lock/ops.py
@@ -96,7 +96,11 @@ def lock_many(ctx, num, machine_type, user=None, description=None,
         # Only query for os_type/os_version if non-vps and non-libcloud, since
         # in that case we just create them.
         vm_types = ['vps'] + teuthology.provision.cloud.get_types()
-        reimage_types = teuthology.provision.fog.get_types()
+        reimage_types = None
+        if config.get('provision_system', 'FOG') == 'pelagos':
+            reimage_types = teuthology.provision.pelagos.get_types()
+        else:
+            reimage_types = teuthology.provision.fog.get_types()
         if machine_type not in vm_types + reimage_types:
             if os_type:
                 data['os_type'] = os_type

--- a/teuthology/nuke/actions.py
+++ b/teuthology/nuke/actions.py
@@ -250,6 +250,7 @@ def remove_ceph_packages(ctx):
     for remote in ctx.cluster.remotes.keys():
         if remote.os.package_type == 'rpm':
             log.info("Remove any broken repos")
+            dist_release = remote.os.name
             remote.run(
                 args=['sudo', 'rm', run.Raw("/etc/yum.repos.d/*ceph*")],
                 check_status=False
@@ -267,14 +268,26 @@ def remove_ceph_packages(ctx):
                 check_status=False,
             )
             remote.run(
-                args=['sudo', 'rpm', '--rebuilddb', run.Raw('&&'), 'yum',
-                      'clean', 'all']
+                args=['sudo', 'rpm', '--rebuilddb']
             )
-            log.info('Remove any ceph packages')
-            remote.run(
-                args=['sudo', 'yum', 'remove', '-y', run.Raw(pkgs)],
-                check_status=False
-            )
+            if dist_release in ['opensuse', 'sle']:
+                remote.run(
+                    args=['sudo', 'zypper', 'clean']
+                )
+                log.info('Remove any ceph packages')
+                remote.run(
+                    args=['sudo', 'zypper', 'remove', '--non-interactive,', run.Raw(pkgs)],
+                    check_status=False
+                )
+            else:
+                remote.run(
+                    args=['sudo',  'yum', 'clean', 'all']
+                )
+                log.info('Remove any ceph packages')
+                remote.run(
+                    args=['sudo', 'yum', 'remove', '-y', run.Raw(pkgs)],
+                    check_status=False
+                )
         else:
             log.info("Remove any broken repos")
             remote.run(
@@ -340,7 +353,6 @@ def remove_ceph_data(ctx):
             run.Raw('/var/run/ceph*'),
         ],
     )
-    install_task.purge_data(ctx)
 
 
 def remove_testing_tree(ctx):

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -292,7 +292,8 @@ class Remote(object):
         :param file_path: The path to the file
         :param context:   The SELinux context to be used
         """
-        if self.os.package_type != 'rpm':
+        if self.os.package_type != 'rpm' or\
+                self.os.name in ['opensuse', 'sle']:
             return
         if teuthology.lock.query.is_vm(self.shortname):
             return

--- a/teuthology/provision/__init__.py
+++ b/teuthology/provision/__init__.py
@@ -1,13 +1,17 @@
 import logging
 
 import teuthology.lock.query
-from teuthology.misc import decanonicalize_hostname, get_distro, get_distro_version
+from teuthology.misc import canonicalize_hostname, decanonicalize_hostname, get_distro, get_distro_version
+from teuthology.config import config
+
 
 from teuthology.provision import cloud
 from teuthology.provision import downburst
 from teuthology.provision import fog
 from teuthology.provision import openstack
+from teuthology.provision import pelagos
 import os
+
 
 
 log = logging.getLogger(__name__)
@@ -22,8 +26,12 @@ def _logfile(ctx, shortname):
 def reimage(ctx, machine_name):
     os_type = get_distro(ctx)
     os_version = get_distro_version(ctx)
-    fog_obj = fog.FOG(machine_name, os_type, os_version)
-    return fog_obj.create()
+
+    if config.get('provision_system', 'FOG') == 'pelagos':
+        obj = pelagos.Pelagos(machine_name, os_type, os_version)
+    else:
+        obj = fog.FOG(machine_name, os_type, os_version)
+    return obj.create()
 
 
 def create_if_vm(ctx, machine_name, _downburst=None):

--- a/teuthology/provision/pelagos.py
+++ b/teuthology/provision/pelagos.py
@@ -1,0 +1,162 @@
+import json
+import logging
+import requests
+import socket
+import time
+import shutil
+import urllib2
+from urllib2 import urlopen, HTTPError
+import re
+
+import teuthology.orchestra
+from teuthology.config import config
+from teuthology.contextutil import safe_while
+from teuthology.exceptions import MaxWhileTries
+from teuthology import misc
+
+log = logging.getLogger(__name__)
+config_section = 'pelagos'
+
+
+def enabled(warn=False):
+    """
+    Check for required Pelagos settings
+
+    :param warn: Whether or not to log a message containing unset parameters
+    :returns: True if they are present; False if they are not
+    """
+    conf = config.get(config_section, dict())
+    params = ['endpoint', 'machine_types']
+    unset = [param for param in params if not conf.get(param)]
+    if unset and warn:
+        log.warn(
+            "Pelagos is disabled; set the following config options to enable: %s",
+            ' '.join(unset),
+        )
+    return (unset == [])
+
+
+def get_types():
+    """
+    Fetch and parse config.pelagos['machine_types']
+
+    :returns: The list of Pelagos-configured machine types. An empty list if Pelagos is
+              not configured.
+    """
+    if not enabled():
+        return []
+    conf = config.get(config_section, dict())
+    types = conf.get('machine_types', '')
+    if not isinstance(types, list):
+        types = types.split(',')
+    return [type_ for type_ in types if type_]
+
+
+class Pelagos(object):
+
+    def __init__(self, name, os_type, os_version):
+        #for service should be a hostname, not a user@host
+        split_uri = re.search(r'(\w*)@(.+)', name)
+        if split_uri is not None:
+            self.name = split_uri.groups()[1]
+        else:
+            self.name = name
+
+        self.os_type = os_type
+        self.os_version = os_version
+        self.os_name = os_type + "-" + os_version
+        self.log = log.getChild(self.name)
+
+    def create(self):
+        """
+        Initiate deployment via REST requests and wait until completion
+
+        """
+        if not enabled():
+            raise RuntimeError("Pelagos is not configured!")
+        try:
+            response = self.do_request('node/provision',
+                                      data={'os': self.os_name,
+                                            'node': self.name},
+                                      method='POST')
+            location = response.headers.get('Location')
+            self.log.info("Waiting for deploy to finish")
+            self.log.info("Observe location: " + location)
+            time.sleep(2)
+            with safe_while(sleep=15, tries=60) as proceed:
+                while proceed():
+                    if not self.is_task_active(location):
+                        break
+        except Exception as e:
+            # TODO implement cancel task
+            raise e
+        self.log.info("Deploy completed")
+        if self.task_status_response.status_code != 200:
+            raise Exception("Provisioning failed")
+        return self.task_status_response
+
+
+    def cancel_deploy_task(self,  task_id):
+        # TODO implement it
+        return
+
+    def is_task_active(self, task_url):
+        try:
+            status_response = self.do_request('', url=task_url, verify=False)
+        except HTTPError as err:
+            self.log.error("Task fail reason: " + err.reason)
+            if err.status_code == 404:
+                self.log.error(err.reason)
+                self.task_status_response = 'faield'
+                return False
+            else:
+                raise HTTPError(err.code, err.reason)
+        self.log.info("Response code:[" +
+                          str(status_response.status_code) + "]")
+        self.task_status_response = status_response
+        if status_response.status_code == 202:
+            self.log.info("Status response:[" +
+                          status_response.headers['status'] + "]")
+            if status_response.headers['status'] == 'not completed':
+                return True
+        return False
+
+    def destroy(self):
+        """A no-op; we just leave idle nodes as-is"""
+        pass
+
+    def do_request(self, url_suffix, url="" , data=None, method='GET', verify=True):
+        """
+        A convenience method to submit a request to the Pelagos server
+        :param url_suffix: The portion of the URL to append to the endpoint,
+                           e.g.  '/system/info'
+        :param data: Optional JSON data to submit with the request
+        :param method: The HTTP method to use for the request (default: 'GET')
+        :param verify: Whether or not to raise an exception if the request is
+                       unsuccessful (default: True)
+        :returns: A requests.models.Response object
+        """
+        prepared_url = config.pelagos['endpoint'] + url_suffix
+        if url != '':
+            prepared_url = url
+        self.log.info("Connect to :" + prepared_url)
+        if data is not None:
+            self.log.info("Send data  :" + str(data))
+        req = requests.Request(
+            method,
+            prepared_url,
+            data=data
+        )
+        prepared = req.prepare()
+        resp = requests.Session().send(prepared)
+        self.log.error("do_request code %s text %s", resp.status_code, resp.text)
+        if not resp.ok and resp.text:
+            self.log.error("%s: %s", resp.status_code, resp.text)
+        if verify:
+            resp.raise_for_status()
+        return resp
+
+    def destroy(self):
+        """A no-op; we just leave idle nodes as-is"""
+        pass
+

--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -53,6 +53,9 @@ class SELinux(Task):
             if remote.is_vm:
                 msg = "Excluding {host}: VMs are not yet supported"
                 log.info(msg.format(host=remote.shortname))
+            elif remote.os.name in ['opensuse', 'sle']:
+                msg = "Excluding {host}: opensuse, sle are not yet supported"
+                log.info(msg.format(host=remote.shortname))
             elif remote.os.package_type == 'rpm':
                 new_cluster.add(remote, roles)
             else:


### PR DESCRIPTION
Add Pelagos provisioner https://github.com/ryg-/pelagos to Teuthology. 
Testing was done on Suse distro, so also was fixed Suse provisioning 
provision/pelagos.py: added support of  Pelagos provisioning project, interface is compatible with FOG provisioner
provision/__init__.py:  added processing of pelagos section in teuthology configuration and provisioner instantiation 
task/selinux.py, orchestra/remote.py: disable SELinux for opensuse/suse distros
lock/*: added Pelagos instantiation
nuke/actions.py: added support for sle/opensuse distros

Signed-off-by: Roman Grigorev <rgrigorev@suse.de>