### PR TITLE
suite/run.py: check config['verify_ceph_hash'] before verifying ceph …

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -170,7 +170,13 @@ def get_initial_tasks(lock, config, machine_type):
     overrides = config.get('overrides', {})
     having_repos = ('repo' in config.get('install', {}) or
                     'repo' in overrides.get('install', {}))
-    if not ('redhat' in config or having_repos):
+    if 'redhat' in config:
+        pass
+    elif having_repos:
+        pass
+    elif not config.get('verify_ceph_hash', True):
+        pass
+    else:
         init_tasks += [
             {'internal.check_packages': None},
             {'internal.buildpackages_prep': None},

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -167,9 +167,9 @@ def validate_tasks(config):
 
 def get_initial_tasks(lock, config, machine_type):
     init_tasks = []
-    overrides = config.get('overrides')
-    having_repos = ('install' in config and 'repos' in config.get('install')) \
-        or (overrides and 'install' in overrides and 'repos' in overrides.get('install'))
+    overrides = config.get('overrides', {})
+    having_repos = ('repo' in config.get('install', {}) or
+                    'repo' in overrides.get('install', {}))
     if not ('redhat' in config or having_repos):
         init_tasks += [
             {'internal.check_packages': None},

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -429,7 +429,8 @@ class Run(object):
             )
 
             sha1 = self.base_config.sha1
-            if config.suite_verify_ceph_hash:
+            if parsed_yaml.get('verify_ceph_hash',
+                               config.suite_verify_ceph_hash):
                 full_job_config = copy.deepcopy(self.base_config.to_dict())
                 deep_merge(full_job_config, parsed_yaml)
                 flavor = util.get_install_task_flavor(full_job_config)


### PR DESCRIPTION
…packages

there is chance that we don't have ceph packages built for the
combination of specified os_type and os_version, for instance, in the
case of rados/thash_old_clients, older ceph clients are installed on
el7, but the ceph cluster is deployed using cephadm, which in turn pull
ceph container images built using the ceph being tested and el8.

since we've dropped the build of master on el7, there is no need to
verify if ceph package is available if cephadm is used for deploying the
cluster.

Signed-off-by: Kefu Chai <kchai@redhat.com>