### PR TITLE
adjust-ulimits: use a larger numbers for open files

### DIFF
--- a/teuthology/task/install/adjust-ulimits
+++ b/teuthology/task/install/adjust-ulimits
@@ -8,7 +8,7 @@ set -e
 if [ "$USER" = "root" ]
 then
     # Enable large number of open files
-    ulimit -n 16384
+    ulimit -n 65536
 fi
 
 # Enable core dumps for everything


### PR DESCRIPTION
For some cephfs test case it will run handreds of threads and with
some mounts in each, we need a larger limit on the number of open
file descriptors.

Fixes: https://tracker.ceph.com/issues/45829
Signed-off-by: Xiubo Li <xiubli@redhat.com>