### PR TITLE
teuthology: s/cStringIO.StringIO/six.StringIO/

### DIFF
--- a/teuthology/orchestra/test/integration/test_integration.py
+++ b/teuthology/orchestra/test/integration/test_integration.py
@@ -1,7 +1,7 @@
 from teuthology.orchestra import monkey
 monkey.patch_all()
 
-from cStringIO import StringIO
+from six import StringIO
 
 import os
 from teuthology.orchestra import connection, remote, run

--- a/teuthology/task/hadoop.py
+++ b/teuthology/task/hadoop.py
@@ -1,4 +1,4 @@
-from cStringIO import StringIO
+from six import StringIO
 import contextlib
 import logging
 from teuthology import misc as teuthology

--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -8,6 +8,7 @@ import logging
 import os
 import time
 import yaml
+import six
 import subprocess
 
 import teuthology.lock.ops
@@ -308,7 +309,7 @@ def fetch_binaries_for_coredumps(path, remote):
             # Parse file output to get program, Example output:
             # 1422917770.7450.core: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, \
             # from 'radosgw --rgw-socket-path /home/ubuntu/cephtest/apache/tmp.client.0/fastcgi_soc'
-            dump_program = dump_out.split("from '")[1].split(' ')[0]
+            dump_program = six.ensure_str(dump_out).split("from '")[1].split(' ')[0]
 
             # Find path on remote server:
             remote_path = remote.sh(['which', dump_program]).rstrip()

--- a/teuthology/task/mpi.py
+++ b/teuthology/task/mpi.py
@@ -1,7 +1,6 @@
 """
 Start mpi processes (and allow commands to be run inside process)
 """
-from StringIO import StringIO
 import logging
 import re
 
@@ -18,7 +17,7 @@ def _check_mpi_version(remotes):
     """
     versions = set()
     for remote in remotes:
-        version_str = remote.run(args=["mpiexec", "--version"], stdout=StringIO()).stdout.getvalue()
+        version_str = remote.sh("mpiexec --version")
         try:
             version = re.search("^\s+Version:\s+(.+)$", version_str, re.MULTILINE).group(1)
         except AttributeError:

--- a/teuthology/task/ssh_keys.py
+++ b/teuthology/task/ssh_keys.py
@@ -8,7 +8,7 @@ import paramiko
 import re
 from datetime import datetime
 
-from cStringIO import StringIO
+from six import StringIO
 from teuthology import contextutil
 import teuthology.misc as misc
 from teuthology.orchestra import run


### PR DESCRIPTION
to be py3 compatible. this addresses the failure of
```
2020-04-05T12:35:02.036 INFO:teuthology.run_tasks:Running task ssh_keys...
2020-04-05T12:35:02.050 ERROR:teuthology.run_tasks:Saw exception from tasks.
Traceback (most recent call last):
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_py3/teuthology/run_tasks.py", line 86, in run_tasks
    manager = run_one_task(taskname, ctx=ctx, config=config)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_py3/teuthology/run_tasks.py", line 64, in run_one_task
    task = get_task(taskname)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_py3/teuthology/run_tasks.py", line 28, in get_task
    module = _import('tasks', module_name, task_name, fail_on_import_error=True)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_py3/teuthology/run_tasks.py", line 52, in _import
    0,
ImportError: No module named 'tasks.ssh_keys'
```

Signed-off-by: Kefu Chai <kchai@redhat.com>