### PR TITLE
requirements,setup: add ipy module for cephfs mount.py 

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -107,6 +107,7 @@ virtualenv==15.1.0        # via tox
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
 xmltodict==0.12.0
+ipy==1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -99,6 +99,7 @@ virtualenv==15.1.0        # via tox
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
 xmltodict==0.12.0
+ipy==1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
             'xmltodict',
             'boto3',
             'PyJWT',            # for qa/tasks/mgr/dashboard/test_auth.py
+            'ipy',              # for qa/tasks/cephfs/mount.py
         ]
     },
 


### PR DESCRIPTION
The IPy module is a tool for handling of IPv4 and IPv6 addresses and
networks, the cephfs mount.py will use it to manage the IP addresses
to isolate the netns for each mount, which could let us get ride of
using ipmi command to hard shutdown the client node for some test cases.

Thanks @tchaikov very much for the help.