### PR TITLE
repo_utils: exclude refs/for branches when ls-remote

### DIFF
--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -62,6 +62,15 @@ def ls_remote(url, ref):
     """
     sha1 = None
     cmd = "git ls-remote {} {}".format(url, ref)
+    # workaround for the refs/for/master branch, sometimes happens when
+    # we run ls-remote against master and we get refs/for/master in
+    # first place instead of only refs/heads/master ref, for example:
+    #
+    # > git ls-remote https://github.com/ceph/ceph.git master
+    # baa1ea6a9656c3db06c66032fa80b476721947ba	refs/for/master
+    # f7f156db5ee98495e4225b56620737ea545fc66b	refs/heads/master
+    if not ref.startswith('refs/for'):
+        cmd += ' | grep -v refs/for'
     result = subprocess.check_output(
         cmd, shell=True).split()
     if result:


### PR DESCRIPTION
If we do not request refs/for branch specifically,
we should exclude them since sometimes when we try
to ls the 'master' branch the ls-remote returns
two branches 'refs/for/master' and 'refs/heads/master',
though the latter is expected only.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>