### PR TITLE
teuthology/misc: make the Valgrind's early exit configurable.

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1020,7 +1020,7 @@ def deep_merge(a, b):
     return b
 
 
-def get_valgrind_args(testdir, name, preamble, v):
+def get_valgrind_args(testdir, name, preamble, v, exit_on_first_error=True):
     """
     Build a command line for running valgrind.
 
@@ -1051,9 +1051,6 @@ def get_valgrind_args(testdir, name, preamble, v):
             '--xml-file={vdir}/{n}.log'.format(vdir=val_path, n=name),
             '--time-stamp=yes',
             '--vgdb=yes',
-            # at least Valgrind 3.14 is required
-            '--exit-on-first-error=yes',
-            '--error-exitcode=42',
         ]
     else:
         extra_args = [
@@ -1064,9 +1061,13 @@ def get_valgrind_args(testdir, name, preamble, v):
             '--log-file={vdir}/{n}.log'.format(vdir=val_path, n=name),
             '--time-stamp=yes',
             '--vgdb=yes',
+        ]
+    if exit_on_first_error:
+        extra_args.extend([
+            # at least Valgrind 3.14 is required
             '--exit-on-first-error=yes',
             '--error-exitcode=42',
-        ]
+        ])
     args = [
         'cd', testdir,
         run.Raw('&&'),


### PR DESCRIPTION
This commit is a follow-up to a98eb3e1405c8ca8f6933eb0356c03955e4e2e83 where Valgrind has been configured to exit on first-seen error as it was (wrongly!) assumed that all components are green when it comes to the Valgrind verification.
This assumption turned out to be broken for RGW which got a few issues over the course as a result of having the Valgrind checks knocked out as a side effect of the python3 transition \[1\]. In the consequence, multiple problems accumulated and introducing a mechanism to disable the early exit to e.g. develop a list of these issues looks desirable.

\[1\]: https://github.com/ceph/teuthology/pull/1503#issuecomment-762837504

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>