### PR TITLE
[WIP] add-teuthology-dispatcher

### DIFF
--- a/docs/COMPONENTS.rst
+++ b/docs/COMPONENTS.rst
@@ -48,10 +48,11 @@ database. Depending on the requirements (in terms of requested machines), the
 scheduler eventually determines when a job can get executed. At this point the
 master communicates with ``teuthology-dispatcher``, which checks the lock
 status of the requested machines (``teuthology-lock``) by querying ``paddles``,
-acquires locks of the nodes if they are available and invokes ``teuthology-worker``
-which in turn invokes ``teuthology`` (the command) which proceeds to execute
-the job (execute every task in the YAML job description). Results from the job
-are stored in the archive directory of the worker for forensic analysis.
+acquires locks of the nodes if they are available and invokes ``teuthology-worker``.
+``teuthology-worker`` reimages target machines and then invokes ``teuthology``
+(the command) which proceeds to execute the job (execute every task in the
+YAML job description). Results from the job are stored in the archive directory
+of the worker for forensic analysis.
 
 Since `QA suites <https://github.com/ceph/ceph-qa-suite>`__ usually
 specify ``install`` and ``ceph`` tasks, we briefly describe what they do. When

--- a/docs/COMPONENTS.rst
+++ b/docs/COMPONENTS.rst
@@ -21,47 +21,47 @@ a scheduler (a.k.a. master node), worker(s), package builder
 
 In the figure above, every service appears on a separate machine but this is
 not a requirement (see :ref:`lab_setup` for an alternative setup). Jobs are
-submitted to the scheduler, which are then processed by workers. One worker
-processes and keeps track of a job (one at a time). The output of the job (logs
-and files associated to an execution) is stored in the archive, which
-is a path in the file system where the worker is running. The job database
+submitted to the scheduler, which are then processed by dispatcher. Dispatcher
+takes job from the queue, allocates nodes for them to run on and initiates
+workers as its sub process to run the job. The output of the job (logs and
+files associated to an execution) is stored in the archive, which is a path
+in the file system where the dispatcher is running. The job database
 contains information about the status of jobs and test nodes, as well as
 results of executions (# of tests passed, failed, etc.). All this information
 can be visualized in ``pulpito``, the web UI. For an example, see Ceph
 community's Lab `here <http://pulpito.ceph.com>`__.
 
-Test nodes can be grouped in classes (referred to as ``machine-type``), 
-allowing teuthology schedule jobs across multiple hardware setups, 
+Test nodes can be grouped in classes (referred to as ``machine-type``),
+allowing teuthology to schedule jobs across multiple hardware setups,
 provided they're visible to the master node.
 
 Life of a Teuthology Job
 ========================
 
 The teuthology scheduler exposes a work queue (using `beanstalkd
-<https://kr.github.io/beanstalkd/>`__) where jobs are submitted. The life of a 
-job begins when ``teuthology-suite`` is executed, which is when a job is 
-prepared and queued (``teuthology-schedule`` is implicitly invoked). When a job 
-is created (or whenever the status of a job is changed, e.g. from queued to 
-started), information about the job is recorded in ``paddles``'s internal 
-database. Depending on the requirements (in terms of requested machines), the 
-scheduler eventually determines when a job can get executed. At this point the 
-master communicates with ``teuthology-worker``, which in turn invokes 
-``teuthology`` (the command). ``teuthology`` checks the lock status of the 
-requested machines (``teuthology-lock``) by querying ``paddles``,  acquires 
-locks of the nodes if they are available and proceeds to execute the job 
-(execute every task in the YAML job description). If no machines are available, 
-the job gets back into the queue. Results from the job are stored in the 
-archive directory of the worker for forensic analysis.
+<https://kr.github.io/beanstalkd/>`__) where jobs are submitted. The life of a
+job begins when ``teuthology-suite`` is executed, which is when a job is
+prepared and queued (``teuthology-schedule`` is implicitly invoked). When a job
+is created (or whenever the status of a job is changed, e.g. from queued to
+started), information about the job is recorded in ``paddles``'s internal
+database. Depending on the requirements (in terms of requested machines), the
+scheduler eventually determines when a job can get executed. At this point the
+master communicates with ``teuthology-dispatcher``, which checks the lock
+status of the requested machines (``teuthology-lock``) by querying ``paddles``,
+acquires locks of the nodes if they are available and invokes ``teuthology-worker``
+which in turn invokes ``teuthology`` (the command) which proceeds to execute
+the job (execute every task in the YAML job description). Results from the job
+are stored in the archive directory of the worker for forensic analysis.
 
 Since `QA suites <https://github.com/ceph/ceph-qa-suite>`__ usually
 specify ``install`` and ``ceph`` tasks, we briefly describe what they do. When
-a suite is scheduled (via ``teuthology-suite``), the branch that is being 
-worked against has to be specified (e.g. a git ``SHA`` or ``ref``). Packages 
-for the given branch and distro are probed on gitbuilder to see if they exist. 
-Once this and other sanity checks pass, the job is created and scheduled. Once 
-the job initializes, the ``install`` task pulls and installs Ceph packages from 
-``gitbuilder``. The installation task might also be preceded by a ``kernel`` 
-task which first reboots testnodes (and optionally installs) into a specified 
-kernel. The ``ceph`` task subsequently configures and launches the cluster. At 
-this point, Ceph is ready to receive requests from other tasks (such as 
+a suite is scheduled (via ``teuthology-suite``), the branch that is being
+worked against has to be specified (e.g. a git ``SHA`` or ``ref``). Packages
+for the given branch and distro are probed on gitbuilder to see if they exist.
+Once this and other sanity checks pass, the job is created and scheduled. Once
+the job initializes, the ``install`` task pulls and installs Ceph packages from
+``gitbuilder``. The installation task might also be preceded by a ``kernel``
+task which first reboots testnodes (and optionally installs) into a specified
+kernel. The ``ceph`` task subsequently configures and launches the cluster. At
+this point, Ceph is ready to receive requests from other tasks (such as
 ``rados``).

--- a/scripts/dispatcher.py
+++ b/scripts/dispatcher.py
@@ -1,0 +1,37 @@
+import argparse
+
+import teuthology.dispatcher
+
+
+def main():
+    teuthology.dispatcher.main(parse_args())
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="""
+Start a dispatcher for the specified tube. Grab jobs from a beanstalk
+queue and run the teuthology tests they describe as subprocesses. One
+job is run at a time.
+""")
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true', default=None,
+        help='be more verbose',
+    )
+    parser.add_argument(
+        '--archive-dir',
+        metavar='DIR',
+        help='path under which to archive results',
+        required=True,
+    )
+    parser.add_argument(
+        '-l', '--log-dir',
+        help='path in which to store logs',
+        required=True,
+    )
+    parser.add_argument(
+        '-t', '--tube',
+        help='which beanstalk tube to read jobs from',
+        required=True,
+    )
+    return parser.parse_args()

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -16,6 +16,7 @@ optional arguments:
   --description DESCRIPTION      job description
   --owner OWNER                  job owner
   --lock                         lock machines for the duration of the run
