### PR TITLE
worker_start: allow ARCHIVE variable override

### DIFF
--- a/docs/_static/worker_start.sh
+++ b/docs/_static/worker_start.sh
@@ -2,7 +2,7 @@
  
 # A simple script used by Red Hat to start teuthology-worker processes.
  
-ARCHIVE=$HOME/archive
+ARCHIVE=${ARCHIVE:-"$HOME/archive"}
 WORKER_LOGS=$ARCHIVE/worker_logs
  
 function start_workers_for_tube {


### PR DESCRIPTION
The worker_start.sh script is using archive directory inside
the worker user home which cannot be changed, this patches
allows override ARCHIVE environment variable to address
this issue.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>