### PR TITLE
Fix docs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 
 Welcome! Teuthology's documentation is primarily hosted at `docs.ceph.com
-<http://docs.ceph.com/teuthology/docs/>`__.
+<https://docs.ceph.com/projects/teuthology/en/latest/README.html>`__.
 
 You can also look at docs `inside this repository <docs/>`__, but note that
 GitHub's `RST <http://docutils.sourceforge.net/rst.html>`__ rendering is quite


### PR DESCRIPTION
docs: fix Teuthology docs link

Updates the link to the canonical location so we don't have to rely on redirects
