### PR TITLE
task/kernel.py: should pass args with name

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -1010,9 +1010,9 @@ def get_image_version(remote, path):
     :param path: (rpm or deb) package path
     """
     if remote.os.package_type == 'rpm':
-        files = remote.run(['rpm', '-qlp', path])
+        files = remote.run(args=['rpm', '-qlp', path])
     elif remote.os.package_type == 'deb':
-        files = remote.run(['dpkg-deb', '-c', path])
+        files = remote.run(args=['dpkg-deb', '-c', path])
     else:
         raise UnsupportedPackageTypeError(remote)
 


### PR DESCRIPTION
to address the failure of

```
Traceback (most recent call last):
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/run_tasks.py", line 86, in run_tasks
    manager = run_one_task(taskname, ctx=ctx, config=config)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/run_tasks.py", line 65, in run_one_task
    return task(**kwargs)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/task/kernel.py", line 1326, in task
    install_and_reboot(ctx, need_install)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/task/kernel.py", line 505, in install_and_reboot
    install_kernel(role_remote, remote_pkg_path(role_remote))
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/task/kernel.py", line 834, in install_kernel
    version = get_image_version(remote, path)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/task/kernel.py", line 1013, in get_image_version
    files = remote.run(['rpm', '-qlp', path])
TypeError: run() takes exactly 1 argument (2 given)
```

Signed-off-by: Kefu Chai <kchai@redhat.com>