### PR TITLE
teuthology: don't use git to define version for released teuthology

### DIFF
--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -37,10 +37,15 @@ __version__ = '1.0.0'
 # do our best, but if it fails, continue with above
 
 try:
-    __version__ += '-' + str(subprocess.check_output(
-        'git rev-parse --short HEAD'.split(),
-        cwd=os.path.dirname(os.path.realpath(__file__))
-    ).decode()).strip()
+    teuthology_dir = os.path.dirname(os.path.realpath(__file__))
+    site_dir = os.path.dirname(teuthology_dir)
+    git_dir = os.path.join(site_dir, '.git')
+    # make sure we use git repo otherwise it is a released version
+    if os.path.exists(git_dir):
+        __version__ += '-' + str(subprocess.check_output(
+            'git rev-parse --short HEAD'.split(),
+            cwd=site_dir
+        ).decode()).strip()
 except Exception as e:
     # before logging; should be unusual
     print("Can't get version from git rev-parse %s" % e, file=sys.stderr)


### PR DESCRIPTION
After installing teuthology using pip there can be found error messages
in the log when running any command, for example 'teuthology --version':

  fatal: not a git repository (or any parent up to mount point /)
  Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
  Can't get version from git rev-parse Command '['git', 'rev-parse', '--short', 'HEAD']' returned non-zero exit status 128.
  1.0.0

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>