### PR TITLE
task/selinux: ignore SElinux denials caused by podman

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -125,6 +125,7 @@ class SELinux(Task):
             'comm="rhsmcertd-worke"',
             'comm="setroubleshootd"',
             'comm="rpm"',
+            'tcontext=system_u:object_r:container_runtime_exec_t:s0',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
it's a workaround of https://tracker.ceph.com/issues/43229

Signed-off-by: Kefu Chai <kchai@redhat.com>