### PR TITLE
run_tasks.py: Python3 don't have exception.message anymore

### DIFF
--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -148,7 +148,7 @@ def run_tasks(tasks, ctx):
         # causes failures with 'too many values to unpack.'  We want to
         # fail as before, but with easier to understand error indicators.
         if isinstance(e, ValueError):
-            if e.message == 'too many values to unpack':
+            if str(e) == 'too many values to unpack':
                 emsg = 'Possible configuration error in yaml file'
                 log.error(emsg)
                 ctx.summary['failure_info'] = emsg


### PR DESCRIPTION
This was probably working fine due to six library which was removed
recently: https://github.com/ceph/teuthology/commit/9f99b9298265be583c350c71de47109bac4bf6f1

Error seen:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/worker/src/github.com_ceph_teuthology_master/teuthology/contextutil.py", line 33, in nested
    yield vars
  File "/home/worker/src/github.com_ceph_teuthology_master/teuthology/task/install/__init__.py", line 612, in task
    yield
  File "/home/worker/src/github.com_ceph_teuthology_master/teuthology/run_tasks.py", line 151, in run_tasks
    if e.message == 'too many values to unpack':
AttributeError: 'ValueError' object has no attribute 'message'
```

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>