### PR TITLE
suite/util: fix KeyError in get_sha1s

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -991,6 +991,8 @@ class ShamanProject(GitbuilderProject):
         )
         build_url = urljoin(self.query_url, path)
 
+        log.debug(f'Check build complete for results: {search_result}')
+        log.debug(f'Querying {build_url}...')
         try:
             resp = requests.get(build_url)
             resp.raise_for_status()
@@ -1003,6 +1005,7 @@ class ShamanProject(GitbuilderProject):
                 build['flavor'] == search_result['flavor'] and
                 build['distro_arch'] in search_result['archs']
                ):
+                log.debug(f'Matched build: {build}')
                 return build['status'] == 'completed'
         return False
 

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -482,7 +482,7 @@ def find_git_parent(project, sha1):
         if len(sha1s) != count:
             log.debug('got response: %s', resp.json())
             log.error('can''t find %d parents of %s in %s: %s',
-                       int(count), sha1, project, resp.json()['error'])
+                       int(count), sha1, project, resp.json()['err'])
         return sha1s
 
     # XXX don't do this every time?..


### PR DESCRIPTION
The git.ceph.com:8080/history returns json with 'err' instead of 'error'.

```
  2021-04-21 08:29:51,334.334 DEBUG:teuthology.suite.util:got response: {'committish': 'e647a64c1e8147b04e84575a0fc53dee65cecab2', 'err': 'fatal: bad object e647a64c1e8147b04e84575a0fc53dee65cecab2\n', 'sha1s': []}
  Traceback (most recent call last):
    File "/home/runner/src/teuthology_master/virtualenv/bin/teuthology-suite", line 33, in <module>
      sys.exit(load_entry_point('teuthology', 'console_scripts', 'teuthology-suite')())
    File "/home/runner/src/teuthology_master/scripts/suite.py", line 189, in main
      return teuthology.suite.main(args)
    File "/home/runner/src/teuthology_master/teuthology/suite/__init__.py", line 143, in main
      run.prepare_and_schedule()
    File "/home/runner/src/teuthology_master/teuthology/suite/run.py", line 397, in prepare_and_schedule
      num_jobs = self.schedule_suite()
    File "/home/runner/src/teuthology_master/teuthology/suite/run.py", line 612, in schedule_suite
      util.find_git_parent('ceph', self.base_config.sha1)
    File "/home/runner/src/teuthology_master/teuthology/suite/util.py", line 491, in find_git_parent
      sha1s = get_sha1s(project, sha1, 2)
    File "/home/runner/src/teuthology_master/teuthology/suite/util.py", line 485, in get_sha1s
      int(count), sha1, project, resp.json()['error'])
  KeyError: 'error'
```

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>