### PR TITLE
teuthology/orchestra: open log file in Python3 way

### DIFF
--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -285,7 +285,7 @@ class PhysicalConsole(RemoteConsole):
         """
         pexpect_templ = \
             "import pexpect; " \
-            "pexpect.run('{cmd}', logfile=file('{log}', 'w'), timeout=None)"
+            "pexpect.run('{cmd}', logfile=open('{log}', 'wb'), timeout=None)"
 
         def start():
             console_cmd = self._console_command()


### PR DESCRIPTION
otherwise we could have
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
NameError: name 'file' is not defined
```

Fixes: https://tracker.ceph.com/issues/45512
Signed-off-by: Kefu Chai <kchai@redhat.com>