### PR TITLE
task.internal.archive: gzip archived file size > 128MB

### DIFF
--- a/docs/detailed_test_config.rst
+++ b/docs/detailed_test_config.rst
@@ -227,6 +227,21 @@ global option can be set to true to make the unlocking happen unconditionally.
 Troubleshooting
 ===============
 
+Postmortem Debugging
+--------------------
+
+After completion of a test, the ``archive`` subdirectory is archived under
+the corresponding ``remote`` subdirectory. We can disable this behavior
+using the top-level configuration, like::
+
+  archive-on-error: true
+
+If ``archive-on-error`` is ``true``, the ``archive`` subdirectory is
+archived only for failed tests.
+
+
+Situ Debugging
+--------------
 Sometimes when a bug triggers, instead of automatic cleanup, you want
 to explore the system as is. Adding a top-level::
 

--- a/docs/detailed_test_config.rst
+++ b/docs/detailed_test_config.rst
@@ -239,6 +239,15 @@ using the top-level configuration, like::
 If ``archive-on-error`` is ``true``, the ``archive`` subdirectory is
 archived only for failed tests.
 
+If the size of the archived file exceeds 128MB, the file will be compressed
+using GZip. This threshold can be configured using the top-level option
+named ``log-compress-min-size``, like::
+
+  log-compress-min-size: 256GB
+
+Other size unit postfixes are also supported,
+see `humanfriendly document <https://pypi.org/project/humanfriendly/#a-note-about-size-units>`__
+for more details.
 
 Situ Debugging
 --------------

--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -4,18 +4,23 @@ Note that there is no corresponding task defined for this module.  All of
 the calls are made from other modules, most notably teuthology/run.py
 """
 import contextlib
+import functools
+import gzip
 import logging
 import os
+import shutil
 import time
 import yaml
 import subprocess
+
+import humanfriendly
 
 import teuthology.lock.ops
 from teuthology import misc
 from teuthology.packaging import get_builder_project
 from teuthology import report
 from teuthology.config import config as teuth_config
-from teuthology.exceptions import VersionNotFoundError
+from teuthology.exceptions import ConfigError, VersionNotFoundError
 from teuthology.job_status import get_status, set_status
 from teuthology.orchestra import cluster, remote, run
 # the below import with noqa is to workaround run.py which does not support multilevel submodule import
@@ -334,6 +339,14 @@ def fetch_binaries_for_coredumps(path, remote):
             remote.get_file(debug_path, coredump_path)
 
 
+def gzip_if_too_large(compress_min_size, src, tarinfo, local_path):
+    if tarinfo.size >= compress_min_size:
+        with gzip.open(local_path + '.gz', 'wb') as dest:
+            shutil.copyfileobj(src, dest)
+    else:
+        misc.copy_fileobj(src, tarinfo, local_path)
+
+
 @contextlib.contextmanager
 def archive(ctx, config):
     """
@@ -364,7 +377,18 @@ def archive(ctx, config):
                 os.mkdir(logdir)
             for rem in ctx.cluster.remotes.keys():
                 path = os.path.join(logdir, rem.shortname)
-                misc.pull_directory(rem, archive_dir, path)
+                min_size_option = ctx.config.get('log-compress-min-size',
+                                                 '128MB')
+                try:
+                    compress_min_size_bytes = \
+                        humanfriendly.parse_size(min_size_option)
+                except humanfriendly.InvalidSize:
+                    msg = 'invalid "log-compress-min-size": {}'.format(min_size_option)
+                    log.error(msg)
+                    raise ConfigError(msg)
+                maybe_compress = functools.partial(gzip_if_too_large,
+                                                   compress_min_size_bytes)
+                misc.pull_directory(rem, archive_dir, path, maybe_compress)
                 # Check for coredumps and pull binaries
                 fetch_binaries_for_coredumps(path, rem)
 


### PR DESCRIPTION
* misc: add an optional write_to argument to misc.pull_directory()
        so the caller can optionally specify the function to write
        to local file.
* task/internal: add a global option "log-compress-min-size" which
        defaults to "128MB". if the size of a file pulled from remote
        host is greater or equal to the specified size, it will be
        compressed with gzip with the extension of ".gz" before
        stored in the archive directory.

Signed-off-by: Kefu Chai <kchai@redhat.com>