### PR TITLE
teuthology-suite: add default machine type(smithi)

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -7,8 +7,8 @@ from teuthology.config import config
 
 doc = """
 usage: teuthology-suite --help
-       teuthology-suite [-v | -vv ] --machine-type <type> --suite <suite> [options] [<config_yaml>...]
-       teuthology-suite [-v | -vv ] --machine-type <type> --rerun <name>  [options] [<config_yaml>...]
+       teuthology-suite [-v | -vv ] --suite <suite> [options] [<config_yaml>...]
+       teuthology-suite [-v | -vv ] --rerun <name>  [options] [<config_yaml>...]
 
 Run a suite of ceph integration tests. A suite is a directory containing
 facets. A facet is a directory containing config snippets. Running a suite

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -112,10 +112,13 @@ def main(args):
         teuthology.log.setLevel(logging.DEBUG)
 
     if not conf.machine_type or conf.machine_type == 'None':
-        schedule_fail("Must specify a machine_type")
+        if not config.default_machine_type or config.default_machine_type == 'None':
+            schedule_fail("Must specify a machine_type")
+        else:
+           conf.machine_type = config.default_machine_type
     elif 'multi' in conf.machine_type:
         schedule_fail("'multi' is not a valid machine_type. " +
-                      "Maybe you want 'plana,mira,burnupi' or similar")
+                      "Maybe you want 'gibba,smithi,mira' or similar")
 
     if conf.email:
         config.results_email = conf.email


### PR DESCRIPTION
right now the default_machine_type fallback is set to None via some internal
mangaling, this makes users always have to pass --machine_type which mostly we
prefer to smithi's . Hence, making it a default unless otherwise, should be
helpful for users.

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>