### PR TITLE
suite: schedule first and last in suite jobs once

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -294,7 +294,6 @@ class Run(object):
     def build_base_args(self):
         base_args = [
             '--name', self.name,
-            '--num', str(self.args.num),
             '--worker', util.get_worker(self.args.machine_type),
         ]
         if self.args.dry_run:
@@ -411,6 +410,7 @@ class Run(object):
 
             arg = copy.deepcopy(self.base_args)
             arg.extend([
+                '--num', str(self.args.num),
                 '--description', description,
                 '--',
             ])

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -250,6 +250,7 @@ class TestScheduleSuite(object):
         # schedule_jobs() is just neutered; check calls below
 
         self.args.newest = 0
+        self.args.num = 42
         runobj = self.klass(self.args)
         runobj.base_args = list()
         count = runobj.schedule_suite()
@@ -263,6 +264,8 @@ class TestScheduleSuite(object):
             yaml=yaml.safe_load('\n'.join(frags)),
             sha1='ceph_sha1',
             args=[
+                '--num',
+                '42',
                 '--description',
                 os.path.join(self.args.suite, build_matrix_desc),
                 '--',


### PR DESCRIPTION
Only schedule --first-in-suite and --last-in-suite jobs
once per run when --num is provided for a teuthology-suite.

Fixes: https://tracker.ceph.com/issues/45520

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>