### PR TITLE
requirements: pip-compile -P six

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -98,7 +98,7 @@ rfc3986==0.4.1            # via oslo.config
 s3transfer==0.2.1         # via boto3
 scandir==1.8              # via pathlib2
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
-six==1.10.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, tox, warlock
+six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, tox, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
 tox==3.0.0
 unicodecsv==0.14.1        # via cliff

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -91,7 +91,7 @@ requestsexceptions==1.2.0  # via os-client-config
 rfc3986==0.4.1            # via oslo.config
 s3transfer==0.2.1         # via boto3
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
-six==1.10.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, tox, warlock
+six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, tox, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
 tox==3.0.0
 urllib3==1.25.3           # via botocore, requests


### PR DESCRIPTION
We need to pump six to the latest 1.14.0 so we have
six.ensure_str() is available

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>