+  --unlock                       unlock machine targets after run
   --machine-type MACHINE_TYPE    Type of machine to lock/run tests on.
   --os-type OS_TYPE              Distro/OS of machine to run test on.
   --os-version OS_VERSION        Distro/OS version of machine to run test on.

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -1,37 +1,21 @@
-import argparse
+"""
+usage: teuthology-worker --help
+       teuthology-worker [options] --archive-dir DIR --bin-path BIN_PATH
+
+Run ceph integration tests
+
+optional arguments:
+  -h, --help                     show this help message and exit
+  -v, --verbose                  be more verbose
+  --archive-dir DIR              path to archive results in
+  --bin-path BIN_PATH            teuth-bin-path
+"""
+
+import docopt
 
 import teuthology.worker
 
 
 def main():
-    teuthology.worker.main(parse_args())
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="""
-Grab jobs from a beanstalk queue and run the teuthology tests they
-describe. One job is run at a time.
-""")
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true', default=None,
-        help='be more verbose',
-    )
-    parser.add_argument(
-        '--archive-dir',
-        metavar='DIR',
-        help='path under which to archive results',
-        required=True,
-    )
-    parser.add_argument(
-        '-l', '--log-dir',
-        help='path in which to store logs',
-        required=True,
-    )
-    parser.add_argument(
-        '-t', '--tube',
-        help='which beanstalk tube to read jobs from',
-        required=True,
-    )
-
-    return parser.parse_args()
+    args = docopt.docopt(__doc__)
+    teuthology.worker.main(args)

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -1,6 +1,6 @@
 """
 usage: teuthology-worker --help
-       teuthology-worker [options] --archive-dir DIR --bin-path BIN_PATH
+       teuthology-worker -v --bin-path BIN_PATH --config-fd FD --archive-dir DIR
 
 Run ceph integration tests
 
@@ -9,6 +9,7 @@ optional arguments:
   -v, --verbose                  be more verbose
   --archive-dir DIR              path to archive results in
   --bin-path BIN_PATH            teuth-bin-path
+  --config-fd FD                 file descriptor of job's config file
 """
 
 import docopt

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
             'teuthology-queue = scripts.queue:main',
             'teuthology-prune-logs = scripts.prune_logs:main',
             'teuthology-describe = scripts.describe:main',
