### PR TITLE
orchestra/daemon/cephadmunit: stop following logs on container exit

### DIFF
--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -44,7 +44,7 @@ class CephadmUnit(DaemonState):
         name = '%s.%s' % (self.type_, self.id_)
         self.remote_logger = self.remote.run(
             args=['sudo', self.use_cephadm, 'logs',
-                  '-f',
+                  '-f', '--logger', 'podman'
                   '--fsid', self.fsid,
                   '--name', name],
             logger=logging.getLogger(self.cluster + '.' + name),


### PR DESCRIPTION
podman will exit when the container is stopped/crashed, whereas
journalctl continues to follow the log of the exited container

Signed-off-by: Michael Fritch <mfritch@suse.com>