### PR TITLE
cephadmunit: Python3 fix: signal.SIGHUP is no longer an int.

### DIFF
--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -36,7 +36,7 @@ class CephadmUnit(DaemonState):
     def kill_cmd(self, sig):
         return ' '.join([
             'sudo', 'docker', 'kill',
-            '-s', str(sig),
+            '-s', str(int(sig)),
             'ceph-%s-%s.%s' % (self.fsid, self.type_, self.id_),
         ])
 


### PR DESCRIPTION
py2: `str(signal.SIGHUP) == "1"`
py3: `str(signal.SIGHUP) == "signal.SIGHUP"`

Fixes: https://tracker.ceph.com/issues/45297

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>