### PR TITLE
Fix regex for 'ps -ef' in SystemDState::pid()

### DIFF
--- a/teuthology/orchestra/daemon/systemd.py
+++ b/teuthology/orchestra/daemon/systemd.py
@@ -106,7 +106,7 @@ class SystemDState(DaemonState):
         # process regex to match RADOSGW process command string
         # eg. "/usr/bin/radosgw -f --cluster ceph --name <daemon-id=self.id_>"
         if self.type_ == "rgw":
-            proc_regex = "{}.* --name .*{}".format(self.daemon_type, self.id_)
+            proc_regex = '"{}.*--name.*{}"'.format(self.daemon_type, self.id_)
 
         args = ['ps', '-ef',
                 run.Raw('|'),

--- a/teuthology/orchestra/test/files/daemon-systemdstate-pid-ps-ef.output
+++ b/teuthology/orchestra/test/files/daemon-systemdstate-pid-ps-ef.output
@@ -1,0 +1,5 @@
+ceph       658     1  0 Jun08 ?        00:07:43 /usr/bin/ceph-mgr -f --cluster ceph --id host1 --setuser ceph --setgroup ceph
+ceph      1634     1  0 Jun08 ?        00:02:17 /usr/bin/ceph-mds -f --cluster ceph --id host1 --setuser ceph --setgroup ceph
+ceph     31555     1  0 Jun08 ?        01:13:50 /usr/bin/ceph-mon -f --cluster ceph --id host1 --setuser ceph --setgroup ceph
+ceph     31765     1  0 Jun08 ?        00:48:42 /usr/bin/radosgw -f --cluster ceph --name client.rgw.host1.rgw0 --setuser ceph --setgroup ceph
+ceph     97427     1  0 Jun17 ?        00:41:39 /usr/bin/ceph-osd -f --cluster ceph --id 0 --setuser ceph --setgroup ceph

--- a/teuthology/orchestra/test/test_systemd.py
+++ b/teuthology/orchestra/test/test_systemd.py
@@ -1,0 +1,54 @@
+import argparse
+import os
+
+from logging import debug
+from teuthology import misc
+from teuthology.orchestra import cluster
+from teuthology.orchestra.run import quote
+from teuthology.orchestra.daemon.group import DaemonGroup
+import subprocess
+
+
+class FakeRemote(object):
+    pass
+
+
+def test_pid():
+    ctx = argparse.Namespace()
+    ctx.daemons = DaemonGroup(use_systemd=True)
+    remote = FakeRemote()
+
+    ps_ef_output_path = os.path.join(
+        os.path.dirname(__file__),
+        "files/daemon-systemdstate-pid-ps-ef.output"
+    )
+
+    # patching ps -ef command output using a file
+    def sh(args):
+        args[0:2] = ["cat", ps_ef_output_path]
+        debug(args)
+        return subprocess.getoutput(quote(args))
+
+    remote.sh = sh
+    remote.init_system = 'systemd'
+    remote.shortname = 'host1'
+
+    ctx.cluster = cluster.Cluster(
+        remotes=[
+            (remote, ['rgw.0', 'mon.a', 'mgr.a', 'mds.a', 'osd.0'])
+        ],
+    )
+
+    for remote, roles in ctx.cluster.remotes.items():
+        for role in roles:
+            _, rol, id_ = misc.split_role(role)
+            if any(rol.startswith(x) for x in ['mon', 'mgr', 'mds']):
+                ctx.daemons.register_daemon(remote, rol, remote.shortname)
+            else:
+                ctx.daemons.register_daemon(remote, rol, id_)
+
+    for _, daemons in ctx.daemons.daemons.items():
+        for daemon in daemons.values():
+            pid = daemon.pid
+            debug(pid)
+            assert pid


### PR DESCRIPTION
updating proc regex,
- removing unwanted white spaces.
- adding quotes to constitute regex as below.
```
2020-06-18T23:46:14.914 INFO:teuthology.orchestra.run.clara014:> ps -ef | grep "radosgw.*--name.*rgw.clara014.rgw0" | grep -v grep | awk {'print $2'}
2020-06-18T23:46:14.960 INFO:teuthology.orchestra.run.clara014.stdout:25084
2020-06-18T23:46:14.962 INFO:teuthology.orchestra.run.clara014:> sudo systemctl restart ceph-radosgw@rgw.clara014.rgw0
2020-06-18T23:46:15.053 INFO:teuthology.orchestra.run.clara014:> sudo systemctl show ceph-radosgw@rgw.clara014.rgw0 | grep -i state
2020-06-18T23:46:15.133 INFO:teuthology.orchestra.run.clara014.stdout:StateDirectoryMode=0755
2020-06-18T23:46:15.134 INFO:teuthology.orchestra.run.clara014.stdout:LoadState=loaded
2020-06-18T23:46:15.134 INFO:teuthology.orchestra.run.clara014.stdout:ActiveState=active
2020-06-18T23:46:15.134 INFO:teuthology.orchestra.run.clara014.stdout:SubState=running
2020-06-18T23:46:15.135 INFO:teuthology.orchestra.run.clara014.stdout:UnitFileState=enabled
2020-06-18T23:46:15.135 INFO:teuthology.orchestra.run.clara014.stdout:StateChangeTimestamp=Fri 2020-06-19 03:46:15 UTC
2020-06-18T23:46:15.135 INFO:teuthology.orchestra.run.clara014.stdout:StateChangeTimestampMonotonic=632122629
```

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>