### PR TITLE
worker: Drop dead code handling old releases

### DIFF
--- a/teuthology/test/test_worker.py
+++ b/teuthology/test/test_worker.py
@@ -1,6 +1,5 @@
 import beanstalkc
 import os
-import subprocess
 
 from mock import patch, Mock, MagicMock
 from datetime import datetime, timedelta
@@ -168,7 +167,7 @@ class TestWorker(object):
             "job_id": "1",
             "worker_log": "worker_log",
             "archive_path": "archive/path",
-            "teuthology_branch": "argonaut"
+            "teuthology_branch": "jewel"
         }
         process = Mock()
         process.poll.return_value = "not None"
@@ -177,13 +176,6 @@ class TestWorker(object):
         m_popen.return_value = m_proc
         worker.run_with_watchdog(process, config)
         m_symlink_log.assert_called_with(config["worker_log"], config["archive_path"])
-        expected_cmd = "teuthology-report -v -D -r the_name -j 1"
-        m_popen.assert_called_with(
-            expected_cmd,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT
-        )
 
     @patch("os.path.isdir")
     @patch("teuthology.worker.fetch_teuthology")

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -316,33 +316,15 @@ def run_with_watchdog(process, job_config):
         report.try_push_job_info(job_info)
         time.sleep(teuth_config.watchdog_interval)
 
-    # The job finished. Let's make sure paddles knows.
-    branches_sans_reporting = ('argonaut', 'bobtail', 'cuttlefish', 'dumpling')
-    if job_config.get('teuthology_branch') in branches_sans_reporting:
-        # The job ran with a teuthology branch that may not have the reporting
-        # feature. Let's call teuthology-report (which will be from the master
-        # branch) to report the job manually.
-        cmd = "teuthology-report -v -D -r {run_name} -j {job_id}".format(
-            run_name=job_info['name'],
-            job_id=job_info['job_id'])
-        try:
-            log.info("Executing %s" % cmd)
-            report_proc = subprocess.Popen(cmd, shell=True,
-                                           stdout=subprocess.PIPE,
-                                           stderr=subprocess.STDOUT)
-            while report_proc.poll() is None:
-                for line in report_proc.stdout.readlines():
-                    log.info(line.strip())
-                time.sleep(1)
-            log.info("Reported results via the teuthology-report command")
-        except Exception:
-            log.exception("teuthology-report failed")
-    else:
-        # Let's make sure that paddles knows the job is finished. We don't know
-        # the status, but if it was a pass or fail it will have already been
-        # reported to paddles. In that case paddles ignores the 'dead' status.
-        # If the job was killed, paddles will use the 'dead' status.
-        report.try_push_job_info(job_info, dict(status='dead'))
+    # we no longer support testing theses old branches
+    assert(job_config.get('teuthology_branch') not in ('argonaut', 'bobtail',
+                                                       'cuttlefish', 'dumpling'))
+
+    # Let's make sure that paddles knows the job is finished. We don't know
+    # the status, but if it was a pass or fail it will have already been
+    # reported to paddles. In that case paddles ignores the 'dead' status.
+    # If the job was killed, paddles will use the 'dead' status.
+    report.try_push_job_info(job_info, dict(status='dead'))
 
 
 def symlink_worker_log(worker_log_path, archive_dir):


### PR DESCRIPTION
We no longer need to check for branches like 'argonaut', 'bobtail',
'cuttlefish' or 'dumpling'. These are long gone.
Removing the code simplifies it a bit.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>