### PR TITLE
dispatcher/repo_utils: handle missing commits better

### DIFF
--- a/teuthology/dispatcher/__init__.py
+++ b/teuthology/dispatcher/__init__.py
@@ -10,6 +10,7 @@ from teuthology import setup_log_file, install_except_hook
 from teuthology import beanstalk
 from teuthology import report
 from teuthology.config import config as teuth_config
+from teuthology.exceptions import SkipJob
 from teuthology.repo_utils import fetch_qa_suite, fetch_teuthology
 from teuthology.lock.ops import block_and_lock_machines
 from teuthology.dispatcher import supervisor
@@ -117,11 +118,14 @@ def main(args):
         if job_config.get('stop_worker'):
             keep_running = False
 
-        job_config, teuth_bin_path = prep_job(
-            job_config,
-            log_file_path,
-            archive_dir,
-        )
+        try:
+            job_config, teuth_bin_path = prep_job(
+                job_config,
+                log_file_path,
+                archive_dir,
+            )
+        except SkipJob:
+            continue
 
         # lock machines but do not reimage them
         if 'roles' in job_config:

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -91,7 +91,7 @@ def enforce_repo_state(repo_url, dest_path, branch, commit=None, remove_on_error
     repo_reset = os.path.join(dest_path, '.fetched_and_reset')
     try:
         if not os.path.isdir(dest_path):
-            clone_repo(repo_url, dest_path, branch)
+            clone_repo(repo_url, dest_path, branch, shallow=commit is None)
         elif not commit and not is_fresh(sentinel):
             set_remote(dest_path, repo_url)
             fetch_branch(dest_path, branch)
@@ -127,7 +127,7 @@ def clone_repo(repo_url, dest_path, branch, shallow=True):
     if branch.startswith('refs/'):
         clone_repo_ref(repo_url, dest_path, branch)
         return
-    args = ['git', 'clone']
+    args = ['git', 'clone', '--single-branch']
     if shallow:
         args.extend(['--depth', '1'])
     args.extend(['--branch', branch, repo_url, dest_path])

--- a/teuthology/worker.py
+++ b/teuthology/worker.py
@@ -14,7 +14,7 @@ from teuthology import report
 from teuthology import safepath
 from teuthology.config import config as teuth_config
 from teuthology.config import set_config_attr
-from teuthology.exceptions import BranchNotFoundError, SkipJob, MaxWhileTries
+from teuthology.exceptions import BranchNotFoundError, CommitNotFoundError, SkipJob, MaxWhileTries
 from teuthology.kill import kill_job
 from teuthology.repo_utils import fetch_qa_suite, fetch_teuthology, ls_remote, build_git_url
 
@@ -181,8 +181,8 @@ def prep_job(job_config, log_file_path, archive_dir):
             fetch_qa_suite(suite_branch, suite_sha1),
             job_config.get('suite_relpath', ''),
         ))
-    except BranchNotFoundError as exc:
-        log.exception("Branch not found; marking job as dead")
+    except (BranchNotFoundError, CommitNotFoundError) as exc:
+        log.exception("Requested version not found; marking job as dead")
         report.try_push_job_info(
             job_config,
             dict(status='dead', failure_reason=str(exc))


### PR DESCRIPTION
If the commit is behind head, we need more history to clone it.

In the future we may be able to configure a git mirror to allow fetching an exact commit to speed this up.
For now, just clone the whole branch, and properly handle the error if the commit is not found.