### PR TITLE
use libcloud 2.8.0 version 

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements2.txt
 #
 ansible==2.8.2
-apache-libcloud==2.6.0
+apache-libcloud==2.8.0
 appdirs==1.4.3            # via os-client-config
 argparse==1.4.0
 atomicwrites==1.1.5       # via pytest

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements3.txt
 #
 ansible==2.8.2
-apache-libcloud==2.6.0
+apache-libcloud==2.8.0
 appdirs==1.4.3            # via os-client-config
 argparse==1.4.0
 atomicwrites==1.1.5       # via pytest


### PR DESCRIPTION
Suggesting using 2.8.0 version of apache-libcloud that introduces
a fix on openstack driver.
(https://github.com/apache/libcloud/pull/1367 is fixing issue
https://github.com/apache/libcloud/issues/1365)

Signed-off-by: Georgios Kyratsas <gkyratsas@suse.com>