### PR TITLE
nuke: kill -9 the teuthology process

### DIFF
--- a/teuthology/nuke/__init__.py
+++ b/teuthology/nuke/__init__.py
@@ -225,7 +225,7 @@ def main(args):
     if ctx.pid:
         if ctx.archive:
             log.info('Killing teuthology process at pid %d', ctx.pid)
-            os.system('grep -q %s /proc/%d/cmdline && sudo kill %d' % (
+            os.system('grep -q %s /proc/%d/cmdline && sudo kill -9 %d' % (
                 ctx.archive,
                 ctx.pid,
                 ctx.pid))


### PR DESCRIPTION
If the process has been kill -STOPped, then we'll unlock the machines, but
the process will stick around and we'll try to nuke it again later,
zapping the machines after they're being used by some other job, leading
to failures.  (Usually this manifests as an error when the other job stops
where it has trouble gzipping the logs.)

Signed-off-by: Sage Weil <sage@newdream.net>