-            'teuthology-reimage = scripts.reimage:main'
+            'teuthology-reimage = scripts.reimage:main',
             'teuthology-dispatcher = scripts.dispatcher:main'
             ],
         },

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ setup(
             'teuthology-prune-logs = scripts.prune_logs:main',
             'teuthology-describe = scripts.describe:main',
             'teuthology-reimage = scripts.reimage:main'
+            'teuthology-dispatcher = scripts.dispatcher:main'
             ],
         },
 

--- a/teuthology/dispatcher/__init__.py
+++ b/teuthology/dispatcher/__init__.py
@@ -119,6 +119,8 @@ def main(ctx):
             log_file_path,
             ctx.archive_dir,
         )
+
+        # lock machines but do not reimage them
         if not job_config.get('first_in_suite') \
                 and not job_config.get('last_in_suite') \
                 and 'roles' in job_config:
@@ -203,7 +205,7 @@ def prep_job(job_config, log_file_path, archive_dir):
 def lock_machines(job_config):
     fake_ctx = create_fake_context(job_config, block=True)
     lock_machines_helper(fake_ctx, [len(job_config['roles']),
-                         job_config['machine_type']])
+                         job_config['machine_type']], reimage=False)
     job_config = fake_ctx.config
     return job_config
 

--- a/teuthology/dispatcher/__init__.py
+++ b/teuthology/dispatcher/__init__.py
@@ -1,0 +1,193 @@
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import yaml
+import json
+
+from datetime import datetime
+
+from teuthology import setup_log_file, install_except_hook
+from teuthology import beanstalk
+from teuthology import report
+from teuthology import safepath
+from teuthology.config import config as teuth_config
+from teuthology.config import set_config_attr
+from teuthology.exceptions import BranchNotFoundError, SkipJob, MaxWhileTries
+from teuthology.kill import kill_job
+from teuthology.repo_utils import fetch_qa_suite, fetch_teuthology
+
+log = logging.getLogger(__name__)
+start_time = datetime.utcnow()
+restart_file_path = '/tmp/teuthology-restart-workers'
+stop_file_path = '/tmp/teuthology-stop-workers'
+
+
+def sentinel(path):
+    if not os.path.exists(path):
+        return False
+    file_mtime = datetime.utcfromtimestamp(os.path.getmtime(path))
+    if file_mtime > start_time:
+        return True
+    else:
+        return False
+
+
+def restart():
+    log.info('Restarting...')
+    args = sys.argv[:]
+    args.insert(0, sys.executable)
+    os.execv(sys.executable, args)
+
+
+def stop():
+    log.info('Stopping...')
+    sys.exit(0)
+
+
+def load_config(ctx=None):
+    teuth_config.load()
+    if ctx is not None:
+        if not os.path.isdir(ctx.archive_dir):
+            sys.exit("{prog}: archive directory must exist: {path}".format(
+                prog=os.path.basename(sys.argv[0]),
+                path=ctx.archive_dir,
+            ))
+        else:
+            teuth_config.archive_base = ctx.archive_dir
+
+
+def main(ctx):
+    loglevel = logging.INFO
+    if ctx.verbose:
+        loglevel = logging.DEBUG
+    log.setLevel(loglevel)
+
+    log_file_path = os.path.join(ctx.log_dir, 'dispatcher.{tube}.{pid}'.format(
+        pid=os.getpid(), tube=ctx.tube,))
+    setup_log_file(log_file_path)
+
+    install_except_hook()
+
+    load_config(ctx=ctx)
+
+    set_config_attr(ctx)
+
+    connection = beanstalk.connect()
+    beanstalk.watch_tube(connection, ctx.tube)
+    result_proc = None
+
+    if teuth_config.teuthology_path is None:
+        fetch_teuthology('master')
+    fetch_qa_suite('master')
+
+    keep_running = True
+    while keep_running:
+        # Check to see if we have a teuthology-results process hanging around
+        # and if so, read its return code so that it can exit.
+        if result_proc is not None and result_proc.poll() is not None:
+            log.debug("teuthology-results exited with code: %s",
+                      result_proc.returncode)
+            result_proc = None
+
+        if sentinel(restart_file_path):
+            restart()
+        elif sentinel(stop_file_path):
+            stop()
+
+        load_config()
+
+        job = connection.reserve(timeout=60)
+        if job is None:
+            continue
+
+        # bury the job so it won't be re-run if it fails
+        job.bury()
+        job_id = job.jid
+        log.info('Reserved job %d', job_id)
+        log.info('Config is: %s', job.body)
+        job_config = yaml.safe_load(job.body)
+        job_config['job_id'] = str(job_id)
+
+        if job_config.get('stop_worker'):
+            keep_running = False
+
+        job_config, teuth_bin_path = prep_job(
+            job_config,
+            log_file_path,
+            ctx.archive_dir,
+        )
+        suite_path = job_config['suite_path']
+        run_args = [
+            os.path.join(teuth_bin_path, 'teuthology-worker'),
+            '-v',
+            '--bin-path', teuth_bin_path,
+            '--archive-dir', ctx.archive_dir,
+        ]
+
+        job_config_bytes = bytes(json.dumps(job_config), 'utf-8')
+
+        job_proc = subprocess.Popen(args=run_args, stdin=subprocess.PIPE)
+        job_proc.communicate(job_config_bytes)
+        log.info('Job subprocess PID: %s', job_proc.pid)
+
+        # This try/except block is to keep the worker from dying when
+        # beanstalkc throws a SocketError
+        try:
+            job.delete()
+        except Exception:
+            log.exception("Saw exception while trying to delete job")
+
+
+def prep_job(job_config, log_file_path, archive_dir):
+    job_id = job_config['job_id']
+    safe_archive = safepath.munge(job_config['name'])
+    job_config['worker_log'] = log_file_path
+    archive_path_full = os.path.join(
+        archive_dir, safe_archive, str(job_id))
+    job_config['archive_path'] = archive_path_full
+
+    # If the teuthology branch was not specified, default to master and
+    # store that value.
+    teuthology_branch = job_config.get('teuthology_branch', 'master')
+    job_config['teuthology_branch'] = teuthology_branch
+
+    try:
+        if teuth_config.teuthology_path is not None:
+            teuth_path = teuth_config.teuthology_path
+        else:
+            teuth_path = fetch_teuthology(branch=teuthology_branch)
+        # For the teuthology tasks, we look for suite_branch, and if we
+        # don't get that, we look for branch, and fall back to 'master'.
+        # last-in-suite jobs don't have suite_branch or branch set.
+        ceph_branch = job_config.get('branch', 'master')
+        suite_branch = job_config.get('suite_branch', ceph_branch)
+        suite_repo = job_config.get('suite_repo')
+        if suite_repo:
+            teuth_config.ceph_qa_suite_git_url = suite_repo
+        job_config['suite_path'] = os.path.normpath(os.path.join(
+            fetch_qa_suite(suite_branch),
+            job_config.get('suite_relpath', ''),
+        ))
+    except BranchNotFoundError as exc:
+        log.exception("Branch not found; marking job as dead")
+        report.try_push_job_info(
+            job_config,
+            dict(status='dead', failure_reason=str(exc))
+        )
+        raise SkipJob()
+    except MaxWhileTries as exc:
+        log.exception("Failed to fetch or bootstrap; marking job as dead")
+        report.try_push_job_info(
+            job_config,
+            dict(status='dead', failure_reason=str(exc))
+        )
+        raise SkipJob()
+
+    teuth_bin_path = os.path.join(teuth_path, 'virtualenv', 'bin')
+    if not os.path.isdir(teuth_bin_path):
+        raise RuntimeError("teuthology branch %s at %s not bootstrapped!" %
+                           (teuthology_branch, teuth_bin_path))
+    return job_config, teuth_bin_path

