### PR TITLE
ceph_ansible: Make sure cryptography version is compatible

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -432,6 +432,11 @@ class CephAnsible(Task):
             run.Raw(';'),
             'pip',
             'install',
+            '--upgrade',
+            'cryptography>=2.5',
+            run.Raw(';'),
+            'pip',
+            'install',
             run.Raw('setuptools>=11.3'),
             run.Raw('notario>=0.0.13'), # FIXME: use requirements.txt
             run.Raw('netaddr'),


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/43843

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>