### PR TITLE
py2: setup.py: add toml for qa/tasks/cephadm.py

### DIFF
--- a/requirements2.txt
+++ b/requirements2.txt
@@ -102,6 +102,7 @@ scandir==1.8              # via pathlib2
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
 six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pathlib2, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, teuthology, tox, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
+toml==0.10.1              # via teuthology
 tox==3.0.0                # via teuthology
 typing==3.7.4.1           # via apache-libcloud
 unicodecsv==0.14.1        # via cliff

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -95,6 +95,7 @@ s3transfer==0.2.1         # via boto3
 simplejson==3.10.0        # via osc-lib, python-cinderclient, python-neutronclient, python-novaclient
 six==1.14.0               # via bcrypt, cliff, cmd2, configobj, cryptography, debtcollector, keystoneauth1, more-itertools, openstacksdk, osc-lib, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-glanceclient, python-keystoneclient, python-neutronclient, python-novaclient, python-openstackclient, stevedore, teuthology, tox, warlock
 stevedore==1.21.0         # via cliff, keystoneauth1, openstacksdk, osc-lib, oslo.config, python-keystoneclient
+toml==0.10.1              # via teuthology
 tox==3.0.0                # via teuthology
 urllib3==1.25.3           # via botocore, requests
 virtualenv==15.1.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
             'boto3',
             'PyJWT',            # for qa/tasks/mgr/dashboard/test_auth.py
             'ipy',              # for qa/tasks/cephfs/mount.py
+            'toml',             # for qa/tasks/cephadm.py
         ]
     },
 


### PR DESCRIPTION
podman's /etc/containers/registries.conf is written
in toml. In order to modify it, we need to parse the
config.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
(cherry picked from commit 86baa47a507f9c171b6722422aea3011b38d1b25)

I need this to unstuck https://github.com/ceph/ceph/pull/35188