### PR TITLE
tasks/internal: put kernel.core_pattern in sysctl.conf too

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -416,6 +416,11 @@ def coredump(ctx, config):
                 '{adir}/coredump'.format(adir=archive_dir),
                 run.Raw('&&'),
                 'sudo', 'sysctl', '-w', 'kernel.core_pattern={adir}/coredump/%t.%p.core'.format(adir=archive_dir),
+		run.Raw('&&'),
+		'echo',
+		'kernel.core_pattern={adir}/coredump/%t.%p.core'.format(adir=archive_dir),
+		run.Raw('|'),
+		'sudo', 'tee', '-a', '/etc/sysctl.conf',
             ],
             wait=False,
         )


### PR DESCRIPTION
This way if systemd restarts  or is reinstalled (as it is on el8 at the
moment) we won't lose this setting.

Signed-off-by: Sage Weil <sage@redhat.com>