### PR TITLE
selinux: ignore issues with sssd

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -131,6 +131,7 @@ class SELinux(Task):
             'comm="rpm"',
             'tcontext=system_u:object_r:container_runtime_exec_t:s0',
             'comm="ksmtuned"',
+            'common="sssd"',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
['type=AVC msg=audit(1614438637.552:5615): avc: denied { read } for pid=876 comm="sssd" name="resolv.conf" dev="sda1" ino=265261 scontext=system_u:system_r:sssd_t:s0 tcontext=unconfined_u:object_r:admin_home_t:s0 tclass=file permissive=1']

(currently seen on rhel 8.3)

Signed-off-by: Sage Weil <sage@newdream.net>