### PR TITLE
teuthology/task: add timeout for clock task

### DIFF
--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -49,6 +49,7 @@ def task(ctx, config):
                 run.Raw('||'),
                 'true'
             ],
+            timeout = 60,
         )
 
     try:


### PR DESCRIPTION
when ntp is not config correctly, the clock task will be blocked

Signed-off-by: chuqifang <chuqifang@hisilicon.com>