### PR TITLE
suite: lower debug_ms for osd back to 1

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -70,7 +70,7 @@ dict_templ = {
                 'osd': {
                     'debug filestore': 20,
                     'debug journal': 20,
-                    'debug ms': 20,
+                    'debug ms': 1,
                     'debug osd': 25
                 }
             },


### PR DESCRIPTION
This was increased for some mgr issues in
044384be450a557f56a2b39bf7d0e71e69d45cd3, but isn't helping much now
and is filling up disks for long-running tests.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>