### PR TITLE
Fix opensuse provisioning support

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -292,7 +292,8 @@ class Remote(object):
         :param file_path: The path to the file
         :param context:   The SELinux context to be used
         """
-        if self.os.package_type != 'rpm':
+        if self.os.package_type != 'rpm' or \
+                self.os.name in ['opensuse', 'sle']:
             return
         if teuthology.lock.query.is_vm(self.shortname):
             return

--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -53,6 +53,10 @@ class SELinux(Task):
             if remote.is_vm:
                 msg = "Excluding {host}: VMs are not yet supported"
                 log.info(msg.format(host=remote.shortname))
+            elif remote.os.name in ['opensuse', 'sle']:
+                msg = "Excluding {host}: \
+                        SELinux is not supported for '{os}' os_type yet"
+                log.info(msg.format(host=remote.shortname, os=remote.os.name))
             elif remote.os.package_type == 'rpm':
                 new_cluster.add(remote, roles)
             else:


### PR DESCRIPTION
task/selinux.py, orchestra/remote.py: disable SELinux for opensuse/suse distros
nuke/actions.py: added support for sle/opensuse distros

Signed-off-by: Roman Grigorev <rgrigorev@suse.de>