### PR TITLE
orchestra/remote: raise FileNotFoundError in read_file

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -307,6 +307,7 @@ class Ansible(Task):
                         self.failure_log.name, e
                     )
                 )
+                fail_log.seek(0)
                 failures = fail_log.read().replace('\n', '')
 
         if failures:


### PR DESCRIPTION
Raise FileNotFoundError exception if the file passed to
remote.read_file was not found.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>