### PR TITLE
teuthology/task/install

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -568,6 +568,9 @@ def task(ctx, config):
                 0,
                 lambda: ansible.CephLab(ctx, config=ansible_config)
             )
+        nested_config = dict(extra_system_packages=config.get('extra_system_packages', []),
+                             extra_packages=config.get('extra_packages', []),
+                             )
         with contextutil.nested(*nested_tasks):
                 yield
     else:


### PR DESCRIPTION
extra_packages and extra_system_packages were not used when `redhat` was used in the config. This caused errors in running some of the RBD tests. 

issue:  [44537](https://tracker.ceph.com/issues/44537)

Test runs: http://magna002.ceph.redhat.com/rakesh-2020-03-31_02:06:51-kcephfs-nautilus-distro-basic-argo/368686/teuthology.log 


Signed-off-by: rakeshgm <rgowdege@redhat.com>