--- a/teuthology/lock/ops.py
+++ b/teuthology/lock/ops.py
@@ -52,7 +52,7 @@ def lock_many_openstack(ctx, num, machine_type, user=None, description=None,
 
 
 def lock_many(ctx, num, machine_type, user=None, description=None,
-              os_type=None, os_version=None, arch=None):
+              os_type=None, os_version=None, arch=None, reimage=True):
     if user is None:
         user = misc.get_user()
 
@@ -128,24 +128,8 @@ def lock_many(ctx, num, machine_type, user=None, description=None,
                     ok_machs = do_update_keys(list(ok_machs.keys()))[1]
                 update_nodes(ok_machs)
                 return ok_machs
-            elif machine_type in reimage_types:
-                reimaged = dict()
-                console_log_conf = dict(
-                    logfile_name='{shortname}_reimage.log',
-                    remotes=[teuthology.orchestra.remote.Remote(machine)
-                             for machine in machines],
-                )
-                with console_log.task(
-                        ctx, console_log_conf):
-                    update_nodes(reimaged, True)
-                    with teuthology.parallel.parallel() as p:
-                        for machine in machines:
-                            p.spawn(teuthology.provision.reimage, ctx,
-                                    machine, machine_type)
-                            reimaged[machine] = machines[machine]
-                reimaged = do_update_keys(list(reimaged.keys()))[1]
-                update_nodes(reimaged)
-                return reimaged
+            elif reimage and machine_type in reimage_types:
+                return reimage_many(ctx, machines, machine_type)
             return machines
         elif response.status_code == 503:
             log.error('Insufficient nodes available to lock %d %s nodes.',
@@ -297,3 +281,31 @@ def push_new_keys(keys_dict, reference):
                 log.error('failed to update %s!', hostname)
                 ret = 1
     return ret
+
+
+def reimage(ctx, machines, machine_type):
+    reimaged = dict()
+    with teuthology.parallel.parallel() as p:
+        for machine in machines:
+            log.info("Start node '%s' reimaging", machine)
+            update_nodes([machine], True)
+            p.spawn(teuthology.provision.reimage, ctx,
+                    machine, machine_type)
+            reimaged[machine] = machines[machine]
+            log.info("Node '%s' reimaging is complete", machine)
+    return reimaged
+
+
+def reimage_many(ctx, machines, machine_type):
+    # Setup log file, reimage machines and update their keys
+    reimaged = dict()
+    console_log_conf = dict(
+        logfile_name='{shortname}_reimage.log',
+        remotes=[teuthology.orchestra.remote.Remote(machine)
+                 for machine in machines],
+    )
+    with console_log.task(ctx, console_log_conf):
+        reimaged = reimage(ctx, machines, machine_type)
+    reimaged = do_update_keys(list(reimaged.keys()))[1]
+    update_nodes(reimaged)
+    return reimaged

--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -205,7 +205,7 @@ def get_initial_tasks(lock, unlock, config, machine_type):
         ])
 
     if ('roles' in config and
-        not config.get('use_existing_cluster', False)):
+            not config.get('use_existing_cluster', False)):
         init_tasks.extend([
             {'internal.check_ceph_data': None},
             {'internal.vm_setup': None},
@@ -284,7 +284,7 @@ def report_outcome(config, archive, summary, fake_ctx, unlock):
         config_dump = yaml.safe_dump(config)
         subject = "Teuthology error -- %s" % summary['failure_reason']
         email_results(subject, "Teuthology", config['email-on-error'],
-            "\n".join([summary_dump, config_dump]))
+                      "\n".join([summary_dump, config_dump]))
 
 
     report.try_push_job_info(config, summary)

--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -348,6 +348,12 @@ def archive(ctx, config):
         )
     )
 
