### PR TITLE
task/internal/redhat.py: added container tool login support

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -250,7 +250,8 @@ def get_initial_tasks(lock, config, machine_type):
             {'internal.git_ignore_ssl': None},
             {'internal.setup_cdn_repo': None},
             {'internal.setup_base_repo': None},
-            {'internal.setup_additional_repo': None}
+            {'internal.setup_additional_repo': None},
+            {'internal.setup_container_registry': None}
         ])
         # Install latest kernel task for redhat downstream runs
         if config.get('redhat').get('install_latest_rh_kernel', False):

--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -24,7 +24,9 @@ from teuthology.exceptions import ConfigError, VersionNotFoundError
 from teuthology.job_status import get_status, set_status
 from teuthology.orchestra import cluster, remote, run
 # the below import with noqa is to workaround run.py which does not support multilevel submodule import
-from teuthology.task.internal.redhat import setup_cdn_repo, setup_base_repo, setup_additional_repo, setup_stage_cdn  # noqa
+from teuthology.task.internal.redhat import (setup_cdn_repo, setup_base_repo,            # noqa
+                                             setup_additional_repo,                      # noqa
+                                             setup_stage_cdn, setup_container_registry)  # noqa
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Setup container registry login task is essential to access Ceph monitoring images from Red Hat registry source.

**Test result:**
- setup_container_registry attribute is provided in config with correct registry name.
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil/test_container-login-1405/teuthology.log
- setup_container_registry attribute is not provided in config.
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil/test_container-login-1405-02/teuthology.log
- setup_container_registry attribute is provided in config with incorrect registry name.
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil/test_container-login-1405-03/teuthology.log