### PR TITLE
teuthology-suite: Check the priority of jobs to be run

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -168,6 +168,7 @@ Scheduler arguments:
                               with --rerun argument. This number can be found
                               in the output of teuthology-suite command. -1
                               for a random seed [default: -1].
+ --force-priority             Skip the priority check.
 
 """.format(
     default_machine_type=config.default_machine_type,


### PR DESCRIPTION
Check if the passed testing priority is according to the range mentioned in
developer guide[1]. This patch also adds '--force-priority' flag which allows to skip
the priority check.

[1] https://docs.ceph.com/docs/master/dev/developer_guide/tests-integration-tests/#testing-priority

Signed-off-by: Varsha Rao <varao@redhat.com>