### PR TITLE
dispatcher: add .log extension for supervisor log

### DIFF
--- a/teuthology/dispatcher/supervisor.py
+++ b/teuthology/dispatcher/supervisor.py
@@ -41,7 +41,7 @@ def main(args):
     log.setLevel(loglevel)
 
     log_file_path = os.path.join(job_config['archive_path'],
-                                 f"supervisor.{job_config['job_id']}")
+                                 f"supervisor.{job_config['job_id']}.log")
     setup_log_file(log_file_path)
     install_except_hook()
 


### PR DESCRIPTION
It would be great to have an extension for easy log identification.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>