### PR TITLE
task.internal.archive: fix 'Permission denied' error when coredump found

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -314,8 +314,12 @@ def fetch_binaries_for_coredumps(path, remote):
             remote_path = remote.sh(['which', dump_program]).rstrip()
 
             # Pull remote program into coredump folder:
-            remote._sftp_get_file(remote_path, os.path.join(coredump_path,
-                                                            dump_program))
+            local_path = os.path.join(coredump_path,
+                                      dump_program.lstrip(os.path.sep))
+            local_dir = os.path.dirname(local_path)
+            if not os.path.exists(local_dir):
+                os.makedirs(local_dir)
+            remote._sftp_get_file(remote_path, local_path)
 
             # Pull Debug symbols:
             debug_path = os.path.join('/usr/lib/debug', remote_path)


### PR DESCRIPTION
This fix address failure like:
```
2020-04-10T10:35:13.508 ERROR:teuthology.run_tasks:Manager failed: internal.archive
Traceback (most recent call last):
  File "/home/worker/src/teuthology_master/teuthology/run_tasks.py", line 167, in run_tasks
    suppress = manager.__exit__(*exc_info)
  File "/usr/lib64/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "/home/worker/src/teuthology_master/teuthology/task/internal/__init__.py", line 363, in archive
    fetch_binaries_for_coredumps(path, rem)
  File "/home/worker/src/teuthology_master/teuthology/task/internal/__init__.py", line 318, in fetch_binaries_for_coredumps
    dump_program))
  File "/home/worker/src/teuthology_master/teuthology/orchestra/remote.py", line 325, in _sftp_get_file
    sftp.get(remote_path, local_path)
  File "/home/worker/src/teuthology_master/virtualenv/lib/python2.7/site-packages/paramiko/sftp_client.py", line 801, in get
    with open(localpath, "wb") as fl:
IOError: [Errno 13] Permission denied: '/usr/bin/python3'
```
The issue happens because of os.path.join ignores all prior arguments
if the next has '/' prefix (i.e. absolute), for example:
```
>>> os.path.join('a/b/', '/x/y')
'/x/y'
```
when a user expect to get 'a/b/x/y', she gets '/x/y'.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>