### PR TITLE
task/internal/syslog: avoid failing runs when ceph daemon logs go to syslog misc.log

### DIFF
--- a/teuthology/task/internal/syslog.py
+++ b/teuthology/task/internal/syslog.py
@@ -99,7 +99,7 @@ def syslog(ctx, config):
                 [
                     'egrep', '--binary-files=text',
                     '\\bBUG\\b|\\bINFO\\b|\\bDEADLOCK\\b',
-                    run.Raw('{adir}/syslog/*.log'.format(adir=archive_dir)),
+                    run.Raw(f'{archive_dir}/syslog/kern.log'),
                     run.Raw('|'),
                     'grep', '-v', 'task .* blocked for more than .* seconds',
                     run.Raw('|'),


### PR DESCRIPTION
Avoid the problem of tests failing by not checking for magic strings in misc.log--these were intended for kern.log checks.

It is still a bit of a mystery why there is a difference in behavior when ceph daemons log to stdout/stderr (output *never* makes its way to misc.log) vs ceph daemons logging to the journald socket (https://github.com/ceph/ceph/pull/40640) (logs *sometimes* end up in misc.log).