### PR TITLE
travis: Use bionic, no sudo and python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 env: HOME=/home/travis
 
-sudo: required
-dist: trusty
-
 before_install:
   - sudo apt-get -qq update
   - ./bootstrap install
 
 language: python
 python:
-    - 2.7
+    - 3.6
 
 install:
     - pip install tox


### PR DESCRIPTION
- switch to Ubuntu Bionic to have a recent version for testing
- Do not use sudo. That will switch from VMs to containers which
  improves build speed on travis a lot
- use python3.6 . python2 is EOL

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>