### PR TITLE
misc: upgrade sudo_write_file()

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -549,7 +549,7 @@ def sudo_write_file(remote, path, data, perms=None, owner=None):
     owner_args = []
     if owner:
         owner_args = [run.Raw('&&'), 'sudo', 'chown', owner, path]
-    remote.run(
+    return remote.run(
         args=[
             'sudo',
             'sh',
@@ -557,6 +557,7 @@ def sudo_write_file(remote, path, data, perms=None, owner=None):
             'cat > ' + path,
         ] + owner_args + permargs,
         stdin=data,
+        omit_sudo=False
     )
 
 


### PR DESCRIPTION
Set `omit_sudo` to `False` and return the return value of `remote.run()`.

Related to `tasks.cephfs.mount.CephFSMount.write_file()` that is added on PR https://github.com/ceph/ceph/pull/32581. 

I intended to upgrade rest of the methods here later.