### PR TITLE
suite/placeholder.py: add "Health detail" to log-ignorelist

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -73,11 +73,11 @@ dict_templ = {
                     'debug osd': 25
                 }
             },
-            'log-whitelist': ['\(MDS_ALL_DOWN\)',
-                              '\(MDS_UP_LESS_THAN_MAX\)',
+            'log-whitelist': ['MDS_ALL_DOWN',
+                              'MDS_UP_LESS_THAN_MAX',
                               'Health detail'],
-            'log-ignorelist': ['\(MDS_ALL_DOWN\)',
-                               '\(MDS_UP_LESS_THAN_MAX\)',
+            'log-ignorelist': ['MDS_ALL_DOWN',
+                               'MDS_UP_LESS_THAN_MAX',
                                'Health detail'],
             'sha1': Placeholder('ceph_hash'),
         },

--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -74,9 +74,11 @@ dict_templ = {
                 }
             },
             'log-whitelist': ['\(MDS_ALL_DOWN\)',
-                              '\(MDS_UP_LESS_THAN_MAX\)'],
+                              '\(MDS_UP_LESS_THAN_MAX\)',
+                              'Health detail'],
             'log-ignorelist': ['\(MDS_ALL_DOWN\)',
-                              '\(MDS_UP_LESS_THAN_MAX\)'],
+                               '\(MDS_UP_LESS_THAN_MAX\)',
+                               'Health detail'],
             'sha1': Placeholder('ceph_hash'),
         },
         'ceph-deploy': {


### PR DESCRIPTION
we start to dump detailed health reports to clog. these reports are just
warnings and not as fatal as other WRN|ERR|SEC messages sent to clog, so
let's ignore them in the "ceph" task when checking for test failures.

Signed-off-by: Kefu Chai <kchai@redhat.com>