### PR TITLE
requirements: Bump cffi version to 1.14.0

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -4,44 +4,44 @@
 #
 #    pip-compile --output-file=requirements2.txt
 #
-ansible==2.8.2
-apache-libcloud==2.8.0
+ansible==2.8.2            # via teuthology
+apache-libcloud==2.8.0    # via teuthology
 appdirs==1.4.3            # via os-client-config
-argparse==1.4.0
+argparse==1.4.0           # via teuthology
 atomicwrites==1.1.5       # via pytest
 attrs==18.1.0             # via pytest
 babel==2.4.0              # via osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-neutronclient, python-novaclient, python-openstackclient
-backports.ssl-match-hostname==3.5.0.1
+backports.ssl-match-hostname==3.5.0.1  # via apache-libcloud, teuthology
 bcrypt==3.1.6             # via paramiko
-beanstalkc3==0.4.0
-boto3==1.9.161
-boto==2.46.1
+beanstalkc3==0.4.0        # via teuthology
+boto3==1.9.161            # via teuthology
+boto==2.46.1              # via teuthology
 botocore==1.12.161        # via boto3, s3transfer
 certifi==2019.3.9         # via requests
-cffi==1.10.0              # via bcrypt, cryptography, pynacl
+cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 cliff==2.5.0              # via osc-lib, python-neutronclient, python-openstackclient
 cmd2==0.7.0               # via cliff
-configobj==5.0.6
-configparser==3.5.0
+configobj==5.0.6          # via teuthology
+configparser==3.5.0       # via teuthology
 contextlib2==0.5.4        # via raven
-cryptography==2.8         # via ansible, paramiko, pyopenssl
+cryptography==2.8         # via ansible, paramiko, pyopenssl, teuthology
 debtcollector==1.13.0     # via oslo.config, oslo.utils, python-keystoneclient, python-neutronclient
 deprecation==1.0          # via openstacksdk
-docopt==0.6.2
+docopt==0.6.2             # via teuthology
 docutils==0.14            # via botocore
-enum34==1.1.6             # via cryptography
+enum34==1.1.6             # via apache-libcloud, cryptography
 funcsigs==1.0.2           # via debtcollector, oslo.utils, pytest
 functools32==3.2.3.post2  # via jsonschema
 futures==3.2.0            # via s3transfer
-gevent==1.4.0
+gevent==1.4.0             # via teuthology
 greenlet==0.4.15          # via gevent
-httplib2==0.10.3
-humanfriendly==8.1
+httplib2==0.10.3          # via teuthology
+humanfriendly==8.1        # via teuthology
 idna==2.5                 # via requests
-ipy==1.0
 ipaddress==1.0.18         # via cryptography
+ipy==1.0                  # via teuthology
 iso8601==0.1.11           # via keystoneauth1, oslo.utils, python-neutronclient, python-novaclient
 jinja2==2.10.1            # via ansible
 jmespath==0.9.4           # via boto3, botocore
@@ -49,16 +49,16 @@ jsonpatch==1.15           # via warlock
 jsonpointer==1.10         # via jsonpatch
 jsonschema==2.6.0         # via warlock
 keystoneauth1==2.19.0     # via openstacksdk, os-client-config, osc-lib, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
-manhole==1.3.0
+manhole==1.3.0            # via teuthology
 markupsafe==1.1.1         # via jinja2
-monotonic==1.3            # via oslo.utils
+monotonic==1.3            # via humanfriendly, oslo.utils
 more-itertools==4.3.0     # via pytest
 msgpack-python==0.4.8     # via oslo.serialization
-mysqlclient==1.4.2
-ndg-httpsclient==0.4.2
-netaddr==0.7.19           # via oslo.config, oslo.utils, python-neutronclient
+mysqlclient==1.4.2        # via teuthology
+ndg-httpsclient==0.4.2    # via teuthology
+netaddr==0.7.19           # via oslo.config, oslo.utils, python-neutronclient, teuthology
 netifaces==0.10.5         # via oslo.utils
