### PR TITLE
task/kernel.py: should pass args with name 2

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -1010,9 +1010,9 @@ def get_image_version(remote, path):
     :param path: (rpm or deb) package path
     """
     if remote.os.package_type == 'rpm':
-        files = remote.run(args=['rpm', '-qlp', path])
+        files = remote.sh(['rpm', '-qlp', path])
     elif remote.os.package_type == 'deb':
-        files = remote.run(args=['dpkg-deb', '-c', path])
+        files = remote.sh(['dpkg-deb', '-c', path])
     else:
         raise UnsupportedPackageTypeError(remote)
 


### PR DESCRIPTION
There is leftover, there should be remote.sh used instead of remote.run

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>