### PR TITLE
supervisor: improve error handling for dead jobs

### DIFF
--- a/scripts/nuke.py
+++ b/scripts/nuke.py
@@ -5,7 +5,7 @@ import teuthology.nuke
 doc = """
 usage:
   teuthology-nuke --help
-  teuthology-nuke [-v] [--owner OWNER] [-n NAME] [-u] [-i] [-r] [-s]
+  teuthology-nuke [-v] [--owner OWNER] [-n NAME] [-u] [-i] [-r] [-s] [-k]
                        [-p PID] [--dry-run] (-t CONFIG... | -a DIR)
   teuthology-nuke [-v] [-u] [-i] [-r] [-s] [--dry-run] --owner OWNER --stale
   teuthology-nuke [-v] [--dry-run] --stale-openstack
@@ -33,6 +33,7 @@ optional arguments:
                         targets thatcould not be nuked.
   -n NAME, --name NAME  Name of run to cleanup
   -i, --noipmi          Skip ipmi checking
+  -k, --keep-logs       Preserve test directories and logs on the machines
 
 Examples:
 teuthology-nuke -t target.yaml --unlock --owner user@host

--- a/scripts/nuke.py
+++ b/scripts/nuke.py
@@ -5,7 +5,7 @@ import teuthology.nuke
 doc = """
 usage:
   teuthology-nuke --help
-  teuthology-nuke [-v] [--owner OWNER] [-n NAME] [-u] [-i] [-r] [-s] [-k]
+  teuthology-nuke [-v] [--owner OWNER] [-n NAME] [-u] [-i] [-r|-R] [-s] [-k]
                        [-p PID] [--dry-run] (-t CONFIG... | -a DIR)
   teuthology-nuke [-v] [-u] [-i] [-r] [-s] [--dry-run] --owner OWNER --stale
   teuthology-nuke [-v] [--dry-run] --stale-openstack
@@ -27,7 +27,8 @@ optional arguments:
                         targets that would be nuked
   --owner OWNER         job owner
   -p PID, --pid PID     pid of the process to be killed
-  -r, --reboot-all      reboot all machines
+  -r, --reboot-all      reboot all machines (default)
+  -R, --no-reboot       do not reboot the machines
   -s, --synch-clocks    synchronize clocks on all machines
   -u, --unlock          Unlock each successfully nuked machine, and output
                         targets thatcould not be nuked.

--- a/teuthology/dispatcher/supervisor.py
+++ b/teuthology/dispatcher/supervisor.py
@@ -161,10 +161,10 @@ def reimage(job_config):
     targets = job_config['targets']
     try:
         reimaged = reimage_machines(ctx, targets, job_config['machine_type'])
-    except Exception:
-        log.info('Reimaging error. Nuking machines...')
+    except Exception as e:
+        log.exception('Reimaging error. Nuking machines...')
         # Reimage failures should map to the 'dead' status instead of 'fail'
-        report.try_push_job_info(ctx.config, dict(status='dead'))
+        report.try_push_job_info(ctx.config, dict(status='dead', failure_reason='Error reimaging machines: ' + str(e)))
         nuke(ctx, True)
         raise
     ctx.config['targets'] = reimaged
@@ -208,11 +208,13 @@ def run_with_watchdog(process, job_config):
 
     # Sleep once outside of the loop to avoid double-posting jobs
     time.sleep(teuth_config.watchdog_interval)
+    hit_max_timeout = False
     while process.poll() is None:
         # Kill jobs that have been running longer than the global max
         run_time = datetime.utcnow() - job_start_time
         total_seconds = run_time.days * 60 * 60 * 24 + run_time.seconds
         if total_seconds > teuth_config.max_job_time:
+            hit_max_timeout = True
             log.warning("Job ran longer than {max}s. Killing...".format(
                 max=teuth_config.max_job_time))
             try:
@@ -249,7 +251,10 @@ def run_with_watchdog(process, job_config):
     # the status, but if it was a pass or fail it will have already been
     # reported to paddles. In that case paddles ignores the 'dead' status.
     # If the job was killed, paddles will use the 'dead' status.
-    report.try_push_job_info(job_info, dict(status='dead'))
+    extra_info = dict(status='dead')
+    if hit_max_timeout:
+        extra_info['failure_reason'] = 'hit max job timeout'
+    report.try_push_job_info(job_info, extra_info)
 
 
 def create_fake_context(job_config, block=False):

--- a/teuthology/nuke/__init__.py
+++ b/teuthology/nuke/__init__.py
@@ -278,6 +278,7 @@ def nuke(ctx, should_unlock, sync_clocks=True, reboot_all=True, noipmi=False):
 def nuke_one(ctx, target, should_unlock, synch_clocks, reboot_all,
              check_locks, noipmi):
     ret = None
+    keep_logs = ctx.keep_logs
     ctx = argparse.Namespace(
         config=dict(targets=target),
         owner=ctx.owner,
@@ -289,7 +290,7 @@ def nuke_one(ctx, target, should_unlock, synch_clocks, reboot_all,
         noipmi=noipmi,
     )
     try:
-        nuke_helper(ctx, should_unlock)
+        nuke_helper(ctx, should_unlock, keep_logs)
     except Exception:
         log.exception('Could not nuke %s' % target)
         # not re-raising the so that parallel calls aren't killed
@@ -300,7 +301,7 @@ def nuke_one(ctx, target, should_unlock, synch_clocks, reboot_all,
     return ret
 
 
-def nuke_helper(ctx, should_unlock):
+def nuke_helper(ctx, should_unlock, keep_logs):
     # ensure node is up with ipmi
     (target,) = ctx.config['targets'].keys()
     host = target.split('@')[-1]
@@ -352,7 +353,8 @@ def nuke_helper(ctx, should_unlock):
     undo_multipath(ctx)
     reset_syslog_dir(ctx)
     remove_ceph_data(ctx)
-    remove_testing_tree(ctx)
+    if not keep_logs:
+        remove_testing_tree(ctx)
     remove_yum_timedhosts(ctx)
     # Once again remove packages after reboot
     remove_installed_packages(ctx)


### PR DESCRIPTION
Include failure messages so we can tell why jobs are marked dead. Also fix a hang in cleaning up when we hit the max jobs timeout due to logs continuing to grow - kill the processes creating them before collecting the logs.