### PR TITLE
Changed the import of mock to unittest.mock

### DIFF
--- a/teuthology/test/test_exit.py
+++ b/teuthology/test/test_exit.py
@@ -2,7 +2,7 @@ import os
 import random
 import signal
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from teuthology import exit
 

--- a/teuthology/test/test_exit.py
+++ b/teuthology/test/test_exit.py
@@ -22,6 +22,9 @@ class TestExiter(object):
             wraps=os.kill,
         )
 
+        #Keep a copy of the unpatched kill and call this in place of os.kill
+        #In the Exiter objects, the os.kill calls are patched.
+        #So the call_count should be 1.
         self.kill_unpatched = os.kill
         self.m_kill = self.patcher_kill.start()
 

--- a/teuthology/test/test_exit.py
+++ b/teuthology/test/test_exit.py
@@ -22,6 +22,7 @@ class TestExiter(object):
             wraps=os.kill,
         )
 
+        self.kill_unpatched = os.kill
         self.m_kill = self.patcher_kill.start()
 
         def m_kill_unwrap(pid, sig):
@@ -47,9 +48,9 @@ class TestExiter(object):
         m_func = Mock()
         obj.add_handler(sig, m_func)
         assert len(obj.handlers) == 1
-        os.kill(self.pid, sig)
+        self.kill_unpatched(self.pid, sig)
         assert m_func.call_count == 1
-        assert self.m_kill.call_count == 2
+        assert self.m_kill.call_count == 1
         for arg_list in self.m_kill.call_args_list:
             assert arg_list[0] == (self.pid, sig)
 
@@ -66,8 +67,8 @@ class TestExiter(object):
         for handler in handlers:
             handler.remove()
         assert obj.handlers == list()
-        os.kill(self.pid, send_sig)
-        assert self.m_kill.call_count == 2
+        self.kill_unpatched(self.pid, send_sig)
+        assert self.m_kill.call_count == 1
         for handler in handlers:
             assert handler.func.call_count == 0
 
@@ -82,10 +83,10 @@ class TestExiter(object):
             m_func = Mock(name="handler %s" % i)
             handlers.append(obj.add_handler(sig, m_func))
         assert obj.handlers == handlers
-        os.kill(self.pid, send_sig)
+        self.kill_unpatched(self.pid, send_sig)
         for i in range(n):
             assert handlers[i].func.call_count == 1
-        assert self.m_kill.call_count == 2
+        assert self.m_kill.call_count == 1
         for arg_list in self.m_kill.call_args_list:
             assert arg_list[0] == (self.pid, send_sig)
 

--- a/teuthology/test/test_ls.py
+++ b/teuthology/test/test_ls.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from teuthology import ls
 

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -1,7 +1,7 @@
 import argparse
 from datetime import datetime
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from teuthology.orchestra import cluster
 from teuthology.config import config
 from teuthology import misc

--- a/teuthology/test/test_nuke.py
+++ b/teuthology/test/test_nuke.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import subprocess
 
-from mock import patch, Mock, DEFAULT
+from unittest.mock import patch, Mock, DEFAULT
 
 from teuthology import nuke
 from teuthology import misc

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from teuthology import packaging
 from teuthology.exceptions import VersionNotFoundError

--- a/teuthology/test/test_repo_utils.py
+++ b/teuthology/test/test_repo_utils.py
@@ -1,5 +1,5 @@
 import logging
-import mock
+import unittest.mock as mock
 import os
 import os.path
 from pytest import raises, mark

--- a/teuthology/test/test_results.py
+++ b/teuthology/test/test_results.py
@@ -3,7 +3,7 @@ from teuthology.config import config
 from teuthology import results
 from teuthology import report
 
-from mock import patch, DEFAULT
+from unittest.mock import patch, DEFAULT
 
 
 class TestResultsEmail(object):

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -1,7 +1,7 @@
 import pytest
 import docopt
 
-from mock import patch, call, Mock
+from unittest.mock import patch, call, Mock
 
 from teuthology import run
 from scripts import run as scripts_run

--- a/teuthology/test/test_timer.py
+++ b/teuthology/test/test_timer.py
@@ -1,6 +1,6 @@
 from teuthology import timer
 
-from mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch, mock_open
 from time import time
 
 

--- a/teuthology/test/test_vps_os_vers_parameter_checking.py
+++ b/teuthology/test/test_vps_os_vers_parameter_checking.py
@@ -1,4 +1,4 @@
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 import teuthology.lock.util
 from teuthology import provision

--- a/teuthology/test/test_worker.py
+++ b/teuthology/test/test_worker.py
@@ -1,7 +1,7 @@
 import beanstalkc
 import os
 
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 from datetime import datetime, timedelta
 
 from teuthology import worker


### PR DESCRIPTION
Since Python 3.3, mock is a part of the Python Standard Library.
Importing it directly as `unittest.mock` reduces a 3rd party dependency.

Reference: https://mock.readthedocs.io/en/latest/

Signed-off-by: Shubham Mishra <smishra99.iitkgp@gmail.com>