### PR TITLE
requirements: add libvirt-python for ubuntu

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,6 +19,7 @@ humanfriendly
 backports.ssl-match-hostname
 beanstalkc3>=0.4.0
 httplib2
+libvirt-python
 ndg-httpsclient
 pyasn1
 pyopenssl>=0.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,102 +4,346 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-ansible==2.8.8            # via -r requirements.in
-apache-libcloud==2.8.0    # via -r requirements.in
-appdirs==1.4.4            # via openstacksdk, virtualenv
-argparse==1.4.0           # via -r requirements.in
-atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via cmd2, pytest
-backports.ssl-match-hostname==3.5.0.1  # via -r requirements.in
-bcrypt==3.1.7             # via paramiko
-beanstalkc3==0.4.0        # via -r requirements.in
-boto3==1.9.161            # via -r requirements.in
-boto==2.46.1              # via -r requirements.in
-botocore==1.12.253        # via boto3, s3transfer
-certifi==2020.6.20        # via requests
-cffi==1.14.0              # via bcrypt, cryptography, pynacl
-chardet==3.0.4            # via requests
-click==7.1.2              # via pip-tools
-cliff==3.3.0              # via osc-lib, python-openstackclient
-cmd2==1.2.1               # via cliff
-colorama==0.4.3           # via cmd2
-configobj==5.0.6          # via -r requirements.in
-configparser==3.5.0       # via -r requirements.in
-cryptography==3.2         # via -r requirements.in, ansible, openstacksdk, paramiko, pyopenssl
-debtcollector==2.1.0      # via oslo.config, oslo.utils, python-keystoneclient
-decorator==4.4.2          # via dogpile.cache, openstacksdk
-distlib==0.3.1            # via virtualenv
-docopt==0.6.2             # via -r requirements.in
-docutils==0.15.2          # via botocore
-dogpile.cache==0.9.2      # via openstacksdk
-filelock==3.0.12          # via virtualenv
-gevent==1.4.0             # via -r requirements.in
-greenlet==0.4.16          # via gevent
-httplib2==0.18.0          # via -r requirements.in
-humanfriendly==8.1        # via -r requirements.in
-idna==2.8                 # via requests
-ipy==1.0                  # via -r requirements.in
-iso8601==0.1.12           # via keystoneauth1, openstacksdk, oslo.utils, python-novaclient
-jinja2==2.11.2            # via ansible
-jmespath==0.10.0          # via boto3, botocore, openstacksdk
-jsonpatch==1.26           # via openstacksdk
-jsonpointer==2.0          # via jsonpatch
-keystoneauth1==4.2.0      # via openstacksdk, osc-lib, python-cinderclient, python-keystoneclient, python-novaclient
-manhole==1.3.0            # via -r requirements.in
-markupsafe==1.1.1         # via jinja2
-more-itertools==8.4.0     # via pytest
-msgpack==1.0.0            # via oslo.serialization
-munch==2.5.0              # via openstacksdk
-ndg-httpsclient==0.4.2    # via -r requirements.in
-netaddr==0.7.19           # via -r requirements.in, oslo.config, oslo.utils
-netifaces==0.10.9         # via openstacksdk, oslo.utils
-nose==1.3.7               # via -r requirements.in
-openstacksdk==0.48.0      # via osc-lib, python-openstackclient
-os-service-types==1.7.0   # via keystoneauth1, openstacksdk
-osc-lib==2.2.0            # via python-openstackclient
-oslo.config==8.2.0        # via python-keystoneclient
-oslo.i18n==5.0.0          # via osc-lib, oslo.config, oslo.utils, python-cinderclient, python-keystoneclient, python-novaclient, python-openstackclient
-oslo.serialization==4.0.0  # via python-keystoneclient, python-novaclient
-oslo.utils==4.2.2         # via osc-lib, oslo.serialization, python-cinderclient, python-keystoneclient, python-novaclient, python-openstackclient
-paramiko==2.7.1           # via -r requirements.in
-pbr==5.4.5                # via cliff, debtcollector, keystoneauth1, openstacksdk, os-service-types, osc-lib, oslo.i18n, oslo.serialization, oslo.utils, python-cinderclient, python-keystoneclient, python-novaclient, python-openstackclient, stevedore
-pexpect==4.7.0            # via -r requirements.in
-pip-tools==4.3.0          # via -r requirements.in
-pluggy==0.13.1            # via pytest, tox
-prettytable==0.7.2        # via -r requirements.in, cliff, python-cinderclient, python-novaclient
-psutil==5.6.6             # via -r requirements.in
-ptyprocess==0.6.0         # via pexpect
-py==1.9.0                 # via pytest, tox
-pyasn1==0.2.3             # via -r requirements.in
-pycparser==2.20           # via cffi
-pyjwt==1.7.1              # via -r requirements.in
-pynacl==1.4.0             # via paramiko
-pyopenssl==19.0.0         # via -r requirements.in, ndg-httpsclient
-pyparsing==2.4.7          # via cliff, oslo.utils
-pyperclip==1.8.0          # via cmd2
-pytest==3.7.1             # via -r requirements.in
-python-cinderclient==7.1.0  # via python-openstackclient
-python-dateutil==2.6.0    # via -r requirements.in, botocore
-python-keystoneclient==4.1.0  # via python-openstackclient
-python-novaclient==17.1.0  # via -r requirements.in, python-openstackclient
-python-openstackclient==5.3.1  # via -r requirements.in
-pytz==2020.1              # via oslo.serialization, oslo.utils
-pyyaml==5.1.2             # via -r requirements.in, ansible, cliff, openstacksdk, oslo.config
-requests==2.22.0          # via -r requirements.in, apache-libcloud, keystoneauth1, oslo.config, python-cinderclient, python-keystoneclient
-requestsexceptions==1.4.0  # via openstacksdk
-rfc3986==1.4.0            # via oslo.config
-s3transfer==0.2.1         # via boto3
-sentry-sdk==0.19.5        # via teuthology
-simplejson==3.17.0        # via osc-lib, python-cinderclient, python-novaclient
-six==1.14.0               # via -r requirements.in, bcrypt, cliff, configobj, cryptography, debtcollector, keystoneauth1, munch, oslo.i18n, oslo.utils, pip-tools, pynacl, pyopenssl, pytest, python-cinderclient, python-dateutil, python-keystoneclient, python-openstackclient, tox, virtualenv
-stevedore==3.1.0          # via cliff, keystoneauth1, osc-lib, oslo.config, python-keystoneclient, python-openstackclient
-toml==0.10.1              # via -r requirements.in
-tox==3.0.0                # via -r requirements.in
-urllib3==1.25.9           # via botocore, requests
-virtualenv==20.0.26       # via tox
-wcwidth==0.2.5            # via cmd2
-wrapt==1.12.1             # via debtcollector
-xmltodict==0.12.0         # via -r requirements.in
+ansible==2.8.8
+    # via -r requirements.in
+apache-libcloud==2.8.0
+    # via -r requirements.in
+appdirs==1.4.4
+    # via
+    #   openstacksdk
+    #   virtualenv
+argparse==1.4.0
+    # via -r requirements.in
+atomicwrites==1.4.0
+    # via pytest
+attrs==19.3.0
+    # via
+    #   cmd2
+    #   pytest
+backports.ssl-match-hostname==3.5.0.1
+    # via -r requirements.in
+bcrypt==3.1.7
+    # via paramiko
+beanstalkc3==0.4.0
+    # via -r requirements.in
+boto3==1.9.161
+    # via -r requirements.in
+boto==2.46.1
+    # via -r requirements.in
+botocore==1.12.253
+    # via
+    #   boto3
+    #   s3transfer
+certifi==2020.6.20
+    # via
+    #   requests
+    #   sentry-sdk
+cffi==1.14.0
+    # via
+    #   bcrypt
+    #   cryptography
+    #   pynacl
+chardet==3.0.4
+    # via requests
+click==7.1.2
+    # via pip-tools
+cliff==3.3.0
+    # via
+    #   osc-lib
+    #   python-openstackclient
+cmd2==1.2.1
+    # via cliff
+colorama==0.4.3
+    # via cmd2
+configobj==5.0.6
+    # via -r requirements.in
+configparser==3.5.0
+    # via -r requirements.in
+cryptography==3.2
+    # via
+    #   -r requirements.in
+    #   ansible
+    #   openstacksdk
+    #   paramiko
+    #   pyopenssl
+debtcollector==2.1.0
+    # via
+    #   oslo.config
+    #   oslo.utils
+    #   python-keystoneclient
+decorator==4.4.2
+    # via
+    #   dogpile.cache
+    #   openstacksdk
+distlib==0.3.1
+    # via virtualenv
+docopt==0.6.2
+    # via -r requirements.in
+docutils==0.15.2
+    # via botocore
+dogpile.cache==0.9.2
+    # via openstacksdk
+filelock==3.0.12
+    # via virtualenv
+gevent==1.4.0
+    # via -r requirements.in
+greenlet==0.4.16
+    # via gevent
+httplib2==0.18.0
+    # via -r requirements.in
+humanfriendly==8.1
+    # via -r requirements.in
+idna==2.8
+    # via requests
+importlib-metadata==1.7.0
+    # via
+    #   cmd2
+    #   pluggy
+    #   stevedore
+    #   virtualenv
+importlib-resources==4.1.1
+    # via virtualenv
+ipy==1.0
+    # via -r requirements.in
+iso8601==0.1.12
+    # via
+    #   keystoneauth1
+    #   openstacksdk
+    #   oslo.utils
+    #   python-novaclient
+jinja2==2.11.2
+    # via ansible
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+    #   openstacksdk
+jsonpatch==1.26
+    # via openstacksdk
+jsonpointer==2.0
+    # via jsonpatch
+keystoneauth1==4.2.0
+    # via
+    #   openstacksdk
+    #   osc-lib
+    #   python-cinderclient
+    #   python-keystoneclient
+    #   python-novaclient
+libvirt-python==6.10.0
+    # via -r requirements.in
+manhole==1.3.0
+    # via -r requirements.in
+markupsafe==1.1.1
+    # via jinja2
+more-itertools==8.4.0
+    # via pytest
+msgpack==1.0.0
+    # via oslo.serialization
+munch==2.5.0
+    # via openstacksdk
+ndg-httpsclient==0.4.2
+    # via -r requirements.in
+netaddr==0.7.19
+    # via
+    #   -r requirements.in
+    #   oslo.config
+    #   oslo.utils
+netifaces==0.10.9
+    # via
+    #   openstacksdk
+    #   oslo.utils
+nose==1.3.7
+    # via -r requirements.in
+openstacksdk==0.48.0
+    # via
+    #   osc-lib
+    #   python-openstackclient
+os-service-types==1.7.0
+    # via
+    #   keystoneauth1
+    #   openstacksdk
+osc-lib==2.2.0
+    # via python-openstackclient
+oslo.config==8.2.0
+    # via python-keystoneclient
+oslo.i18n==5.0.0
+    # via
+    #   osc-lib
+    #   oslo.config
+    #   oslo.utils
+    #   python-cinderclient
+    #   python-keystoneclient
+    #   python-novaclient
+    #   python-openstackclient
+oslo.serialization==4.0.0
+    # via
+    #   python-keystoneclient
+    #   python-novaclient
+oslo.utils==4.2.2
+    # via
+    #   osc-lib
+    #   oslo.serialization
+    #   python-cinderclient
+    #   python-keystoneclient
+    #   python-novaclient
+    #   python-openstackclient
+paramiko==2.7.1
+    # via -r requirements.in
+pbr==5.4.5
+    # via
+    #   cliff
+    #   debtcollector
+    #   keystoneauth1
+    #   openstacksdk
+    #   os-service-types
+    #   osc-lib
+    #   oslo.i18n
+    #   oslo.serialization
+    #   oslo.utils
+    #   python-cinderclient
+    #   python-keystoneclient
+    #   python-novaclient
+    #   python-openstackclient
+    #   stevedore
+pexpect==4.7.0
+    # via -r requirements.in
+pip-tools==4.3.0
+    # via -r requirements.in
+pluggy==0.13.1
+    # via
+    #   pytest
+    #   tox
+prettytable==0.7.2
+    # via
+    #   -r requirements.in
+    #   cliff
+    #   python-cinderclient
+    #   python-novaclient
+psutil==5.6.6
+    # via -r requirements.in
+ptyprocess==0.6.0
+    # via pexpect
+py==1.9.0
+    # via
+    #   pytest
+    #   tox
+pyasn1==0.2.3
+    # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pyjwt==1.7.1
+    # via -r requirements.in
+pynacl==1.4.0
+    # via paramiko
+pyopenssl==19.0.0
+    # via
+    #   -r requirements.in
+    #   ndg-httpsclient
+pyparsing==2.4.7
+    # via
+    #   cliff
+    #   oslo.utils
+pyperclip==1.8.0
+    # via cmd2
+pytest==3.7.1
+    # via -r requirements.in
+python-cinderclient==7.1.0
+    # via python-openstackclient
+python-dateutil==2.6.0
+    # via
+    #   -r requirements.in
+    #   botocore
+python-keystoneclient==4.1.0
+    # via python-openstackclient
+python-novaclient==17.1.0
+    # via
+    #   -r requirements.in
+    #   python-openstackclient
+python-openstackclient==5.3.1
+    # via -r requirements.in
+pytz==2020.1
+    # via
+    #   oslo.serialization
+    #   oslo.utils
+pyyaml==5.1.2
+    # via
+    #   -r requirements.in
+    #   ansible
+    #   cliff
+    #   openstacksdk
+    #   oslo.config
+requests==2.22.0
+    # via
+    #   -r requirements.in
+    #   apache-libcloud
+    #   keystoneauth1
+    #   oslo.config
+    #   python-cinderclient
+    #   python-keystoneclient
+requestsexceptions==1.4.0
+    # via openstacksdk
+rfc3986==1.4.0
+    # via oslo.config
+s3transfer==0.2.1
+    # via boto3
+sentry-sdk==0.19.5
+    # via -r requirements.in
+simplejson==3.17.0
+    # via
+    #   osc-lib
+    #   python-cinderclient
+    #   python-novaclient
+six==1.14.0
+    # via
+    #   -r requirements.in
+    #   bcrypt
+    #   cliff
+    #   configobj
+    #   cryptography
+    #   debtcollector
+    #   keystoneauth1
+    #   munch
+    #   oslo.i18n
+    #   oslo.utils
+    #   pip-tools
+    #   pynacl
+    #   pyopenssl
+    #   pytest
+    #   python-cinderclient
+    #   python-dateutil
+    #   python-keystoneclient
+    #   python-openstackclient
+    #   tox
+    #   virtualenv
+stevedore==3.1.0
+    # via
+    #   cliff
+    #   keystoneauth1
+    #   osc-lib
+    #   oslo.config
+    #   python-keystoneclient
+    #   python-openstackclient
+toml==0.10.1
+    # via -r requirements.in
+tox==3.0.0
+    # via -r requirements.in
+urllib3==1.25.9
+    # via
+    #   botocore
+    #   requests
+    #   sentry-sdk
+virtualenv==20.0.26
+    # via tox
+wcwidth==0.2.5
+    # via cmd2
+wrapt==1.12.1
+    # via debtcollector
+xmltodict==0.12.0
+    # via -r requirements.in
+zipp==3.4.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
             'backports.ssl_match_hostname',
             'beanstalkc3 >= 0.4.0',
             'httplib2',
+            'libvirt-python',
             'ndg-httpsclient',  # for requests, urllib3
             'pyasn1',           # for requests, urllib3
             'pyopenssl>=0.13',  # for requests, urllib3


### PR DESCRIPTION
libvirt-python is needed to import libvirt in python for ubuntu

Signed-off-by: Seena Fallah <seenafallah@gmail.com>