+    with open(os.path.join(ctx.archive, 'info.yaml'), 'r+') as info_file:
+        info_yaml = yaml.safe_load(info_file)
+        info_file.seek(0)
+        info_yaml['archive'] = {'init': archive_dir}
+        yaml.safe_dump(info_yaml, info_file, default_flow_style=False)
+
     try:
         yield
     except Exception:

--- a/teuthology/task/internal/lock_machines.py
+++ b/teuthology/task/internal/lock_machines.py
@@ -30,7 +30,7 @@ def lock_machines(ctx, config):
         unlock_machines(ctx)
 
 
-def lock_machines_helper(ctx, config):
+def lock_machines_helper(ctx, config, reimage=True):
     # It's OK for os_type and os_version to be None here.  If we're trying
     # to lock a bare metal machine, we'll take whatever is available.  If
     # we want a vps, defaults will be provided by misc.get_distro and
@@ -83,7 +83,7 @@ def lock_machines_helper(ctx, config):
         try:
             newly_locked = teuthology.lock.ops.lock_many(ctx, requested, machine_type,
                                                          ctx.owner, ctx.archive, os_type,
-                                                         os_version, arch)
+                                                         os_version, arch, reimage=reimage)
         except Exception:
             # Lock failures should map to the 'dead' status instead of 'fail'
             if 'summary' in ctx:
@@ -153,6 +153,7 @@ def lock_machines_helper(ctx, config):
         )
         log.warn('Could not lock enough machines, waiting...')
         time.sleep(10)
+
 
 def unlock_machines(ctx):
     # If both unlock_on_failure and nuke-on-error are set, don't unlock now

