### PR TITLE
task/install/rpm: fix issued with upgrading packages under DNF

### DIFF
--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -401,14 +401,14 @@ def _upgrade_packages(ctx, config, remote, pkgs):
     # Actually upgrade the project packages
     if builder.dist_release in ['opensuse', 'sle']:
         pkg_mng_opts = '-n'
-        pkg_mng_subcommand_opts = '--capability'
-        pkg_mng_install_opts = '--no-recommends'
+        pkg_mng_subcommand = 'install'
+        pkg_mng_subcommand_opts = ['--capability', '--no-recommends']
     else:
         pkg_mng_opts = '-y'
-        pkg_mng_subcommand_opts = ''
-        pkg_mng_install_opts = ''
-    args = ['sudo', pkg_mng_cmd, pkg_mng_opts,
-            'install', pkg_mng_subcommand_opts,
-            pkg_mng_install_opts]
+        pkg_mng_subcommand = 'upgrade'
+        pkg_mng_subcommand_opts = []
+    args = ['sudo', pkg_mng_cmd, pkg_mng_opts, pkg_mng_subcommand]
+    if pkg_mng_subcommand_opts:
+        args += pkg_mng_subcommand_opts
     args += pkgs
     remote.run(args=args)


### PR DESCRIPTION
yum is an alias for dnf on modern RHEL-like systems but it's not
100% compatible. The "install" command does not upgrade packages
unless you give it a specific version to install. Additionally,
the code was incorrectly inserting two blank arguments that resulted
in "yum install" failing.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>