### PR TITLE
docs: acknowledge py2 and py3 where requirements.txt is mentioned

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.rst
-include requirements.txt
+include requirements2.txt
+include requirements3.txt

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -33,14 +33,15 @@ First install the non-PyPI dependencies::
 
 Next, clone its `git repository <https://github.com/ceph/teuthology/>`__,
 create a `virtualenv <http://virtualenv.readthedocs.org/en/latest/>`__, and
-install dependencies::
+install dependencies. For python3, the instructions are given below. For
+python2, replace the ``requirements3.txt`` with ``requirements2.txt`` ::
 
     git clone https://github.com/ceph/teuthology/
     cd teuthology
     virtualenv ./virtualenv
     source virtualenv/bin/activate
     pip install --upgrade pip
-    pip install -r requirements.txt
+    pip install -r requirements3.txt
     python setup.py develop
 
 
@@ -65,11 +66,12 @@ interacting with the services to schedule tests and to report the test results.
 Update Dependencies
 -------------------
 
-We track the dependencies using ``requirements.txt``. These packages are tested,
-and should work with teuthology. But if you want to bump up the versions of them,
-please use the following command to update this file ::
+We track the dependencies using ``requirements2.txt`` and ``requirements3.txt`` 
+for python2 and python3 respectively. These packages are tested, and should work 
+with teuthology. But if you want to bump up the versions of them, please use the 
+following command to update these files. For python3 ::
 
-  pip-compile -qo- | sed '/^-e / d' > requirements.txt
+  pip-compile -qo- | sed '/^-e / d' > requirements3.txt
 
 Please upgrade pip-tool using following command ::
 


### PR DESCRIPTION
This PR removes mention of deleted file `requirements.txt` and
acknowledges the two separate requirements files, `requirements2.txt`
and `requirements3.txt`, for python2 and python3 respectively, in the
following files:

1.` MANIFEST.in`
2. `docs/INSTALL.rst`

I found the mention of `requirements.txt` in `teuthology/openstack/setup-openstack.sh`, but I wasn't entirely sure how to rectify that.