### PR TITLE
Restrict build_complete check to x86_64

### DIFF
--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -1001,7 +1001,7 @@ class ShamanProject(GitbuilderProject):
                 build['distro'] == search_result['distro'] and
                 build['distro_version'] == search_result['distro_version'] and
                 build['flavor'] == search_result['flavor'] and
-                build['distro_arch'] in search_result['archs']
+                build['distro_arch'] == 'x86_64'
                ):
                 return build['status'] == 'completed'
         return False


### PR DESCRIPTION
Without this restriction a failed arm64 build will result in the
container build reporting failure.

Fixes: https://tracker.ceph.com/issues/50922

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>