### PR TITLE
task/internal: ignore systemd-sysusers core file

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -467,6 +467,9 @@ def coredump(ctx, config):
                 args=[
                     'sudo', 'sysctl', '-w', 'kernel.core_pattern=core',
                     run.Raw('&&'),
+                    'sudo', 'bash', '-c',
+                    f'for f in `find {archive_dir}/coredump -type f`; do file $f | grep -q systemd-sysusers && rm $f ; done',
+                    run.Raw('&&'),
                     # don't litter the archive dir if there were no cores dumped
                     'rmdir',
                     '--ignore-fail-on-non-empty',


### PR DESCRIPTION
This is related to dnsmasq.  When installing hte kubic podman 3.0.1
packages,

  Running scriptlet: dnsmasq-2.79-13.el8_3.1.x86_64                                                                                                                                                                                                                                                                                                                                                                                                                            14/16
/var/tmp/rpm-tmp.6MFp00: line 5:  9079 Segmentation fault      (core dumped) systemd-sysusers -  &> /dev/null <<SYSTEMD_INLINE_EOF
u dnsmasq - "Dnsmasq DHCP and DNS server" /var/lib/dnsmasq
SYSTEMD_INLINE_EOF


  Installing       : dnsmasq-2.79-13.el8_3.1.x86_64                                                                                                                                                                                                                                                                                                                                                                                                                            14/16
warning: group dnsmasq does not exist - using root
warning: group dnsmasq does not exist - using root
warning: group dnsmasq does not exist - using root

  Running scriptlet: dnsmasq-2.79-13.el8_3.1.x86_64                                                                                                                                                                                                                                                                                                                                                                                                                            14/16
/var/tmp/rpm-tmp.pfCGxn: line 3:  9089 Segmentation fault      (core dumped) systemd-sysusers &> /dev/null

  Installing       : podman-3.0.1-2.el8.3.2.x86_64                                                                                                                                                                                                                                                                                                                                                                                                                             15/16
  Installing       : podman-plugins-3.0.1-2.el8.3.2.x86_64                                                                                                                                                                                                                                                                                                                                                                                                                     16/16
  Running scriptlet: container-selinux-2:2.145.0-1.el8.noarch                                                                                                                                                                                                                                                                                                                                                                                                                  16/16
  Running scriptlet: podman-plugins-3.0.1-2.el8.3.2.x86_64                                                                                                                                                                                                                                                                                                                                                                                                                     16/16
/var/tmp/rpm-tmp.bFfmjl: line 6: 11098 Segmentation fault      (core dumped) /usr/bin/systemd-sysusers
warning: %triggerin(systemd-239-18.el8.x86_64) scriptlet failed, exit status 139

Error in <unknown> scriptlet in rpm package podman-plugins
  Verifying        : dnsmasq-2.79-13.el8_3.1.x86_64                                                                                                                                                                                                                                                                                                                                                                                                                             1/16

Nothing to do with us.

Signed-off-by: Sage Weil <sage@newdream.net>