### PR TITLE
suite: Implement --sleep-before-teardown option

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -38,7 +38,9 @@ futures==3.2.0            # via s3transfer
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 httplib2==0.10.3
+humanfriendly==8.1
 idna==2.5                 # via requests
+ipy==1.0
 ipaddress==1.0.18         # via cryptography
 iso8601==0.1.11           # via keystoneauth1, oslo.utils, python-neutronclient, python-novaclient
 jinja2==2.10.1            # via ansible
@@ -107,7 +109,6 @@ virtualenv==15.1.0        # via tox
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
 xmltodict==0.12.0
-ipy==1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -34,7 +34,9 @@ docutils==0.14            # via botocore
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 httplib2==0.10.3
+humanfriendly==8.1
 idna==2.5                 # via requests
+ipy==1.0
 iso8601==0.1.11           # via keystoneauth1, oslo.utils, python-neutronclient, python-novaclient
 jinja2==2.10.1            # via ansible
 jmespath==0.9.4           # via boto3, botocore
@@ -99,7 +101,6 @@ virtualenv==15.1.0        # via tox
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
 xmltodict==0.12.0
-ipy==1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -187,6 +187,11 @@ def get_suite_parser():
         help=("Use tasks and suite definition in this repository"),
         default=os.getenv('TEUTH_SUITE_REPO', 'https://github.com/ceph/ceph'),
     )
+    parser.add_argument(
+        '--sleep-before-teardown',
+        help='Number of seconds to sleep before tearing down the target VMs',
+        default=0
+    )
     return parser
 
 def get_openstack_parser():

--- a/scripts/openstack.py
+++ b/scripts/openstack.py
@@ -189,7 +189,7 @@ def get_suite_parser():
     )
     parser.add_argument(
         '--sleep-before-teardown',
-        help='Number of seconds to sleep before tearing down the target VMs',
+        help='Number of seconds to sleep before the teardown',
         default=0
     )
     return parser

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -25,6 +25,8 @@ Miscellaneous arguments:
   --dry-run                   Do a dry run; do not schedule anything. In
                               combination with -vv, also call
                               teuthology-schedule with --dry-run.
+  -y, --non-interactive       Do not ask question and say yes when
+                              it is possible.
 
 Standard arguments:
   <config_yaml>               Optional extra job yaml to include

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -80,9 +80,14 @@ Standard arguments:
                               Validate that git SHA1s passed to -S exist.
                               [default: true]
   --sleep-before-teardown <seconds>
-                              Number of seconds to sleep before tearing down
-                              the test cluster(s). Use with care, as this
-                              applies to all jobs in the run.
+                              Number of seconds to sleep before teardown.
+                              Use with care, as this applies to all jobs in the
+                              run. This option is used along with --limit one.
+                              If the --limit ommitted then it's forced to 1.
+                              If the --limit is greater than 4, then user must
+                              confirm it interactively to avoid massive lock
+                              of resources, however --non-interactive option
+                              can be used to skip user input.
                               [default: 0]
 
 Scheduler arguments:

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -79,6 +79,11 @@ Standard arguments:
   --validate-sha1 <bool>
                               Validate that git SHA1s passed to -S exist.
                               [default: true]
+  --sleep-before-teardown <seconds>
+                              Number of seconds to sleep before tearing down
+                              the test cluster(s). Use with care, as this
+                              applies to all jobs in the run.
+                              [default: 0]
 
 Scheduler arguments:
   --owner <owner>             Job owner

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
                       'ansible>=2.0',
                       'prettytable',
                       'manhole',
+                      'humanfriendly',
                       ],
     extras_require = {
         'coverage': [ 'mysqlclient == 1.4.2'],

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -185,6 +185,7 @@ class TeuthologyConfig(YamlConfig):
                 'size': 1,
             },
         },
+        'sleep_before_teardown': 0,
     }
 
     def __init__(self, yaml_path=None):

--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+import time
 import types
 
 from copy import deepcopy
@@ -151,6 +152,13 @@ def run_tasks(tasks, ctx):
     finally:
         try:
             exc_info = sys.exc_info()
+            sleep_before_teardown = ctx.config.get('sleep_before_teardown')
+            if sleep_before_teardown:
+                log.info(
+                    'Sleeping for {} seconds before unwinding because'
+                    ' --sleep-before-teardown was given...'
+                    .format(sleep_before_teardown))
+                time.sleep(sleep_before_teardown)
             while stack:
                 taskname, manager = stack.pop()
                 log.debug('Unwinding manager %s', taskname)

--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -98,6 +98,7 @@ dict_templ = {
         }
     },
     'repo': Placeholder('ceph_repo'),
+    'sleep_before_teardown': 0,
     'suite': Placeholder('suite'),
     'suite_repo': Placeholder('suite_repo'),
     'suite_relpath': Placeholder('suite_relpath'),

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -284,6 +284,8 @@ class Run(object):
             job_config.email = self.args.email
         if self.args.owner:
             job_config.owner = self.args.owner
+        if self.args.sleep_before_teardown:
+            job_config.sleep_before_teardown = int(self.args.sleep_before_teardown)
         return job_config
 
     def build_base_args(self):


### PR DESCRIPTION
This is another try to merge the useful debugging feature which is supposed to be not breaking 'parallel' and 'sequential' tasks.
The `sleep-before-teardown` only works on the front line of tasks not going deep into parallel and sequential tasks and does not give a sleep within them correspondingly, allowing to finish them correctly before unwinding the main stack of tasks.

Usage hints:
- option can be used with either `teuthology-suite` or `teuthology-openstack`
- use `teuthology-kill` to cleanup the job or run to interrupt the sleep and free resources.

Changes:
- [x] add --non-interactive option
- [x] add force using --limit 1 if it was omitted when --sleep-before-teardown is given  
- [x] add interactive confirmation if --sleep-before-teardown is given and --limit is more than 4
- [x] add --limit check skipping for --sleep-before-teardown when --non-interactive mode is enabled

Notes:
   I had to move job limit check out of the collect_jobs method and newest check loop to avoid asking the same confirmation question over and over again. 
