### PR TITLE
bootstrap: install setuptools 44

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -141,7 +141,11 @@ SVER=${LVER%%.*}
 ./$VENV/bin/pip install --upgrade pip
 
 # Ensure setuptools is installed
-./$VENV/bin/pip install setuptools --upgrade
+if [ "$SVER" = "2" ]; then
+    ./$VENV/bin/pip install setuptools==44
+else
+    ./$VENV/bin/pip install setuptools --upgrade
+fi
 
 # Install all requirements
 ./$VENV/bin/pip install --upgrade -r requirements${SVER}.txt


### PR DESCRIPTION
With setuptools 45 python2 support was dropped.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>