### PR TITLE
fix py3 issue in pid method

### DIFF
--- a/teuthology/orchestra/daemon/systemd.py
+++ b/teuthology/orchestra/daemon/systemd.py
@@ -85,7 +85,7 @@ class SystemDState(DaemonState):
             #    Main process exited, code=exited, status=1/FAILURE
             self.status_cmd + " | grep 'Main.*code=exited'",
         )
-        line = out.split('\n')[-1]
+        line = out.strip().split('\n')[-1]
         exit_code = int(re.match('.*status=(\d+).*', line).groups()[0])
         if exit_code:
             self.remote.run(
@@ -167,10 +167,12 @@ class SystemDState(DaemonState):
         :return: The PID if remote run command value is set, False otherwise.
         """
         pid = self.pid
-        if pid > 0:
-            return pid
-        else:
+        if pid is None:
             return None
+        elif pid <= 0:
+            return None
+        else:
+            return pid
 
     def signal(self, sig, silent=False):
         """


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Fix python3 comparison issue.
- Fix issue with the newline character.

http://pastebin.test.redhat.com/894147

```
1. The system-ctl status command response has newline character at the end of the output, which results empty string after split.
the issue occurs when empty string is given to re.match. so need to strip the command response before split.
 
2020-08-17T03:07:39.329 INFO:teuthology.orchestra.run.magna102:> sudo systemctl status ceph-mgr@magna102 | grep 'Main.*code=exited'
2020-08-17T03:07:39.376 INFO:teuthology.orchestra.run.magna102.stdout: Main PID: 73508 (code=exited, status=0/SUCCESS)
2020-08-17T03:07:39.377 ERROR:tasks.mixed_system_tests.system:[ CEPH.MGR ] : Daemon System tests - FAILED
2020-08-17T03:07:39.377 INFO:tasks.mixed_system_tests.system:[ CEPH.MGR ] : Daemon System tests - COMPLETED
2020-08-17T03:07:39.377 INFO:tasks.mixed_system_test:System tests - COMPLETED
2020-08-17T03:07:39.378 ERROR:teuthology.run_tasks:Saw exception from tasks.
Traceback (most recent call last):
  File "/home/sunnagar/system-tests/repo/ceph-1/qa/tasks/mixed_system_tests/system.py", line 353, in ceph_daemon_system_test
    check_service_status(ctx, dstate, **kwargs)
  File "/home/sunnagar/system-tests/repo/ceph-1/qa/tasks/mixed_system_tests/system.py", line 182, in check_service_status
    if dstate.check_status() is not exit_status:
  File "/home/sunnagar/system-tests/repo/teuthology/teuthology/orchestra/daemon/systemd.py", line 89, in check_status
    exit_code = int(re.match('.*status=(\d+).*', line).groups()[0])
AttributeError: 'NoneType' object has no attribute 'groups'
 
 
>>> line
' Main PID: 1177 (ceph-mgr)\n'
 
>>> re.match('.*:\s+(\d+).*', line.split('\n')[-1]).groups()[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'groups'
 
>>> re.match('.*:\s+(\d+).*', line.strip().split('\n')[-1]).groups()[0]
'1177'  
```
 
```  
2. Need python3 compatible update here while comparing None with integers.
 
Traceback (most recent call last):
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/home/sunnagar/system-tests/repo/teuthology/teuthology/orchestra/daemon/systemd.py", line 170, in running
    if pid > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
 
$ python2.7 -c "print(None > 0)"                                                                                                                                                          
False
 
$ python3.6 -c "print(None > 0)"                                                                                                                                                        
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: '>' not supported between instances of 'NoneType' and 'int' 
```
