### PR TITLE
Use remote.write_file instead of misc.create_file

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -307,6 +307,7 @@ class Ansible(Task):
                         self.failure_log.name, e
                     )
                 )
+                fail_log.seek(0)
                 failures = fail_log.read().replace('\n', '')
 
         if failures:

--- a/teuthology/task/ssh_keys.py
+++ b/teuthology/task/ssh_keys.py
@@ -154,13 +154,13 @@ def push_keys_to_host(ctx, config, public_key, private_key):
             priv_key_data = '{priv_key}'.format(priv_key=private_key)
             misc.delete_file(remote, priv_key_file, force=True)
             # Hadoop requires that .ssh/id_rsa have permissions of '500'
-            misc.create_file(remote, priv_key_file, priv_key_data, str(500))
+            remote.write_file(priv_key_file, priv_key_data, mode='0500')
 
             # then a private key
             pub_key_file = '/home/{user}/.ssh/id_rsa.pub'.format(user=username)
             pub_key_data = 'ssh-rsa {pub_key} {user_host}'.format(pub_key=public_key, user_host=str(remote))
             misc.delete_file(remote, pub_key_file, force=True)
-            misc.create_file(remote, pub_key_file, pub_key_data)
+            remote.write_file(pub_key_file, pub_key_data)
 
             # add appropriate entries to the authorized_keys file for this host
             auth_keys_file = '/home/{user}/.ssh/authorized_keys'.format(


### PR DESCRIPTION
This PR addresses:
```
2020-09-05T10:00:32.003 INFO:teuthology.task.ssh_keys:pushing keys to smithi086.front.sepia.ceph.com for ubuntu
2020-09-05T10:00:32.003 INFO:teuthology.orchestra.run.smithi086:> rm -f -- /home/ubuntu/.ssh/id_rsa
2020-09-05T10:00:32.046 INFO:teuthology.orchestra.run.smithi086:> touch /home/ubuntu/.ssh/id_rsa && chmod 500 -- /home/ubuntu/.ssh/id_rsa
2020-09-05T10:00:32.095 INFO:teuthology.orchestra.run.smithi086:> set -ex
2020-09-05T10:00:32.096 INFO:teuthology.orchestra.run.smithi086:> dd of=/home/ubuntu/.ssh/id_rsa conv=notrunc oflag=append
2020-09-05T10:00:32.140 INFO:teuthology.orchestra.run.smithi086.stderr:+ dd of=/home/ubuntu/.ssh/id_rsa conv=notrunc oflag=append
2020-09-05T10:00:32.142 INFO:teuthology.orchestra.run.smithi086.stderr:dd: failed to open '/home/ubuntu/.ssh/id_rsa': Permission denied
2020-09-05T10:00:32.142 DEBUG:teuthology.orchestra.run:got remote process result: 1
2020-09-05T10:00:32.143 ERROR:teuthology.contextutil:Saw exception from nested tasks
Traceback (most recent call last):
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/contextutil.py", line 31, in nested
    vars.append(enter())
  File "/usr/lib/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/task/ssh_keys.py", line 157, in push_keys_to_host
    misc.create_file(remote, priv_key_file, priv_key_data, str(500))
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/misc.py", line 698, in create_file
    append_lines_to_file(remote, path, data, sudo)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/misc.py", line 660, in append_lines_to_file
    remote.write_file(path, lines, append=True, sudo=sudo)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/orchestra/remote.py", line 578, in write_file
    self.run(args=args, stdin=data)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/orchestra/remote.py", line 213, in run
    r = self._runner(client=self.ssh, name=self.shortname, **kwargs)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/orchestra/run.py", line 446, in run
    r.wait()
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/orchestra/run.py", line 160, in wait
    self._raise_for_status()
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/teuthology/orchestra/run.py", line 182, in _raise_for_status
    node=self.hostname, label=self.label
teuthology.exceptions.CommandFailedError: Command failed on smithi086 with status 1: 'set -ex\ndd of=/home/ubuntu/.ssh/id_rsa conv=notrunc oflag=append'
2020-09-05T10:00:32.144 INFO:teuthology.orchestra.run.smithi037:> rm /home/ubuntu/.ssh/config
```