### PR TITLE
Revert "Merge pull request #1631 from jdurgin/wip-nuke-poweroff"

### DIFF
--- a/teuthology/nuke/__init__.py
+++ b/teuthology/nuke/__init__.py
@@ -314,14 +314,13 @@ def nuke_helper(ctx, should_unlock, keep_logs, should_reboot):
         # we want to be able to nuke a downed node
         check_lock.check_lock(ctx, None, check_up=False)
     status = get_status(host)
-    if should_reboot:
-        if status['machine_type'] in provision.fog.get_types():
-            remote = Remote(host)
-            remote.console.power_off()
-            return
-        elif status['machine_type'] in provision.pelagos.get_types():
-            provision.pelagos.park_node(host)
-            return
+    if status['machine_type'] in provision.fog.get_types():
+        remote = Remote(host)
+        remote.console.power_off()
+        return
+    elif status['machine_type'] in provision.pelagos.get_types():
+        provision.pelagos.park_node(host)
+        return
 
     if (not ctx.noipmi and 'ipmi_user' in config and
             'vpm' not in shortname):


### PR DESCRIPTION
This reverts commit c48eb744081d22bc82d7d099d4edb67ae02551e0, reversing
changes made to b96569170f15eae4604f361990ea65737b28dff1.

This is causing log gzipping to fail because the logs already exist as .gz files.
My guess is that the logs are left over from previous, but I'm not sure how
that would happen.

In any case, the merge of this PR corresponds exactly to when we started seeing
the log gzip failures.

Signed-off-by: Sage Weil <sage@newdream.net>