### PR TITLE
suite/run.py: provide teuthology hash along with branch

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -15,6 +15,7 @@ from teuthology.exceptions import (
 )
 from teuthology.misc import deep_merge, get_results_url
 from teuthology.orchestra.opsys import OS
+from teuthology.repo_utils import build_git_url
 
 from teuthology.suite import util
 from teuthology.suite.build_matrix import combine_path, build_matrix
@@ -206,7 +207,14 @@ class Run(object):
                     "branch {0} not in teuthology.git; will use master for"
                     " teuthology".format(self.args.ceph_branch))
                 teuthology_branch = 'master'
-        log.info("teuthology branch: %s", teuthology_branch)
+        teuthology_hash = util.git_ls_remote(
+            'teuthology',
+            teuthology_branch
+        )
+        if not teuthology_hash:
+            exc = BranchNotFoundError(teuthology_branch, build_git_url('teuthology'))
+            util.schedule_fail(message=str(exc), name=self.name)
+        log.info("teuthology branch: %s %s", teuthology_branch, teuthology_hash)
         return teuthology_branch
 
     @property


### PR DESCRIPTION
When running teuthology-suite with -t option, I see:

```
teuthology branch: wip-fix-opensuse-provisioning
ceph branch: wip-foo eb2fd5065c6e489ca8dd9282ba62ab231f144f7a
```

In other words, the ceph branch message has the SHA1 but the
teuthology branch message does not. This commit adds it.

Signed-off-by: Nathan Cutler <ncutler@suse.com>