### PR TITLE
orchestra/daemon/cephadmunit: ignore exception when sending signal

### DIFF
--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -120,7 +120,12 @@ class CephadmUnit(DaemonState):
         """
         if not silent:
             self.log.info('Senging signal %d to %s...' % (sig, self.name()))
-        self.remote.sh(self.kill_cmd(sig))
+        # Ignore exception here because sending a singal via docker can be
+        # quite slow and easily race with, say, the daemon shutting down.
+        try:
+            self.remote.sh(self.kill_cmd(sig))
+        except Exception as e:
+            self.log.info(f'Ignoring exception while sending signal: {e}')
 
     def start(self, timeout=300):
         """


### PR DESCRIPTION
The osd thrashing is sending lots of signals (sighup) and can easily race with
a daemon shutting down entirely.

This makes us match the behavior of the original state.py signal() method.

Signed-off-by: Sage Weil <sage@newdream.net>