### PR TITLE
teuthology/run_tasks: do not call sys.exc_clear() for clearing exception

### DIFF
--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -187,7 +187,6 @@ def run_tasks(tasks, ctx):
                         interactive.task(ctx=ctx, config=None)
                 else:
                     if suppress:
-                        sys.exc_clear()
                         exc_info = (None, None, None)
 
             if exc_info != (None, None, None):


### PR DESCRIPTION
sys.exc_clear() was removed in Python3, see
https://docs.python.org/3/whatsnew/3.0.html#index-22. so we should not
call it.

Signed-off-by: Kefu Chai <kchai@redhat.com>