### PR TITLE
teuthology-suite: automate -t argument default value

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -54,7 +54,13 @@ Standard arguments:
                               [default: basic]
   -t <branch>, --teuthology-branch <branch>
                               The teuthology branch to run against.
-                              [default: {default_teuthology_branch}]
+                              Default value is determined in the next order.
+                              There is TEUTH_BRANCH environment variable set.
+                              There is `qa/.teuthology_branch` present in
+                              the suite repo and contains non-empty string.
+                              There is `teuthology_branch` present in one of
+                              the user or system `teuthology.yaml` configuration
+                              files respectively, otherwise use `master`.
   -m <type>, --machine-type <type>
                               Machine type [default: {default_machine_type}]
   -d <distro>, --distro <distro>
@@ -165,7 +171,6 @@ Scheduler arguments:
     default_suite_repo=defaults('--suite-repo',
                             config.get_ceph_qa_suite_git_url()),
     default_ceph_branch=defaults('--ceph-branch', 'master'),
-    default_teuthology_branch=defaults('--teuthology-branch', 'master'),
 )
 
 

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -25,7 +25,6 @@ def override_arg_defaults(name, default, env=os.environ):
         '--suite-repo'        : 'TEUTH_SUITE_REPO',
         '--ceph-branch'       : 'TEUTH_CEPH_BRANCH',
         '--suite-branch'      : 'TEUTH_SUITE_BRANCH',
-        '--teuthology-branch' : 'TEUTH_BRANCH',
     }
     if name in env_arg and env_arg[name] in env.keys():
         variable = env_arg[name]

--- a/teuthology/suite/test/test_init.py
+++ b/teuthology/suite/test/test_init.py
@@ -156,6 +156,9 @@ class TestSuiteMain(object):
         def fake_bool(*args, **kwargs):
             return True
 
+        def fake_false(*args, **kwargs):
+            return False
+
         with patch.multiple(
                 'teuthology.suite.run.util',
                 fetch_repos=DEFAULT,
@@ -166,6 +169,9 @@ class TestSuiteMain(object):
             with patch.multiple(
                 'teuthology.suite.run.Run',
                 prepare_and_schedule=prepare_and_schedule,
+            ), patch.multiple(
+                'teuthology.suite.run.os.path',
+                exists=fake_false,
             ):
                 main([
                     '--ceph', 'master',

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -145,8 +145,10 @@ class TestRun(object):
     @patch('teuthology.suite.run.util.git_branch_exists')
     @patch('teuthology.suite.run.util.package_version_for_hash')
     @patch('teuthology.suite.run.util.git_ls_remote')
+    @patch('teuthology.suite.run.os.path.exists')
     def test_regression(
         self,
+        m_qa_teuthology_branch_exists,
         m_git_ls_remote,
         m_package_version_for_hash,
         m_git_branch_exists,
@@ -157,6 +159,7 @@ class TestRun(object):
         m_package_version_for_hash.return_value = 'ceph_hash'
         m_git_branch_exists.return_value = True
         m_git_ls_remote.return_value = "suite_branch"
+        m_qa_teuthology_branch_exists.return_value = False
         self.args_dict = {
             'base_yaml_paths': [],
             'ceph_branch': 'master',


### PR DESCRIPTION
This change is required to determine which teuthology
branch should be used for scheduling a run for the
given ceph branch.

In order to enable the functionality of this patch we need
submit and merge `qa/.teuthology` to ceph `master` 
with following content:
```
# cherry-pick this for py3 ready branches
teuthology_branch: master
```
And add to `/etc/teuthology.yaml` on sepia server the line
```
# remove this line when all ceph branches get py3 compatible qa tasks
teuthology_branch: py2
```
Obviously, all users have to update their teuthology sandboxes.
As far as other branches 
