### PR TITLE
selinux: use text processing

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -137,8 +137,8 @@ class SELinux(Task):
         ignore_known_denials = '\'\(' + str.join('\|', known_denials) + '\)\''
         for remote in self.cluster.remotes.keys():
             proc = remote.run(
-                args=['sudo', 'grep', 'avc: .*denied',
-                      '/var/log/audit/audit.log', run.Raw('|'), 'grep', '-v',
+                args=['sudo', 'grep', '-a', 'avc: .*denied',
+                      '/var/log/audit/audit.log', run.Raw('|'), 'grep', '-av',
                       run.Raw(ignore_known_denials)],
                 stdout=StringIO(),
                 check_status=False,


### PR DESCRIPTION
We ran into some odd grep bug treating the audit.log as binary and
wrongly returning a match result.

Fixes: https://tracker.ceph.com/issues/43797
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>