### PR TITLE
bootstrap: do not pass '--use-feature=2020-resolver' to pip

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -155,15 +155,8 @@ if [ -z "$NO_CLOBBER" ] || [ ! -e ./$VENV ]; then
     virtualenv --python=$PYTHON $VENV
 fi
 
-
-# be compatible with pip shipped by distro older v20.2
-if ./$VENV/bin/pip --use-feature=2020-resolver >/dev/null 2>&1 ; then
-    PIP_INSTALL="./$VENV/bin/pip install --use-feature=2020-resolver"
-else
-    PIP_INSTALL="./$VENV/bin/pip install"
-fi
 # Upgrade pip first - then we have a new pip version with the --use-feature flag
-$PIP_INSTALL --upgrade pip
+./$VENV/bin/pip install --upgrade pip
 
 # Ensure setuptools is installed
 ./$VENV/bin/pip install --use-feature=2020-resolver setuptools --upgrade


### PR DESCRIPTION
this reverts f2607ee8ce149f2951c5fd62c259fc4fa3ddcb5a

to silence the warning from pip:

WARNING: --use-feature=2020-resolver no longer has any effect, since it
is now the default dependency resolver in pip. This will become an error
in pip 21.0.

Signed-off-by: Kefu Chai <kchai@redhat.com>