### PR TITLE
teuthology/run.py: s/repo/repos/

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -168,8 +168,8 @@ def validate_tasks(config):
 def get_initial_tasks(lock, config, machine_type):
     init_tasks = []
     overrides = config.get('overrides', {})
-    having_repos = ('repo' in config.get('install', {}) or
-                    'repo' in overrides.get('install', {}))
+    having_repos = ('repos' in config.get('install', {}) or
+                    'repos' in overrides.get('install', {}))
     if 'redhat' in config:
         pass
     elif having_repos:


### PR DESCRIPTION
to address the regression introduced by
fe6bec1d42178cade0ed6d63319e4abc08f0f775, which broke the `--test-repo`
option handling machinery

Signed-off-by: Kefu Chai <kchai@redhat.com>