### PR TITLE
bootstrap: Do not use --use-feature=2020-resolver for pip upgrade

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -156,8 +156,14 @@ if [ -z "$NO_CLOBBER" ] || [ ! -e ./$VENV ]; then
 fi
 
 
-# Upgrade pip first
-./$VENV/bin/pip install --use-feature=2020-resolver --upgrade pip
+# be compatible with pip shipped by distro older v20.2
+if $vdir/bin/pip --use-feature=2020-resolver >/dev/null 2>&1 ; then
+    PIP_INSTALL="./$VENV/bin/pip install --use-feature=2020-resolver"
+else
+    PIP_INSTALL="./$VENV/bin/pip install"
+fi
+# Upgrade pip first - then we have a new pip version with the --use-feature flag
+$PIP_INSTALL --upgrade pip
 
 # Ensure setuptools is installed
 ./$VENV/bin/pip install --use-feature=2020-resolver setuptools --upgrade


### PR DESCRIPTION
pip might be too old so the --use-feature flag is not available. That
leads to:

$ ./bootstrap
Removing old virtualenv because it uses system site-packages
created virtual environment CPython3.8.5.final.0-64 in 173ms
  creator CPython3Posix(dest=/home/tom/devel/ceph/teuthology/virtualenv, clear=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/tom/.local/share/virtualenv)
    added seed packages: pip==20.1.1, setuptools==50.3.0, wheel==0.35.1
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator,XonshActivator

Usage:
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

no such option: --use-feature

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>