### PR TITLE
fix some old flake8 issues

### DIFF
--- a/scripts/queue.py
+++ b/scripts/queue.py
@@ -28,7 +28,7 @@ optional arguments:
   -p, --pause SECONDS   Pause queues for a number of seconds. A value of 0
                         will unpause. If -m is passed, pause that queue,
                         otherwise pause all queues.
-""".format(archive_base=teuthology.config.config.archive_base)
+"""
 
 
 def main():

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1063,7 +1063,7 @@ def get_valgrind_args(testdir, name, preamble, v):
         'env', 'OPENSSL_ia32cap=~0x1000000000000000',
     ])
 
-    val_path = '/var/log/ceph/valgrind'.format(tdir=testdir)
+    val_path = '/var/log/ceph/valgrind'
     if '--tool=memcheck' in v or '--tool=helgrind' in v:
         extra_args = [
             'valgrind',

--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -274,8 +274,7 @@ class PhysicalConsole(RemoteConsole):
         child = self._pexpect_spawn_ipmi('power on')
         child.expect('Chassis Power Control: Up/On', timeout=self.timeout)
         self._wait_for_login()
-        log.info('Power off for {i} seconds completed'.format(
-            s=self.shortname, i=interval))
+        log.info('Power off for {i} seconds completed'.format(i=interval))
 
     def spawn_sol_log(self, dest_path):
         """
@@ -385,5 +384,4 @@ class VirtualConsole(RemoteConsole):
         self.vm_domain.info().destroy()
         time.sleep(interval)
         self.vm_domain.info().create()
-        log.info('Power off for {i} seconds completed'.format(
-            s=self.shortname, i=interval))
+        log.info('Power off for {i} seconds completed'.format(i=interval))


### PR DESCRIPTION
For now fixes only flake8 issues seen in new versions, we could as well get rid of flake8 check with py2 but thats up for another discussion.

As seen during flake8 debug

```
flake8 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021
```

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>