### PR TITLE
orchestra/remote.py: to be compatible with py3

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -17,6 +17,7 @@ import time
 import re
 import logging
 from io import BytesIO
+from io import StringIO
 import os
 import pwd
 import tempfile
@@ -448,7 +449,8 @@ class Remote(object):
     def os(self):
         if not hasattr(self, '_os'):
             try:
-                os_release = self.sh('cat /etc/os-release').strip()
+                os_release = self.sh('cat /etc/os-release',
+                                     stdout=StringIO()).strip()
                 self._os = OS.from_os_release(os_release)
                 return self._os
             except CommandFailedError:


### PR DESCRIPTION
```
ERROR: test_filelock (tasks.cephfs.test_client_recovery.TestClientRecovery)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/ceph/qa/tasks/cephfs/test_client_recovery.py", line 387, in test_filelock
    flockable = self._is_flockable()
  File "/data/ceph/qa/tasks/cephfs/test_client_recovery.py", line 361, in _is_flockable
    a_version_str = get_package_version(self.mount_a.client_remote, "fuse")
  File "/data/teuthology/teuthology/packaging.py", line 354, in get_package_version
    if remote.os.package_type == "deb":
  File "/data/teuthology/teuthology/orchestra/remote.py", line 452, in os
    self._os = OS.from_os_release(os_release)
  File "/data/teuthology/teuthology/orchestra/opsys.py", line 161, in from_os_release
    name = cls._get_value(str_, 'ID').lower()
  File "/data/teuthology/teuthology/orchestra/opsys.py", line 204, in _get_value
    match = re.search(regex, str_, flags=re.M)
  File "/usr/lib64/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object
```

Signed-off-by: Xiubo Li <xiubli@redhat.com>