### PR TITLE
workaround to install dbench for rhel-8

### DIFF
--- a/teuthology/task/internal/redhat.py
+++ b/teuthology/task/internal/redhat.py
@@ -113,6 +113,10 @@ def _enable_rhel_repos(remote):
         remote.run(args=['sudo', 'subscription-manager',
                          'repos', '--enable={r}'.format(r=repo)])
 
+    if remote.os.version.startswith('8'):
+        workaround(remote)
+
+
 @contextlib.contextmanager
 def setup_base_repo(ctx, config):
     """
@@ -224,3 +228,11 @@ def _create_temp_repo_file(repos, repo_file):
         repo_file.write(gpgcheck)
         repo_file.write(enabled)
     repo_file.close()
+
+
+def workaround(remote):
+    log.info('temporary workaround')
+    remote.run(args=['sudo',
+                     'yum',
+                     'install', '-y',
+                     'http://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/d/dbench-4.0-10.el7.x86_64.rpm'])


### PR DESCRIPTION
A temporary fix for `dbench` package not available seen in this run 
http://pulpito.ceph.redhat.com/rakesh-2020-01-06_12:06:20-rgw-nautilus-distro-basic-pluto/354305/

Signed-off-by: rakeshgm <rakeshgm014@gmail.com>