### PR TITLE
orchestra/connection: accept ecdsa (and future) host key types.

### DIFF
--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -1,13 +1,13 @@
 """
 Connection utilities
 """
-import base64
 import paramiko
 import os
 import logging
 
 from teuthology.config import config
 from teuthology.contextutil import safe_while
+from paramiko.hostkeys import HostKeyEntry
 
 log = logging.getLogger(__name__)
 
@@ -29,14 +29,11 @@ def create_key(keytype, key):
     """
     Create an ssh-rsa, ssh-dss or ssh-ed25519 key.
     """
-    if keytype == 'ssh-rsa':
-        return paramiko.rsakey.RSAKey(data=base64.decodestring(key.encode()))
-    elif keytype == 'ssh-dss':
-        return paramiko.dsskey.DSSKey(data=base64.decodestring(key.encode()))
-    elif keytype == 'ssh-ed25519':
-        return paramiko.ed25519key.Ed25519Key(data=base64.decodestring(key.encode()))
-    else:
-        raise ValueError('keytype must be ssh-rsa, ssh-dss (DSA) or ssh-ed25519')
+    l = "{hostname} {keytype} {key}".format(hostname="x", keytype=keytype, key=key)
+
+    ke = HostKeyEntry.from_line(l)
+    assert ke, f'invalid host key "{keytype} {key}"'
+    return ke.key
 
 
 def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,


### PR DESCRIPTION
Out of the box, centos 8 ssh daemon makes this file,
/etc/ssh/ssh_host_ecdsa_key.pub
containing a key of type "ecdsa-sha2-nistp256", which was
not recognized by the existing teuthology logic.
Use logic in paramiko.hostkeys to recognize the new key types.

Signed-off-by: Marcus Watts <mwatts@redhat.com>