### PR TITLE
teuthology-suite: allow dump job configs to a file instead of beanstalkd

### DIFF
--- a/scripts/schedule.py
+++ b/scripts/schedule.py
@@ -16,6 +16,11 @@ positional arguments:
 optional arguments:
   -h, --help                           Show this help message and exit
   -v, --verbose                        Be more verbose
+  -b <backend>, --queue-backend <backend>
+                                       Queue backend name, use prefix '@'
+                                       to append job config to the given
+                                       file path as yaml.
+                                       [default: beanstalk]
   -n <name>, --name <name>             Name of suite run the job is part of
   -d <desc>, --description <desc>      Job description
   -o <owner>, --owner <owner>          Job owner

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -96,6 +96,10 @@ Standard arguments:
                               of resources, however --non-interactive option
                               can be used to skip user input.
                               [default: 0]
+  --arch <arch>               Override architecture defaults, for example,
+                              aarch64, armv7l, x86_64. Normally this
+                              argument should not be provided and the arch
+                              is determined from --machine-type.
 
 Scheduler arguments:
   --owner <owner>             Job owner

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -103,6 +103,8 @@ Standard arguments:
 
 Scheduler arguments:
   --owner <owner>             Job owner
+  -b <backend>, --queue-backend <backend>
+                              Scheduler queue backend name
   -e <email>, --email <email>
                               When tests finish or time out, send an email
                               here. May also be specified in ~/.teuthology.yaml

--- a/teuthology/schedule.py
+++ b/teuthology/schedule.py
@@ -1,4 +1,3 @@
-import pprint
 import yaml
 
 import teuthology.beanstalk
@@ -33,7 +32,7 @@ def main(args):
         raise ValueError("Please use a more descriptive value for --name")
     job_config = build_config(args)
     if args['--dry-run']:
-        pprint.pprint(job_config)
+        print('---\n' + yaml.safe_dump(job_config))
     else:
         schedule_job(job_config, args['--num'], report_status)
 

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -331,6 +331,8 @@ class Run(object):
             base_args.append('-v')
         if self.args.owner:
             base_args.extend(['--owner', self.args.owner])
+        if self.args.queue_backend:
+            base_args.extend(['--queue-backend', self.args.queue_backend])
         return base_args
 
 

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -32,6 +32,7 @@ class Run(object):
     __slots__ = (
         'args', 'name', 'base_config', 'suite_repo_path', 'base_yaml_paths',
         'base_args', 'package_versions', 'kernel_dict', 'config_input',
+        'timestamp', 'user',
     )
 
     def __init__(self, args):
@@ -39,6 +40,11 @@ class Run(object):
         args must be a config.YamlConfig object
         """
         self.args = args
+        # We assume timestamp is a datetime.datetime object
+        self.timestamp = self.args.timestamp or \
+            datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+        self.user = self.args.user or pwd.getpwuid(os.getuid()).pw_name
+
         self.name = self.make_run_name()
 
         if self.args.ceph_repo:
@@ -60,16 +66,15 @@ class Run(object):
         Generate a run name. A run name looks like:
             teuthology-2014-06-23_19:00:37-rados-dumpling-testing-basic-plana
         """
-        user = self.args.user or pwd.getpwuid(os.getuid()).pw_name
-        # We assume timestamp is a datetime.datetime object
-        timestamp = self.args.timestamp or \
-            datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
-
         worker = util.get_worker(self.args.machine_type)
         return '-'.join(
             [
-                user, str(timestamp), self.args.suite, self.args.ceph_branch,
-                self.args.kernel_branch or '-', self.args.kernel_flavor, worker
+                self.user,
+                str(self.timestamp),
+                self.args.suite,
+                self.args.ceph_branch,
+                self.args.kernel_branch or '-',
+                self.args.kernel_flavor, worker
             ]
         ).replace('/', ':')
 
@@ -309,6 +314,8 @@ class Run(object):
         conf_dict.update(self.kernel_dict)
         job_config = JobConfig.from_dict(conf_dict)
         job_config.name = self.name
+        job_config.user = self.user
+        job_config.timestamp = self.timestamp
         job_config.priority = self.args.priority
         if self.args.email:
             job_config.email = self.args.email

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -498,7 +498,11 @@ class Run(object):
         Schedule the suite-run. Returns the number of jobs scheduled.
         """
         name = self.name
-        arch = util.get_arch(self.base_config.machine_type)
+        if self.args.arch:
+            arch = self.args.arch
+            log.debug("Using '%s' as an arch" % arch)
+        else:
+            arch = util.get_arch(self.base_config.machine_type)
         suite_name = self.base_config.suite
         suite_path = os.path.normpath(os.path.join(
             self.suite_repo_path,


### PR DESCRIPTION
This will allow to see what job config contents can be submitted to beanstalkd by storing them into the separate file in yaml multi-document format.
Having `--queue-backend` option can be later used for queuing the jobs into alternative to beanstalkd service, for example, we can queue jobs to the paddles database directly, or any other.
The yaml file can be easily read and any job config can be taken from it and used with teuthology-run directly to run tests without involving beanstalkd and paddles.