--- a/teuthology/task/internal/lock_machines.py
+++ b/teuthology/task/internal/lock_machines.py
@@ -23,6 +23,14 @@ def lock_machines(ctx, config):
     new machines.  This is not called if the one has teuthology-locked
     machines and placed those keys in the Targets section of a yaml file.
     """
+    lock_machines_helper(ctx, config)
+    try:
+        yield
+    finally:
+        unlock_machines(ctx)
+
+
+def lock_machines_helper(ctx, config):
     # It's OK for os_type and os_version to be None here.  If we're trying
     # to lock a bare metal machine, we'll take whatever is available.  If
     # we want a vps, defaults will be provided by misc.get_distro and
@@ -78,7 +86,8 @@ def lock_machines(ctx, config):
                                                          os_version, arch)
         except Exception:
             # Lock failures should map to the 'dead' status instead of 'fail'
-            set_status(ctx.summary, 'dead')
+            if ctx.summary:
+                set_status(ctx.summary, 'dead')
             raise
         all_locked.update(newly_locked)
         log.info(
@@ -144,16 +153,15 @@ def lock_machines(ctx, config):
         )
         log.warn('Could not lock enough machines, waiting...')
         time.sleep(10)
-    try:
-        yield
-    finally:
-        # If both unlock_on_failure and nuke-on-error are set, don't unlock now
-        # because we're just going to nuke (and unlock) later.
-        unlock_on_failure = (
+
+def unlock_machines(ctx):
+    # If both unlock_on_failure and nuke-on-error are set, don't unlock now
+    # because we're just going to nuke (and unlock) later.
+    unlock_on_failure = (
             ctx.config.get('unlock_on_failure', False)
             and not ctx.config.get('nuke-on-error', False)
         )
-        if get_status(ctx.summary) == 'pass' or unlock_on_failure:
-            log.info('Unlocking machines...')
-            for machine in ctx.config['targets'].keys():
-                teuthology.lock.ops.unlock_one(ctx, machine, ctx.owner, ctx.archive)
+    if get_status(ctx.summary) == 'pass' or unlock_on_failure:
+        log.info('Unlocking machines...')
+        for machine in ctx.config['targets'].keys():
+            teuthology.lock.ops.unlock_one(ctx, machine, ctx.owner, ctx.archive)

--- a/teuthology/task/internal/lock_machines.py
+++ b/teuthology/task/internal/lock_machines.py
@@ -86,7 +86,7 @@ def lock_machines_helper(ctx, config):
                                                          os_version, arch)
         except Exception:
             # Lock failures should map to the 'dead' status instead of 'fail'
-            if ctx.summary:
+            if 'summary' in ctx:
                 set_status(ctx.summary, 'dead')
             raise
         all_locked.update(newly_locked)

--- a/teuthology/task/internal/unlock_targets.py
+++ b/teuthology/task/internal/unlock_targets.py
@@ -1,0 +1,20 @@
+import contextlib
+import logging
+
+from teuthology.task.internal.lock_machines import unlock_machines
+
+log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def unlock_targets(ctx, config):
+    """
+    Unlock target machines. Called when the job has target machines
+    specified in the job config. It unlocks the targets at the end
+    of the teuthology run. This is not called if teuthology run locks
+    machines.
+    """
+    try:
+        yield
+    finally:
+        unlock_machines(ctx)

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -103,8 +103,7 @@ def run_job(job_config, teuth_bin_path, archive_dir, verbose):
         arg.append('-v')
 
     arg.extend([
-        '--lock',
-        '--block',
+        '--unlock',
         '--owner', job_config['owner'],
         '--archive', job_config['archive_path'],
         '--name', job_config['name'],

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import time
 import yaml
+import json
 
 from datetime import datetime
 
@@ -17,6 +18,7 @@ from teuthology.config import set_config_attr
 from teuthology.exceptions import BranchNotFoundError, SkipJob, MaxWhileTries
 from teuthology.kill import kill_job
 from teuthology.repo_utils import fetch_qa_suite, fetch_teuthology
+from teuthology.misc import merge_configs
 
 log = logging.getLogger(__name__)
 start_time = datetime.utcnow()
@@ -24,168 +26,22 @@ restart_file_path = '/tmp/teuthology-restart-workers'
 stop_file_path = '/tmp/teuthology-stop-workers'
 
 
-def sentinel(path):
-    if not os.path.exists(path):
-        return False
-    file_mtime = datetime.utcfromtimestamp(os.path.getmtime(path))
-    if file_mtime > start_time:
-        return True
-    else:
-        return False
+def main(args):
+    verbose = args["--verbose"]
+    archive_dir = args["--archive-dir"]
+    teuth_bin_path = args["--bin-path"]
 
-
-def restart():
-    log.info('Restarting...')
-    args = sys.argv[:]
-    args.insert(0, sys.executable)
-    os.execv(sys.executable, args)
-
-
-def stop():
-    log.info('Stopping...')
-    sys.exit(0)
-
-
-def load_config(ctx=None):
-    teuth_config.load()
-    if ctx is not None:
-        if not os.path.isdir(ctx.archive_dir):
-            sys.exit("{prog}: archive directory must exist: {path}".format(
-                prog=os.path.basename(sys.argv[0]),
-                path=ctx.archive_dir,
-            ))
-        else:
-            teuth_config.archive_base = ctx.archive_dir
-
-
-def main(ctx):
-    loglevel = logging.INFO
-    if ctx.verbose:
-        loglevel = logging.DEBUG
-    log.setLevel(loglevel)
-
-    log_file_path = os.path.join(ctx.log_dir, 'worker.{tube}.{pid}'.format(
-        pid=os.getpid(), tube=ctx.tube,))
-    setup_log_file(log_file_path)
-
-    install_except_hook()
-
-    load_config(ctx=ctx)
-
-    set_config_attr(ctx)
-
-    connection = beanstalk.connect()
-    beanstalk.watch_tube(connection, ctx.tube)
-    result_proc = None
-
-    if teuth_config.teuthology_path is None:
-        fetch_teuthology('master')
-    fetch_qa_suite('master')
-
-    keep_running = True
-    while keep_running:
-        # Check to see if we have a teuthology-results process hanging around
-        # and if so, read its return code so that it can exit.
-        if result_proc is not None and result_proc.poll() is not None:
-            log.debug("teuthology-results exited with code: %s",
-                      result_proc.returncode)
-            result_proc = None
-
-        if sentinel(restart_file_path):
-            restart()
-        elif sentinel(stop_file_path):
-            stop()
-
-        load_config()
-
-        job = connection.reserve(timeout=60)
-        if job is None:
-            continue
-
-        # bury the job so it won't be re-run if it fails
-        job.bury()
-        job_id = job.jid
-        log.info('Reserved job %d', job_id)
-        log.info('Config is: %s', job.body)
-        job_config = yaml.safe_load(job.body)
-        job_config['job_id'] = str(job_id)
-
-        if job_config.get('stop_worker'):
-            keep_running = False
-
-        try:
-            job_config, teuth_bin_path = prep_job(
-                job_config,
-                log_file_path,
-                ctx.archive_dir,
-            )
-            run_job(
-                job_config,
-                teuth_bin_path,
-                ctx.archive_dir,
-                ctx.verbose,
-            )
-        except SkipJob:
-            continue
-
-        # This try/except block is to keep the worker from dying when
-        # beanstalkc throws a SocketError
-        try:
-            job.delete()
-        except Exception:
-            log.exception("Saw exception while trying to delete job")
-
-
-def prep_job(job_config, log_file_path, archive_dir):
-    job_id = job_config['job_id']
-    safe_archive = safepath.munge(job_config['name'])
-    job_config['worker_log'] = log_file_path
-    archive_path_full = os.path.join(
-        archive_dir, safe_archive, str(job_id))
-    job_config['archive_path'] = archive_path_full
-
-    # If the teuthology branch was not specified, default to master and
-    # store that value.
-    teuthology_branch = job_config.get('teuthology_branch', 'master')
-    job_config['teuthology_branch'] = teuthology_branch
+    job_config = json.loads(input())
 
     try:
-        if teuth_config.teuthology_path is not None:
-            teuth_path = teuth_config.teuthology_path
-        else:
-            teuth_path = fetch_teuthology(branch=teuthology_branch)
-        # For the teuthology tasks, we look for suite_branch, and if we
-        # don't get that, we look for branch, and fall back to 'master'.
-        # last-in-suite jobs don't have suite_branch or branch set.
-        ceph_branch = job_config.get('branch', 'master')
-        suite_branch = job_config.get('suite_branch', ceph_branch)
-        suite_repo = job_config.get('suite_repo')
-        if suite_repo:
-            teuth_config.ceph_qa_suite_git_url = suite_repo
-        job_config['suite_path'] = os.path.normpath(os.path.join(
-            fetch_qa_suite(suite_branch),
-            job_config.get('suite_relpath', ''),
-        ))
-    except BranchNotFoundError as exc:
-        log.exception("Branch not found; marking job as dead")
-        report.try_push_job_info(
+        run_job(
             job_config,
-            dict(status='dead', failure_reason=str(exc))
+            teuth_bin_path,
+            archive_dir,
+            verbose
         )
-        raise SkipJob()
-    except MaxWhileTries as exc:
-        log.exception("Failed to fetch or bootstrap; marking job as dead")
-        report.try_push_job_info(
-            job_config,
-            dict(status='dead', failure_reason=str(exc))
-        )
-        raise SkipJob()
-
-    teuth_bin_path = os.path.join(teuth_path, 'virtualenv', 'bin')
-    if not os.path.isdir(teuth_bin_path):
-        raise RuntimeError("teuthology branch %s at %s not bootstrapped!" %
-                           (teuthology_branch, teuth_bin_path))
-    return job_config, teuth_bin_path
+    except SkipJob:
+        return
 
 
 def run_job(job_config, teuth_bin_path, archive_dir, verbose):


### PR DESCRIPTION
Related PRs: [#36352](https://github.com/ceph/ceph/pull/36352)

**Motivation**
[Project Idea Link](https://ceph.io/gsoc-2020/#teuthology-scheduling%20Improvements) The existing worker framework leads to jobs, that require large number of machines to run on, waiting for a long time (often indefinitely). This also leads to running jobs in unreliable priority order. To solve the above, this PR is is the first step. It replaces the existing worker framework with a dispatcher that takes jobs from a queue, allocates nodes for them to run on, and executes them. 

Flow charts for:
*  [teuthology-dispatcher](https://docs.google.com/drawings/d/1JTRcqnzZ1YdKv0IDADyMTWffCoU8SJaD3bVIdWO5lww/edit?usp=sharing)
* [modified teuthology-worker](https://docs.google.com/drawings/d/1bkwGI8ar2FL18ohIyjv8USOA78Mp4bFRnu6DTy6cIhY/edit?usp=sharing)

**Changes in the current working:** 

* `teuthology-dispatcher` takes jobs from the queue, locks machines, populates job config with targets and invokes `teuthology-worker`. Without waiting for `teuthology-worker` child process to finish, it moves on to take another job from the queue and repeat the above process.
* `teuthology-worker` is now job specific. It sets up a worker new log file in suites archive dir named worker.{job_id}. It then reimages the target machines, constructs the `teuthology` cmd and invokes it. In case of job timeout, It also archives log dirs from target machines before nuking them. For the same, the [teuthology task](https://github.com/ceph/teuthology/pull/1540/files#diff-57bfcbe1ad60f3514b043712cf1b62e1) and [ceph task](opened PR [#36352](https://github.com/ceph/ceph/pull/36352)) are modified to add the log dirs to info.yaml. When job times out, the dirs to archive are read from here.    
* `teuthology` cmd: now adds an internal task, [unlock_targets](https://github.com/ceph/teuthology/pull/1540/files#diff-1ddc90aa37564b7357f276dfd792da67) in [run.py](https://github.com/ceph/teuthology/pull/1540/files#diff-438dc42f85af0a957680785784f8417dR256-R259) that unlocks the target machines (locked by dispatcher) at the end of the job run. 

**Development Lab Setup**: 

I have setup a development lab for teuthology, using some mira nodes from the current cluster, to test out the above mentioned changes. I have done so using:
* Master node (teuthworker/teuthology node): mira045
* Paddles/Pulpito node: mira119
* Test nodes: mira062, mira072, mira085

Pulpito can be accessed [here](http://mira119.front.sepia.ceph.com:8081/). 
archive logs are on the master node (mira045) in location: /home/teuthworker/archive

**Test performed**

* Job meant to pass: [link](http://mira119.front.sepia.ceph.com:8081/teuthology-2020-07-28_02:55:19-:tmp:test1.yaml-wip-jd-testing-distro-basic-mira/)
* Job meant to fail: [link](http://mira119.front.sepia.ceph.com:8081/teuthology-2020-07-28_03:01:40-:tmp:test2.yaml-wip-jd-testing-distro-basic-mira/)


**Changes Made**
* [X] Add a new dispatcher command, `teuthology-dispatcher`, that runs each job in the queue as its subprocess by invoking `teuthology-worker`. 
* [X] Modify `teuthology-worker` such that it only runs the job whose config is provided to it and ported to `docopt`.
* [X] Add an internal task, task/internal/unlock_targets.py to unlock target machines after the job run is complete.
* [X] Modify `teuthology` command by adding a `--unlock` flag to to unlock target machines if specified in config/s. 
* [X] Enables graceful job timeout by archiving logs before nuking machines.
* [X] Only lock machines in dispatcher and move reimaging machines to worker. 
* [X] Update documentation
* [ ] Update unit tests for worker
* [ ] Port `teuthology-dispatcher` to `docopt`.