### PR TITLE
tox: Avoid system site-packages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = docs, py3, py27, py27-integration, flake8, flake8-py3, openstack
 [testenv:py27]
 install_command = pip install --upgrade {opts} {packages}
 passenv = HOME
-sitepackages=True
 deps=
   -r{toxinidir}/requirements2.txt
   mock==2.0.0
@@ -13,14 +12,13 @@ deps=
   coverage==4.5.4
 
 commands=
-    py.test --cov=teuthology --cov-report=term -v {posargs:teuthology scripts}
+    python -m pytest --cov=teuthology --cov-report=term -v {posargs:teuthology scripts}
 
 
 [testenv:py3]
 basepython=python3
 install_command = pip install --upgrade {opts} {packages}
 passenv = HOME
-sitepackages=True
 deps=
   -r{toxinidir}/requirements3.txt
   mock==2.0.0
@@ -29,7 +27,7 @@ deps=
   coverage==4.5.4
 
 commands=
-    py.test --cov=teuthology --cov-report=term -v {posargs:teuthology scripts}
+    python -m pytest --cov=teuthology --cov-report=term -v {posargs:teuthology scripts}
 
 
 [testenv:py27-integration]


### PR DESCRIPTION
This fixes a failure to locate `py.test` using python3 on MacOS:
```
py3 runtests: commands[0] | py.test --cov=teuthology --cov-report=term -v teuthology scripts
Traceback (most recent call last):
  File "/Users/zack/dev/teuthology/.tox/py3/bin/py.test", line 5, in <module>
    from pytest import main
ModuleNotFoundError: No module named 'pytest'
```