### PR TITLE
bootstrap: use pip --use-feature=2020-resolver

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -157,13 +157,13 @@ fi
 
 
 # Upgrade pip first
-./$VENV/bin/pip install --upgrade pip
+./$VENV/bin/pip install --use-feature=2020-resolver --upgrade pip
 
 # Ensure setuptools is installed
-./$VENV/bin/pip install setuptools --upgrade
+./$VENV/bin/pip install --use-feature=2020-resolver setuptools --upgrade
 
 # Install all requirements
-./$VENV/bin/pip install --upgrade -r requirements.txt
+./$VENV/bin/pip install --use-feature=2020-resolver --upgrade -r requirements.txt
 
 # Check to make sure requirements are met
 ./$VENV/bin/pip check


### PR DESCRIPTION
follow the suggestion from pip

ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

Signed-off-by: Kefu Chai <kchai@redhat.com>