### PR TITLE
orchestra: introduce quiet mode for remote.run

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -550,7 +550,7 @@ class Remote(object):
         if iflags:
             args += ' iflag=' + ','.join(iflags)
         args = 'set -ex' + '\n' + args
-        proc = self.run(args=args, stdout=stdout, stderr=StringIO(), check_status=False)
+        proc = self.run(args=args, stdout=stdout, stderr=StringIO(), check_status=False, quiet=True)
         if proc.returncode:
             if 'No such file or directory' in proc.stderr.getvalue():
                 raise FileNotFoundError(errno.ENOENT,
@@ -591,7 +591,7 @@ class Remote(object):
             chown = 'sudo chown' if sudo else 'chown'
             args += '\n' + chown + ' ' + owner + ' ' + path
         args = 'set -ex' + '\n' + args
-        self.run(args=args, stdin=data)
+        self.run(args=args, stdin=data, quiet=True)
 
     def sudo_write_file(self, path, data, **kwargs):
         """


### PR DESCRIPTION
Applied changes:

- Add quiet option to remote.run and subsidiary function calls
- Logging commands now directed to DEBUG instead of INFO logger

This is usefull when we want suppress logs for some kind of commmands like
reading binary files or logging useless data to stdout/stderr as well as
dumping some vulnarable information.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>