### PR TITLE
run_task: fix qa/ directory missing

### DIFF
--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -15,7 +15,7 @@ from teuthology.timer import Timer
 log = logging.getLogger(__name__)
 
 
-def get_task(name):
+def get_task(name, ctx):
     if '.' in name:
         module_name, task_name = name.split('.')
     else:
@@ -25,6 +25,9 @@ def get_task(name):
     module = _import('teuthology.task', module_name, task_name)
     # If it is not found, try qa/ directory (if it is in sys.path)
     if not module:
+        module = _import('tasks', module_name, task_name)
+    if not module:
+        sys.path.append(ctx.config.get("suite_path") + "/qa")
         module = _import('tasks', module_name, task_name, fail_on_import_error=True)
     try:
         # Attempt to locate the task object inside the module
@@ -61,7 +64,7 @@ def _import(from_package, module_name, task_name, fail_on_import_error=False):
 
 def run_one_task(taskname, **kwargs):
     taskname = taskname.replace('-', '_')
-    task = get_task(taskname)
+    task = get_task(taskname, kwargs['ctx'])
     return task(**kwargs)
 
 


### PR DESCRIPTION
In my testing environments, sys.path have "/home/teuthworker/src/github.com_ceph_ceph_xxx/", but don't have "/qa" path.  In this case, will show error "ImportError: No module named tasks.ceph"

if we add "/qa" path to sys.path using suite_path, can fix this error. 
  