### PR TITLE
teuthology/beanstalk: use pystalkd instead of beanstalkc

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -13,7 +13,7 @@ attrs==18.1.0             # via pytest
 babel==2.4.0              # via osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-neutronclient, python-novaclient, python-openstackclient
 backports.ssl-match-hostname==3.5.0.1  # via apache-libcloud, teuthology
 bcrypt==3.1.6             # via paramiko
-beanstalkc3==0.4.0        # via teuthology
+pystalk==1.14.0           # via teuthology
 boto3==1.9.161            # via teuthology
 boto==2.46.1              # via teuthology
 botocore==1.12.161        # via boto3, s3transfer

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -13,7 +13,7 @@ attrs==18.1.0             # via pytest
 babel==2.4.0              # via osc-lib, oslo.i18n, python-cinderclient, python-glanceclient, python-neutronclient, python-novaclient, python-openstackclient
 backports.ssl-match-hostname==3.5.0.1  # via teuthology
 bcrypt==3.1.6             # via paramiko
-beanstalkc3==0.4.0        # via teuthology
+pystalk==1.14.0           # via teuthology
 boto3==1.9.161            # via teuthology
 boto==2.46.1              # via teuthology
 botocore==1.12.161        # via boto3, s3transfer

--- a/teuthology/beanstalk.py
+++ b/teuthology/beanstalk.py
@@ -1,4 +1,4 @@
-import beanstalkc
+from pystalk.client
 import yaml
 import logging
 import pprint
@@ -18,7 +18,7 @@ def connect():
         raise RuntimeError(
             'Beanstalk queue information not found in {conf_path}'.format(
                 conf_path=config.teuthology_yaml))
-    return beanstalkc.Connection(host=host, port=port)
+    return pystalk.client.BeanstalkClient(host=host, port=port)
 
 
 def watch_tube(connection, tube_name):

--- a/teuthology/schedule.py
+++ b/teuthology/schedule.py
@@ -88,10 +88,10 @@ def schedule_job(job_config, num=1):
     beanstalk = teuthology.beanstalk.connect()
     beanstalk.use(tube)
     while num > 0:
-        jid = beanstalk.put(
+        jid = beanstalk.put_job(
             job,
             ttr=60 * 60 * 24,
-            priority=job_config['priority'],
+            pri=job_config['priority'],
         )
         print('Job scheduled with name {name} and ID {jid}'.format(
             name=job_config['name'], jid=jid))


### PR DESCRIPTION
For some python3.X version the beanstalkc is not support, and the
pystalkd is compatible for python 3.X.

Signed-off-by: Xiubo Li <xiubli@redhat.com>