### PR TITLE
teuthology: pass integer as "tries" to safe_while()

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -863,7 +863,7 @@ def wait_until_healthy(ctx, remote, ceph_cluster='ceph', use_sudo=False):
             'ceph-coverage',
             '{tdir}/archive/coverage'.format(tdir=testdir)]
     args.extend(cmd)
-    with safe_while(tries=(900 / 6), action="wait_until_healthy") as proceed:
+    with safe_while(tries=(900 // 6), action="wait_until_healthy") as proceed:
         while proceed():
             out = remote.sh(args, logger=log.getChild('health'))
             log.debug('Ceph health: %s', out.rstrip('\n'))

--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -485,7 +485,7 @@ def wait(processes, timeout=None):
     if timeout:
         log.info("waiting for %d", timeout)
     if timeout and timeout > 0:
-        with safe_while(tries=(timeout / 6)) as check_time:
+        with safe_while(tries=(timeout // 6)) as check_time:
             not_ready = list(processes)
             while len(not_ready) > 0:
                 check_time()


### PR DESCRIPTION
in Python3, `a / b` could return a float, and `safe_while()` uses
`itertools.islice()` under the hood, where `stop` should be None or an
integer. so let's use `a // b` instead.

Signed-off-by: Kefu Chai <kchai@redhat.com>