### PR TITLE
ls: nicer ls output

### DIFF
--- a/teuthology/ls.py
+++ b/teuthology/ls.py
@@ -56,23 +56,14 @@ def print_debug_info(job, job_dir, archive_dir):
     print('%s      ' % job, end='')
 
     try:
-        pidfile = os.path.join(job_dir, 'pid')
-        found = False
-        if os.path.isfile(pidfile):
-            pid = open(pidfile, 'r').read()
-            if os.path.isdir("/proc/%s" % pid):
-                cmdline = open('/proc/%s/cmdline' % pid,
-                               'r').read()
-                if cmdline.find(archive_dir) >= 0:
-                    print('(pid %s)' % pid, end='')
-                    found = True
-        if not found:
-            print('(no process or summary.yaml)', end='')
-        # tail
-        tail = os.popen(
-            'tail -1 %s/%s/teuthology.log' % (archive_dir, job)
-        ).read().rstrip()
-        print(tail, end='')
+        log_path = os.path.join(archive_dir, job, 'teuthology.log')
+        if os.path.exists(log_path):
+            tail = os.popen(
+                'tail -1 %s' % log_path
+            ).read().rstrip()
+            print(tail, end='')
+        else:
+            print('<no teuthology.log yet>', end='')
     except IOError:
         pass
     print('')


### PR DESCRIPTION
- no error when teuthology.log is missing (provisioning)
- leave off pid

Signed-off-by: Sage Weil <sage@redhat.com>