### PR TITLE
packaging: add 'version_major' option support

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -472,9 +472,13 @@ class GitbuilderProject(object):
         self.os_version = self.remote.os.version
         self.codename = self.remote.os.codename
         self.pkg_type = self.remote.system_type
+        _version = self.remote.os.version
+        _major_version = self.job_config.get('install_per_major_version', False)
+        if _major_version:
+            _version = _version.split('.')[0]
         self.distro = self._get_distro(
             distro=self.remote.os.name,
-            version=self.remote.os.version,
+            version=_version,
             codename=self.remote.os.codename,
         )
         # when we're initializing with a remote we most likely have

--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -431,6 +431,14 @@ def task(ctx, config):
         branch: foo
         extra_packages: ['samba']
     - install:
+        project: tcmu-runner
+        sha1: latest
+        install_per_major_version: True
+
+    Note: the install_per_major_version will make the GitbuilderProject
+    class discard the minor version, False as default.
+
+    - install:
         extra_packages:
            deb: ['librados-dev', 'libradosstriper-dev']
            rpm: ['librados-devel', 'libradosstriper-devel']


### PR DESCRIPTION
In case for the distros having the same major version, such as for
RHEL 8/8.1/8.2, etc, and there has only one repo using the major
version in the url for one specified package.

The git builder class will just try to get the os version from the
remote node and then use it to build the request uri. So it won't
work for the above case.

Signed-off-by: Xiubo Li <xiubli@redhat.com>