### PR TITLE
console.py: Wait longer for IPMI timeouts

### DIFF
--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -35,7 +35,7 @@ class PhysicalConsole(RemoteConsole):
     Physical Console (set from getRemoteConsole)
     """
     def __init__(self, name, ipmiuser=None, ipmipass=None, ipmidomain=None,
-                 logfile=None, timeout=20):
+                 logfile=None, timeout=40):
         self.name = name
         self.shortname = self.getShortName(name)
         self.timeout = timeout


### PR DESCRIPTION
The smithi have really crappy/flaky BMCs.  I occasionally see `'wait for power on' reached maximum tries (5) after waiting for 20.0 seconds` but when I go to check the BMC, it just needed some more time.  So let's give it more time.

Signed-off-by: David Galloway <dgallowa@redhat.com>