### PR TITLE
teuthology/orchestra/remote.py: write remote file without sudo

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -415,10 +415,11 @@ class Remote(object):
         args.extend([
             'tar',
             'cz',
-            '-f', remote_temp_path,
+            '-f', '-',
             '-C', path,
             '--',
             '.',
+            run.Raw('>'), remote_temp_path
             ])
         self.run(args=args)
         if sudo:


### PR DESCRIPTION
the remote file is created using "ubuntu" user. in ubuntu xenial,
superuser is able to write to that file using tar, it seems that "tar"
starts another process when writing to the dest file specified by "-f",
and that process does not have the privilege for writing that file.

so when we are trying to archive a directory on ubuntu/focal test node,
we have following error:
```
tar (child): /tmp/tmp.vkl0kAtc06: Cannot open: Permission denied
tar (child): Error is not recoverable: exiting now
tar: /tmp/tmp.vkl0kAtc06: Cannot write: Broken pipe
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

and this is reproduciable with tar 1.30:
```
$ touch /tmp/helloworld
$ mkdir /tmp/foobar
$ sudo tar czf /tmp/helloworld -C /tmp/foobar -- .
tar (child): /tmp/helloworld: Cannot open: Permission denied
tar (child): Error is not recoverable: exiting now
tar: /tmp/helloworld: Cannot write: Broken pipe
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

but we can workaround this by writing the temp file using "ubuntu" user, like
```
sudo tar czf - -C /tmp/foobar -- . > /tmp/helloworld
```

Signed-off-by: Kefu Chai <kchai@redhat.com>