### PR TITLE
teuthology/suite: use rhel8 for querying package version

### DIFF
--- a/teuthology/orchestra/opsys.py
+++ b/teuthology/orchestra/opsys.py
@@ -61,10 +61,10 @@ DISTRO_CODENAME_MAP = {
 DEFAULT_OS_VERSION = dict(
     ubuntu="18.04",
     fedora="25",
-    centos="7.6",
+    centos="8.1",
     opensuse="15.0",
     sle="15.0",
-    rhel="7.6",
+    rhel="8.1",
     debian='8.0'
 )
 

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -252,7 +252,7 @@ def get_branch_info(project, branch, project_owner='ceph'):
 
 
 def package_version_for_hash(hash, kernel_flavor='basic', distro='rhel',
-                             distro_version='7.0', machine_type='smithi'):
+                             distro_version='8.0', machine_type='smithi'):
     """
     Does what it says on the tin. Uses gitbuilder repos.
 

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -475,8 +475,8 @@ class TestBuilderProject(object):
         assert gp.distro == expected
 
     DISTRO_MATRIX_NOVER = [
-        ('rhel', None, None, 'centos7'),
-        ('centos', None, None, 'centos7'),
+        ('rhel', None, None, 'centos8'),
+        ('centos', None, None, 'centos8'),
         ('fedora', None, None, 'fedora25'),
         ('ubuntu', None, None, 'bionic'),
         ('debian', None, None, 'jessie'),
@@ -501,6 +501,7 @@ class TestBuilderProject(object):
         ('centos', '6.5', None, 'el6'),
         ('centos', '7.0', None, 'el7'),
         ('centos', '7.1', None, 'el7'),
+        ('centos', '8.1', None, 'el8'),
         ('fedora', '20', None, 'fc20'),
         ('debian', '7.0', None, 'debian'),
         ('debian', '7', None, 'debian'),
@@ -602,6 +603,7 @@ class TestGitbuilderProject(TestBuilderProject):
         ('centos', '6.5', None, 'centos6'),
         ('centos', '7.0', None, 'centos7'),
         ('centos', '7.1', None, 'centos7'),
+        ('centos', '8.1', None, 'centos8'),
         ('fedora', '20', None, 'fedora20'),
         ('ubuntu', '14.04', 'trusty', 'trusty'),
         ('ubuntu', '14.04', None, 'trusty'),
@@ -741,6 +743,7 @@ class TestShamanProject(TestBuilderProject):
         ('centos', '6.5', None, 'centos/6'),
         ('centos', '7.0', None, 'centos/7'),
         ('centos', '7.1', None, 'centos/7'),
+        ('centos', '8.1', None, 'centos/8'),
         ('fedora', '20', None, 'fedora/20'),
         ('ubuntu', '14.04', 'trusty', 'ubuntu/14.04'),
         ('ubuntu', '14.04', None, 'ubuntu/14.04'),
@@ -752,8 +755,8 @@ class TestShamanProject(TestBuilderProject):
     ]
 
     DISTRO_MATRIX_NOVER = [
-        ('rhel', None, None, 'centos/7'),
-        ('centos', None, None, 'centos/7'),
+        ('rhel', None, None, 'centos/8'),
+        ('centos', None, None, 'centos/8'),
         ('fedora', None, None, 'fedora/25'),
         ('ubuntu', None, None, 'ubuntu/18.04'),
         ('debian', None, None, 'debian/8.0'),


### PR DESCRIPTION
as we don't build packages for el7 on master anymore. but we do build
packages for nautilus and octopus.

Signed-off-by: Kefu Chai <kchai@redhat.com>