### PR TITLE
teuthology/task/clock: increase timeout

### DIFF
--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -49,7 +49,7 @@ def task(ctx, config):
                 run.Raw('||'),
                 'true'
             ],
-            timeout = 60,
+            timeout = 360,
         )
 
     try:


### PR DESCRIPTION
Increase timeout because 1 minute is not always enough
to configure ntp.

This is fixing the bug introduced with f054b20


Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>