### PR TITLE
docs: add docs.ceph.com link in README.rst

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -109,6 +109,8 @@ jewel kernel, with a 'basic' kernel flavor, and the teuthology jewel branch
 will be used.  It will run on mira machines and send an email to
 bob.smith@foo.com when it's completed. For more details on
 ``teuthology-suite``, please consult the output of ``teuthology-suite --help``.
+Read more about running integration tests using teuthology at `docs.ceph.com
+<http://docs.ceph.com/docs/master/dev/developer_guide/running-tests-using-teuth/>`__.
 
 In order for a queued task to be run, a teuthworker thread on
 ``teuthology.front.sepia.ceph.com`` needs to remove the task from the queue.


### PR DESCRIPTION
This commit adds a hyperlink to [Running Integration Tests Using
Teuthology](https://docs.ceph.com/docs/master/dev/developer_guide/running-tests-using-teuth/) in docs/README.rst under the section Test Suites.

Signed-off-by: Shraddha Agrawal <shraddha.agrawal000@gmail.com>