### PR TITLE
exceptions: only use one of label or command for fingerprint

### DIFF
--- a/teuthology/exceptions.py
+++ b/teuthology/exceptions.py
@@ -74,9 +74,8 @@ class CommandFailedError(Exception):
         Used by sentry instead of grouping by backtrace.
         """
         return [
-            ' '.join(self.command),
+            self.label or self.command,
             'exit status {}'.format(self.exitstatus),
-            self.label,
             '{{ type }}',
         ]
 


### PR DESCRIPTION
Commands like those running workunits include the ceph sha1 being
tested, so they're not useful for grouping. This also lets us group
together other tests if we like, for example to map tests with small
differences in configuration to the same fingerprint for sentry.

Also use the plain command, it's already a string at this point
so there's no reason to add spaces between its characters.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>