### PR TITLE
backport: orchestra/connection: add retry exceptions

### DIFF
--- a/scripts/queue.py
+++ b/scripts/queue.py
@@ -28,7 +28,7 @@ optional arguments:
   -p, --pause SECONDS   Pause queues for a number of seconds. A value of 0
                         will unpause. If -m is passed, pause that queue,
                         otherwise pause all queues.
-""".format(archive_base=teuthology.config.config.archive_base)
+"""
 
 
 def main():

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1063,7 +1063,7 @@ def get_valgrind_args(testdir, name, preamble, v):
         'env', 'OPENSSL_ia32cap=~0x1000000000000000',
     ])
 
-    val_path = '/var/log/ceph/valgrind'.format(tdir=testdir)
+    val_path = '/var/log/ceph/valgrind'
     if '--tool=memcheck' in v or '--tool=helgrind' in v:
         extra_args = [
             'valgrind',

--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -4,12 +4,22 @@ Connection utilities
 import base64
 import paramiko
 import os
+import socket
 import logging
+
+from paramiko import AuthenticationException
+from paramiko.ssh_exception import NoValidConnectionsError
 
 from teuthology.config import config
 from teuthology.contextutil import safe_while
 
 log = logging.getLogger(__name__)
+
+RECONNECT_EXCEPTIONS = (
+  socket.error,
+  AuthenticationException,
+  NoValidConnectionsError,
+)
 
 
 def split_user(user_at_host):
@@ -107,8 +117,14 @@ def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,
                 try:
                     ssh.connect(**connect_args)
                     break
-                except paramiko.AuthenticationException:
-                    log.exception(
-                        "Error connecting to {host}".format(host=host))
+                except RECONNECT_EXCEPTIONS as e:
+                    log.debug("Error connecting to {host}: {e}".format(host=host,e=e))
+                except Exception as e:
+                    # gevent.__hub_primitives returns a generic Exception, *sigh*
+                    if "timed out" in str(e):
+                        log.debug("Error connecting to {host}: {e}".format(host=host,e=e))
+                    else:
+                        raise
+
     ssh.get_transport().set_keepalive(keep_alive)
     return ssh

--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -274,8 +274,7 @@ class PhysicalConsole(RemoteConsole):
         child = self._pexpect_spawn_ipmi('power on')
         child.expect('Chassis Power Control: Up/On', timeout=self.timeout)
         self._wait_for_login()
-        log.info('Power off for {i} seconds completed'.format(
-            s=self.shortname, i=interval))
+        log.info('Power off for {i} seconds completed'.format(i=interval))
 
     def spawn_sol_log(self, dest_path):
         """
@@ -385,5 +384,4 @@ class VirtualConsole(RemoteConsole):
         self.vm_domain.info().destroy()
         time.sleep(interval)
         self.vm_domain.info().create()
-        log.info('Power off for {i} seconds completed'.format(
-            s=self.shortname, i=interval))
+        log.info('Power off for {i} seconds completed'.format(i=interval))


### PR DESCRIPTION
Typical connection errors would cause a command to fail.

Fixes: https://tracker.ceph.com/issues/45438

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>
(cherry picked from commit 1e30d6f624921ae98c27981d55e06c29d1b0fdd0)