### PR TITLE
suite/util.py: Update Ubuntu default to Xenial

### DIFF
--- a/teuthology/suite/test/test_util.py
+++ b/teuthology/suite/test/test_util.py
@@ -313,8 +313,8 @@ class TestDistroDefaults(object):
         assert util.get_distro_defaults('ubuntu', 'saya') == expected
 
     def test_distro_defaults_plana(self):
-        expected = ('x86_64', 'trusty',
-                    OS(name='ubuntu', version='14.04', codename='trusty'))
+        expected = ('x86_64', 'xenial',
+                    OS(name='ubuntu', version='16.04', codename='xenial'))
         assert util.get_distro_defaults('ubuntu', 'plana') == expected
 
     def test_distro_defaults_debian(self):

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -140,7 +140,7 @@ def get_distro_defaults(distro, machine_type):
             os_version = '13.10'
             arch = 'armv7l'
         else:
-            os_version = '14.04'
+            os_version = '16.04'
     elif distro == 'debian':
         os_type = distro
         os_version = '7'


### PR DESCRIPTION
This will need to change to Bionic when we stop supporting luminous or must test Octopus.

Signed-off-by: David Galloway <dgallowa@redhat.com>