### PR TITLE
misc: CentOSStream => rpm

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1174,6 +1174,7 @@ def get_system_type(remote, distro=False, version=False):
         return "deb"
     if system_value in ['CentOS', 'Fedora', 'RedHatEnterpriseServer',
                         'RedHatEnterprise',
+                        'CentOSStream',
                         'openSUSE', 'openSUSE project', 'SUSE', 'SUSE LINUX']:
         return "rpm"
     return system_value


### PR DESCRIPTION
lsb_release -is identifies CentOS 8 Stream as CentOSStream.
Teuthology should recognize this as 'rpm'.

Signed-off-by: Marcus Watts <mwatts@redhat.com>