### PR TITLE
teuthology/config: Add container_images to site configs.

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -242,3 +242,15 @@ Here is a sample configuration with many of the options set and documented::
     pelagos:
       endpoint: http://head.ses.suse.de:5000/
       machine_types: ['type1', 'type2', 'type3']
+
+    # Defines the bases for container images
+    container_images:
+      # This is a read-only mirror to limit the number of requests for downloading
+      # prometheus, grafana, node-exporter and alertmanager. Typically, this is a mirror
+      # for docker.io, but could be a mirror for any search registry, as the images are
+      # referenced without an explicit registry name.
+      base_registry_mirror: 'vossi04.front.sepia.ceph.com:5000'
+
+      # Container image name for CI images.
+      ci_image: 'quay.io/ceph-ci/ceph'
+

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -186,6 +186,10 @@ class TeuthologyConfig(YamlConfig):
             },
         },
         'sleep_before_teardown': 0,
+        'container_images': {
+            'base_registry_mirror': 'vossi04.front.sepia.ceph.com:5000',
+            'ci_image': 'quay.io/ceph-ci/ceph'
+        }
     }
 
     def __init__(self, yaml_path=None):


### PR DESCRIPTION
Every teuthology installation needs to have a different mirror for docker.io and
for the CI images. This means we shoudn't put the configs into any ceph git repos,
but instead in the site configs.

Later, if this is also backported to py2, we can then change the container sources for all branches at once.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

See https://github.com/ceph/ceph/pull/35308 for the ceph side