### PR TITLE
install: install extra packages from overrides

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -203,6 +203,13 @@ def install(ctx, config):
         debs += extra_pkgs
         rpms += extra_pkgs
 
+    overrides_extra_packages = ctx.config.get(
+        'overrides', {}).get('install', {}).get('extra_packages', [])
+    log.info('extra packages from overrides: {packages}'.format(packages=overrides_extra_packages))
+    if isinstance(overrides_extra_packages, dict):
+        debs += overrides_extra_packages.get('deb', [])
+        rpms += overrides_extra_packages.get('rpm', [])
+
     # When extras is in the config we want to purposely not install ceph.
     # This is typically used on jobs that use ceph-deploy to install ceph
     # or when we are testing ceph-deploy directly.  The packages being


### PR DESCRIPTION
At the moment the only way to install extra
packages is through the config in the install
task. Installing extra packages could not be done
through the install tasks overrides.

This commit changes adds 'extra_pacakages'
from overrides to the rpm/deb package list to
install.

Signed-off-by: Ali Maredia <amaredia@redhat.com>