-nose==1.3.7
+nose==1.3.7               # via teuthology
 openstacksdk==0.9.15      # via python-openstackclient
 os-client-config==1.26.0  # via openstacksdk, osc-lib, python-neutronclient
 osc-lib==1.3.0            # via python-neutronclient, python-openstackclient
@@ -66,49 +66,50 @@ oslo.config==3.24.0       # via python-keystoneclient
 oslo.i18n==3.15.0         # via osc-lib, oslo.config, oslo.utils, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
 oslo.serialization==2.18.0  # via python-keystoneclient, python-neutronclient, python-novaclient
 oslo.utils==3.25.0        # via osc-lib, oslo.serialization, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
-paramiko==2.7.1
+paramiko==2.7.1           # via teuthology
 pathlib2==2.3.2           # via pytest
 pbr==2.0.0                # via cliff, debtcollector, keystoneauth1, openstacksdk, osc-lib, oslo.i18n, oslo.serialization, oslo.utils, positional, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, requestsexceptions, stevedore
-pexpect==4.7.0
-pip-tools==4.3.0
+pexpect==4.7.0            # via teuthology
+pip-tools==4.3.0          # via teuthology
 pluggy==0.7.1             # via pytest, tox
 positional==1.1.1         # via keystoneauth1, python-keystoneclient
-prettytable==0.7.2        # via cliff, python-cinderclient, python-glanceclient, python-novaclient
-psutil==5.2.2
+prettytable==0.7.2        # via cliff, python-cinderclient, python-glanceclient, python-novaclient, teuthology
+psutil==5.2.2             # via teuthology
 ptyprocess==0.5.1         # via pexpect
 py==1.5.3                 # via pytest, tox
-pyasn1==0.2.3
+pyasn1==0.2.3             # via teuthology
 pycparser==2.17           # via cffi
-pyjwt==1.7.1
+pyjwt==1.7.1              # via teuthology
 pynacl==1.3.0             # via paramiko
-pyopenssl==19.0.0         # via ndg-httpsclient
+pyopenssl==19.0.0         # via ndg-httpsclient, teuthology
 pyparsing==2.2.0          # via cliff, cmd2, oslo.utils
-pytest==3.7.1
+pytest==3.7.1             # via teuthology
 python-cinderclient==2.0.1  # via python-openstackclient
-python-dateutil==2.6.0    # via botocore
+python-dateutil==2.6.0    # via botocore, teuthology
 python-glanceclient==2.6.0  # via python-openstackclient
 python-keystoneclient==3.10.0  # via python-neutronclient, python-openstackclient
-python-neutronclient==6.2.0
-python-novaclient==8.0.0  # via python-openstackclient
-python-openstackclient==3.9.0
+python-neutronclient==6.2.0  # via teuthology
+python-novaclient==8.0.0  # via python-openstackclient, teuthology
+python-openstackclient==3.9.0  # via teuthology
 pytz==2017.2              # via babel, oslo.serialization, oslo.utils
-pyyaml==5.1.2             # via ansible, cliff, os-client-config
-raven==6.0.0
-requests==2.22.0          # via apache-libcloud, keystoneauth1, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient
+pyyaml==5.1.2             # via ansible, cliff, os-client-config, teuthology
+raven==6.0.0              # via teuthology
+requests==2.22.0          # via apache-libcloud, keystoneauth1, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, teuthology
 requestsexceptions==1.2.0  # via os-client-config
 rfc3986==0.4.1            # via oslo.config
 s3transfer==0.2.1         # via boto3
 scandir==1.8              # via pathlib2
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
-six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, tox, warlock
+six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, teuthology, tox, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
-tox==3.0.0
+tox==3.0.0                # via teuthology
+typing==3.7.4.1           # via apache-libcloud
 unicodecsv==0.14.1        # via cliff
 urllib3==1.25.3           # via botocore, requests
 virtualenv==15.1.0        # via tox
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
-xmltodict==0.12.0
+xmltodict==0.12.0         # via teuthology
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -4,39 +4,39 @@
 #
 #    pip-compile --output-file=requirements3.txt
 #
