### PR TITLE
enable py3

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -12,7 +12,7 @@ else
   fi
 fi
 
-PYTHON=${PYTHON:-"python2"}
+PYTHON=${PYTHON:-"python3"}
 VENV=${VENV:-"virtualenv"}
 
 case "$(uname -s)" in


### PR DESCRIPTION
This PR is supposed to be different from #1362 only by one commit which makes bootstrap to use py3 by default.
THIS PR CAN BE MERGED AFTER 

- [x] create a "py3" branch with the change in this PR in https://github.com/ceph/teuthology
- [x] install `python3-devel` in sepia
- [x] fix the py3 compatibility issues in master. see https://github.com/ceph/ceph/pull/34264
- [ ] backport py3 compatibility patches to octopus
- [ ] backport py3 compatibility patches to nautilus. see https://github.com/ceph/ceph/pull/34171
- [ ] test qa suites in octopus, nautilus and master with the "py3" branch using `--teuthology-branch py3`
  - [ ] octopus
  - [ ] nautilus
  - [x] master
- [x] create a "py2" branch without the change in this PR in https://github.com/ceph/teuthology
- [x] update the cron jobs testing luminous and mimic using `--teuthology-branch py2`: https://github.com/ceph/ceph/pull/34487
- [ ] merge this PR
- [ ] remove "py3" branch from https://github.com/ceph/teuthology

i am also tracking the progress in https://trello.com/c/GNCbsxBW/573-python3-migration