### PR TITLE
drop requirements.in

### DIFF
--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -68,9 +68,9 @@ Update Dependencies
 We track the dependencies using ``requirements.txt`` 
 for python2 and python3 respectively. These packages are tested, and should work 
 with teuthology. But if you want to bump up the versions of them, please use the 
-following command to update these files. For python3 ::
+following command to update these files::
 
-  pip-compile -qo- | sed '/^-e / d' > requirements.txt
+  ./update-requirements.sh
 
 Please upgrade pip-tool using following command ::
 

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -65,10 +65,9 @@ interacting with the services to schedule tests and to report the test results.
 Update Dependencies
 -------------------
 
-We track the dependencies using ``requirements.txt`` 
-for python2 and python3 respectively. These packages are tested, and should work 
-with teuthology. But if you want to bump up the versions of them, please use the 
-following command to update these files::
+We track the dependencies using ``requirements.txt`` . These packages are
+tested, and should work  with teuthology. But if you want to bump up the
+versions of them, please use the following command to update these files::
 
   ./update-requirements.sh
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,0 @@
--e .[orchestra,test]

--- a/update-requirements.sh
+++ b/update-requirements.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "-e .[orchestra,test]" | pip-compile - -qo- | sed '/^-e / d' > requirements.txt


### PR DESCRIPTION
dependabot adds an entry in generated requirements.txt like
```
-e file:///home/dependabot/dependabot-updater/tmp/dependabot_20200617-72-1n8af4b  # via -r requirements.in
```

this is expected. as dependabot does not read docs/INSTALL.rst, hence
failed to apply `sed '/^-e / d'` to the generated file.

instead of teaching dependabot to read the manual, it's simpler
just ditch requirements.in .

see also #1367

Signed-off-by: Kefu Chai <kchai@redhat.com>