-ansible==2.8.2
-apache-libcloud==2.8.0
+ansible==2.8.2            # via teuthology
+apache-libcloud==2.8.0    # via teuthology
 appdirs==1.4.3            # via os-client-config
-argparse==1.4.0
+argparse==1.4.0           # via teuthology
 atomicwrites==1.1.5       # via pytest
 attrs==18.1.0             # via pytest
 babel==2.4.0              # via osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-neutronclient, python-novaclient, python-openstackclient
-backports.ssl-match-hostname==3.5.0.1
+backports.ssl-match-hostname==3.5.0.1  # via teuthology
 bcrypt==3.1.6             # via paramiko
-beanstalkc3==0.4.0
-boto3==1.9.161
-boto==2.46.1
+beanstalkc3==0.4.0        # via teuthology
+boto3==1.9.161            # via teuthology
+boto==2.46.1              # via teuthology
 botocore==1.12.161        # via boto3, s3transfer
 certifi==2019.3.9         # via requests
-cffi==1.10.0              # via bcrypt, cryptography, pynacl
+cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 cliff==2.5.0              # via osc-lib, python-neutronclient, python-openstackclient
 cmd2==0.7.0               # via cliff
-configobj==5.0.6
-configparser==3.5.0
+configobj==5.0.6          # via teuthology
+configparser==3.5.0       # via teuthology
 contextlib2==0.5.4        # via raven
-cryptography==2.8         # via ansible, paramiko, pyopenssl
+cryptography==2.8         # via ansible, paramiko, pyopenssl, teuthology
 debtcollector==1.13.0     # via oslo.config, oslo.utils, python-keystoneclient, python-neutronclient
 deprecation==1.0          # via openstacksdk
-docopt==0.6.2
+docopt==0.6.2             # via teuthology
 docutils==0.14            # via botocore
-gevent==1.4.0
+gevent==1.4.0             # via teuthology
 greenlet==0.4.15          # via gevent
-httplib2==0.10.3
-humanfriendly==8.1
+httplib2==0.10.3          # via teuthology
+humanfriendly==8.1        # via teuthology
 idna==2.5                 # via requests
-ipy==1.0
+ipy==1.0                  # via teuthology
 iso8601==0.1.11           # via keystoneauth1, oslo.utils, python-neutronclient, python-novaclient
 jinja2==2.10.1            # via ansible
 jmespath==0.9.4           # via boto3, botocore
@@ -44,16 +44,16 @@ jsonpatch==1.15           # via warlock
 jsonpointer==1.10         # via jsonpatch
 jsonschema==2.6.0         # via warlock
 keystoneauth1==2.19.0     # via openstacksdk, os-client-config, osc-lib, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
-manhole==1.3.0
+manhole==1.3.0            # via teuthology
 markupsafe==1.1.1         # via jinja2
 monotonic==1.3            # via oslo.utils
 more-itertools==4.3.0     # via pytest
 msgpack-python==0.4.8     # via oslo.serialization
-mysqlclient==1.4.2
-ndg-httpsclient==0.4.2
-netaddr==0.7.19           # via oslo.config, oslo.utils, python-neutronclient
+mysqlclient==1.4.2        # via teuthology
+ndg-httpsclient==0.4.2    # via teuthology
+netaddr==0.7.19           # via oslo.config, oslo.utils, python-neutronclient, teuthology
 netifaces==0.10.5         # via oslo.utils
-nose==1.3.7
+nose==1.3.7               # via teuthology
 openstacksdk==0.9.15      # via python-openstackclient
 os-client-config==1.26.0  # via openstacksdk, osc-lib, python-neutronclient
 osc-lib==1.3.0            # via python-neutronclient, python-openstackclient
