### PR TITLE
Update distro maps

### DIFF
--- a/teuthology/orchestra/opsys.py
+++ b/teuthology/orchestra/opsys.py
@@ -59,12 +59,12 @@ DISTRO_CODENAME_MAP = {
 }
 
 DEFAULT_OS_VERSION = dict(
-    ubuntu="18.04",
+    ubuntu="20.04",
     fedora="25",
-    centos="8.1",
+    centos="8.4",
     opensuse="15.0",
     sle="15.0",
-    rhel="8.1",
+    rhel="8.4",
     debian='8.0'
 )
 

--- a/teuthology/orchestra/opsys.py
+++ b/teuthology/orchestra/opsys.py
@@ -26,6 +26,7 @@ DISTRO_CODENAME_MAP = {
         "6": "santiago",
     },
     "centos": {
+        "9": "stream",
         "8": "core",
         "7": "core",
         "6": "core",

--- a/teuthology/test/test_get_distro_version.py
+++ b/teuthology/test/test_get_distro_version.py
@@ -17,10 +17,10 @@ class TestGetDistroVersion(object):
         self.fake_ctx_noarg.os_type = None
 
     def test_default_distro_version(self):
-        # Default distro is ubuntu, default version of ubuntu is 16.04
+        # Default distro is ubuntu, default version of ubuntu is 20.04
         self.fake_ctx.os_version = None
         distroversion = get_distro_version(self.fake_ctx)
-        assert distroversion == '18.04'
+        assert distroversion == '20.04'
 
     def test_argument_version(self):
         self.fake_ctx.os_version = '13.04'

--- a/teuthology/test/test_packaging.py
+++ b/teuthology/test/test_packaging.py
@@ -478,7 +478,7 @@ class TestBuilderProject(object):
         ('rhel', None, None, 'centos8'),
         ('centos', None, None, 'centos8'),
         ('fedora', None, None, 'fedora25'),
-        ('ubuntu', None, None, 'bionic'),
+        ('ubuntu', None, None, 'focal'),
         ('debian', None, None, 'jessie'),
     ]
 
@@ -508,6 +508,9 @@ class TestBuilderProject(object):
         ('debian', '7.1', None, 'debian'),
         ('ubuntu', '12.04', None, 'ubuntu'),
         ('ubuntu', '14.04', None, 'ubuntu'),
+        ('ubuntu', '16.04', None, 'ubuntu'),
+        ('ubuntu', '18.04', None, 'ubuntu'),
+        ('ubuntu', '20.04', None, 'ubuntu'),
     ]
 
     @pytest.mark.parametrize(
@@ -612,6 +615,9 @@ class TestGitbuilderProject(TestBuilderProject):
         ('debian', '7.1', None, 'wheezy'),
         ('ubuntu', '12.04', None, 'precise'),
         ('ubuntu', '14.04', None, 'trusty'),
+        ('ubuntu', '16.04', None, 'xenial'),
+        ('ubuntu', '18.04', None, 'bionic'),
+        ('ubuntu', '20.04', None, 'focal'),
     ]
 
 
@@ -752,12 +758,15 @@ class TestShamanProject(TestBuilderProject):
         ('debian', '7.1', None, 'debian/7.1'),
         ('ubuntu', '12.04', None, 'ubuntu/12.04'),
         ('ubuntu', '14.04', None, 'ubuntu/14.04'),
+        ('ubuntu', '16.04', None, 'ubuntu/16.04'),
+        ('ubuntu', '18.04', None, 'ubuntu/18.04'),
+        ('ubuntu', '20.04', None, 'ubuntu/20.04'),
     ]
 
     DISTRO_MATRIX_NOVER = [
         ('rhel', None, None, 'centos/8'),
         ('centos', None, None, 'centos/8'),
         ('fedora', None, None, 'fedora/25'),
-        ('ubuntu', None, None, 'ubuntu/18.04'),
+        ('ubuntu', None, None, 'ubuntu/20.04'),
         ('debian', None, None, 'debian/8.0'),
     ]


### PR DESCRIPTION
- Ubuntu (20.04) Focal should be the default now.  It's the latest and we target it for octopus, pacific, and master.
- RHEL and CentOS 8.4 have been available for weeks
- In the process of adding support for CentOS 9 Stream.  May as well add it here now.