### PR TITLE
suite: set auth_{mon,service}_ticket_ttl to smaller values

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -61,6 +61,8 @@ dict_templ = {
         'ceph': {
             'conf': {
                 'mon': {
+                    'auth mon ticket ttl': 660,  # 11m
+                    'auth service ticket ttl': 240,  # 4m
                     'debug mon': 20,
                     'debug ms': 1,
                     'debug paxos': 20},


### PR DESCRIPTION
Trigger ticket renewal code paths for medium and long-running jobs
for all suites.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>