### PR TITLE
run: fix typo after refactor

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -168,8 +168,8 @@ def validate_tasks(config):
 def get_initial_tasks(lock, config, machine_type):
     init_tasks = []
     overrides = config.get('overrides', {})
-    having_repos = ('repo' in config.get('install', {}) or
-                    'repo' in overrides.get('install', {}))
+    having_repos = ('repos' in config.get('install', {}) or
+                    'repos' in overrides.get('install', {}))
     if 'redhat' in config:
         pass
     elif having_repos:


### PR DESCRIPTION
This addresses issue introduced by PR 1520 commit:
b9fe404403db8f983a402ed64b85a2a292de66af

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>