@@ -61,46 +61,46 @@ oslo.config==3.24.0       # via python-keystoneclient
 oslo.i18n==3.15.0         # via osc-lib, oslo.config, oslo.utils, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
 oslo.serialization==2.18.0  # via python-keystoneclient, python-neutronclient, python-novaclient
 oslo.utils==3.25.0        # via osc-lib, oslo.serialization, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient
-paramiko==2.7.1
+paramiko==2.7.1           # via teuthology
 pbr==2.0.0                # via cliff, debtcollector, keystoneauth1, openstacksdk, osc-lib, oslo.i18n, oslo.serialization, oslo.utils, positional, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, requestsexceptions, stevedore
-pexpect==4.7.0
-pip-tools==4.3.0
+pexpect==4.7.0            # via teuthology
+pip-tools==4.3.0          # via teuthology
 pluggy==0.7.1             # via pytest, tox
 positional==1.1.1         # via keystoneauth1, python-keystoneclient
-prettytable==0.7.2        # via cliff, python-cinderclient, python-glanceclient, python-novaclient
-psutil==5.2.2
+prettytable==0.7.2        # via cliff, python-cinderclient, python-glanceclient, python-novaclient, teuthology
+psutil==5.2.2             # via teuthology
 ptyprocess==0.5.1         # via pexpect
 py==1.5.3                 # via pytest, tox
-pyasn1==0.2.3
+pyasn1==0.2.3             # via teuthology
 pycparser==2.17           # via cffi
-pyjwt==1.7.1
+pyjwt==1.7.1              # via teuthology
 pynacl==1.3.0             # via paramiko
-pyopenssl==19.0.0         # via ndg-httpsclient
+pyopenssl==19.0.0         # via ndg-httpsclient, teuthology
 pyparsing==2.2.0          # via cliff, cmd2, oslo.utils
-pytest==3.7.1
+pytest==3.7.1             # via teuthology
 python-cinderclient==2.0.1  # via python-openstackclient
-python-dateutil==2.6.0    # via botocore
+python-dateutil==2.6.0    # via botocore, teuthology
 python-glanceclient==2.6.0  # via python-openstackclient
 python-keystoneclient==3.10.0  # via python-neutronclient, python-openstackclient
-python-neutronclient==6.2.0
-python-novaclient==8.0.0  # via python-openstackclient
-python-openstackclient==3.9.0
+python-neutronclient==6.2.0  # via teuthology
+python-novaclient==8.0.0  # via python-openstackclient, teuthology
+python-openstackclient==3.9.0  # via teuthology
 pytz==2017.2              # via babel, oslo.serialization, oslo.utils
-pyyaml==5.1.2             # via ansible, cliff, os-client-config
-raven==6.0.0
-requests==2.22.0          # via apache-libcloud, keystoneauth1, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient
+pyyaml==5.1.2             # via ansible, cliff, os-client-config, teuthology
+raven==6.0.0              # via teuthology
+requests==2.22.0          # via apache-libcloud, keystoneauth1, python-cinderclient, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, teuthology
 requestsexceptions==1.2.0  # via os-client-config
 rfc3986==0.4.1            # via oslo.config
 s3transfer==0.2.1         # via boto3
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
-six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, tox, warlock
+six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, teuthology, tox, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
-tox==3.0.0
+tox==3.0.0                # via teuthology
 urllib3==1.25.3           # via botocore, requests
 virtualenv==15.1.0        # via tox
 warlock==1.2.0            # via python-glanceclient
 wrapt==1.10.10            # via debtcollector, positional, python-glanceclient
-xmltodict==0.12.0
+xmltodict==0.12.0         # via teuthology
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
python 3.8 needs a newer cffi version. So bump it. Otherwise, calling
"./bootstrap" with python3.8 will fail.
This is also done for the python2 requirements to be in sync.

Fixes: https://tracker.ceph.com/issues/45132

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>