### PR TITLE
hammer.sh: don't do teuthology-nuke anymore.

### DIFF
--- a/hammer.sh
+++ b/hammer.sh
@@ -14,8 +14,6 @@ fi
 
 test -e $1
 
-teuthology-nuke -t $job
-
 title() {
 	echo '\[\033]0;hammer '$job' '$N' passes\007\]'
 }


### PR DESCRIPTION
Apparently `hammer.sh` is pretty old. It calls `teuthology-nuke` expecting the further call to `teuhology` will be able to still reach the nodes. However, it doesn't seem that anybody is turning them back these days.

The commit just drops the `teuthology-nuke` call.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>