### PR TITLE
task/install: skip package removal by default

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -8,6 +8,7 @@ from teuthology.orchestra import run
 from teuthology.orchestra import connection
 from teuthology.orchestra import console
 from teuthology.orchestra.opsys import OS
+import teuthology.provision
 from teuthology import misc
 from teuthology.exceptions import CommandFailedError
 from teuthology.misc import host_shortname
@@ -33,6 +34,7 @@ class Remote(object):
 
     # for unit tests to hook into
     _runner = staticmethod(run.run)
+    _reimage_types = None
 
     def __init__(self, name, ssh=None, shortname=None, console=None,
                  host_key=None, keep_alive=True):
@@ -52,6 +54,9 @@ class Remote(object):
         self.keep_alive = keep_alive
         self._console = console
         self.ssh = ssh
+
+        if self._reimage_types is None:
+            Remote._reimage_types = teuthology.provision.get_reimage_types()
 
     def connect(self, timeout=None, create_key=None, context='connect'):
         args = dict(user_at_host=self.name, host_key=self._host_key,
@@ -149,6 +154,10 @@ class Remote(object):
                 return None
             self._machine_type = remote_info.get("machine_type", None)
         return self._machine_type
+
+    @property
+    def is_reimageable(self):
+        return self.machine_type in self._reimage_types
 
     @property
     def shortname(self):

--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -588,20 +588,20 @@ def task(ctx, config):
     else:
         nested_config = dict(
                 branch=config.get('branch'),
-                tag=config.get('tag'),
-                sha1=config.get('sha1'),
                 debuginfo=config.get('debuginfo'),
-                flavor=flavor,
                 downgrade_packages=config.get('downgrade_packages', []),
+                exclude_packages=config.get('exclude_packages', []),
                 extra_packages=config.get('extra_packages', []),
                 extra_system_packages=config.get('extra_system_packages', []),
-                exclude_packages=config.get('exclude_packages', []),
                 extras=config.get('extras', None),
-                wait_for_package=config.get('wait_for_package', False),
-                project=project,
-                packages=config.get('packages', dict()),
+                flavor=flavor,
                 install_ceph_packages=config.get('install_ceph_packages', True),
+                packages=config.get('packages', dict()),
+                project=project,
                 repos_only=config.get('repos_only', False),
+                sha1=config.get('sha1'),
+                tag=config.get('tag'),
+                wait_for_package=config.get('wait_for_package', False),
         )
         if repos:
             nested_config['repos'] = repos


### PR DESCRIPTION
Every teuthology job cleans up its package install after completion.
This was necessary cleanup when we didn't reimage boxes before the use
of FOG as we wanted a "clean" slate for the next job to acquire the
machine. Now this is just unnecessary work which takes up valuable
machine time. For one job I looked at, this takes about 2 minutes.

We should still test that there are no unexpected issues with removing
the packages but this can be delegated to a small subset of smoke tests.
That will be posted in another PR to ceph.git.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>