### PR TITLE
nuke: s/yaml.load/yaml.safe_load/

### DIFF
--- a/teuthology/nuke/__init__.py
+++ b/teuthology/nuke/__init__.py
@@ -185,7 +185,7 @@ def main(args):
         ifn = os.path.join(ctx.archive, 'info.yaml')
         if os.path.exists(ifn):
             with open(ifn, 'r') as fd:
-                info = yaml.load(fd.read())
+                info = yaml.safe_load(fd.read())
         if not ctx.pid:
             ctx.pid = info.get('pid')
             if not ctx.pid:


### PR DESCRIPTION
to silence following warning:

YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

Signed-off-by: Kefu Chai <kchai@redhat.com>