### PR TITLE
orchestra/daemon/cephadmunit: add journalctl suffix

### DIFF
--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -50,7 +50,7 @@ class CephadmUnit(DaemonState):
                   '-u',
                   'ceph-%s@%s.service' % (self.fsid, name)
             ],
-            logger=logging.getLogger(self.cluster + '.' + name),
+            logger=logging.getLogger('journalctl@' + self.cluster + '.' + name),
             label=name,
             wait=False,
             check_status=False,


### PR DESCRIPTION
The logger is running in background and the output is mixed
with other loggers. Adding a recognizable suffix will
help to distinguish logging threads.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>