### PR TITLE
kill: find targets for killing a job

### DIFF
--- a/teuthology/kill.py
+++ b/teuthology/kill.py
@@ -72,7 +72,10 @@ def kill_job(run_name, job_id, archive_base=None, owner=None):
                 "Please pass --owner <owner>.")
         owner = job_info['owner']
     kill_processes(run_name, [job_info.get('pid')])
-    targets = dict(targets=job_info.get('targets', {}))
+    # Because targets can be missing for some cases, for example, when all
+    # the necessary nodes ain't locked yet, we do not use job_info to get them,
+    # but use find_targets():
+    targets = find_targets(run_name, owner, job_id)
     nuke_targets(targets, owner)
 
 
@@ -191,12 +194,12 @@ def find_pids(run_name):
     return run_pids
 
 
-def find_targets(run_name, owner):
+def find_targets(run_name, owner, job_id=None):
     lock_args = [
         'teuthology-lock',
         '--list-targets',
         '--desc-pattern',
-        '/' + run_name + '/',
+        '/' + run_name + '/' + str(job_id or ''),
         '--status',
         'up',
         '--owner',


### PR DESCRIPTION
In some circumstances teuthology-kill does not unlock the nodes
if it is used to kill just a single job from a run, for example,
while a job in the middle of locking many targets the job_info
does not include targets yet, corresponding if someone kills
the job in the middles, the targets remains in locked state.
This commit address the issue.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>