### PR TITLE
suite/build_matrix: get rid of '.yaml' in descriptions

### DIFF
--- a/teuthology/suite/build_matrix.py
+++ b/teuthology/suite/build_matrix.py
@@ -185,7 +185,7 @@ def generate_combinations(path, mat, generate_from, generate_to):
     for i in range(generate_from, generate_to):
         output = mat.index(i)
         ret.append((
-            matrix.generate_desc(combine_path, output),
+            matrix.generate_desc(combine_path, output).replace('.yaml', ''),
             matrix.generate_paths(path, output, combine_path)))
     return ret
 

--- a/teuthology/suite/test/test_build_matrix.py
+++ b/teuthology/suite/test/test_build_matrix.py
@@ -637,9 +637,9 @@ class TestSubset(object):
                     sub_max_facets, max_fanout,
                     max_depth - 1, namegen, top=False)
                 if subtree is not None:
-                    tree[next(namegen)] = subtree
+                    tree['d' + next(namegen)] = subtree
                 else:
-                    tree[yamilify(next(namegen))] = None
+                    tree[yamilify('f' + next(namegen))] = None
             random.choice([
                 lambda: tree.update({'%': None}),
                 lambda: None])()
@@ -680,7 +680,12 @@ class TestSubset(object):
                     ret += ('\t'*tabs) + (k + ':').ljust(10) + "\n"
                     ret += pptree(v, tabs+1)
             return ret
-        for facet in flatten(tree):
+        def deyamlify(name):
+            if name.endswith('.yaml'):
+                return name[:-5]
+            else:
+                return name
+        for facet in (deyamlify(_) for _ in flatten(tree)):
             found = False
             for i in description_list:
                 if facet in i:


### PR DESCRIPTION
Test descriptions have structured representation of yaml
fragments the test config is composed from. Although
having the .yaml extentions in the description looks
redundant and has no use in the code.
It worth to say that no other files except yaml
participate in description composition.

This change removes many '.yaml' sufixes from
descriptions which make it more compact and easy
to read.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>