### PR TITLE
added rhbuild attribute for redhat task and changes to retrieve correct daemon pid.

### DIFF
--- a/teuthology/orchestra/daemon/systemd.py
+++ b/teuthology/orchestra/daemon/systemd.py
@@ -100,7 +100,7 @@ class SystemDState(DaemonState):
     @property
     def pid(self):
         proc_name = 'ceph-%s' % self.type_
-        proc_regex = '"%s.*--id %s"' % (proc_name, self.id_)
+        proc_regex = '"%s.*--id %s "' % (proc_name, self.id_)
         args = ['ps', '-ef',
                 run.Raw('|'),
                 'grep',


### PR DESCRIPTION
-  Added rhbuild attribute under redhat 
example:
```
redhat:
    rhbuild: '4.x'
    base-repo-url: <repo-url>
```
-  Code changes to retrieve correct daemon pid.