### PR TITLE
task/install: fix UnboundLocalError of local variable repos

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -541,6 +541,7 @@ def task(ctx, config):
     project, = config.get('project', 'ceph'),
     log.debug('project %s' % project)
     overrides = ctx.config.get('overrides')
+    repos = None
     if overrides:
         install_overrides = overrides.get('install', {})
         teuthology.deep_merge(config, install_overrides.get(project, {}))


### PR DESCRIPTION
If overrides is None, repos will don't be assignmented.
In this case, will occur error "UnboundLocalError: local variable repos referenced before assignment"

Signed-off-by: dehao.shang@intel.com