### PR TITLE
teuthology/orchestra: store temporaries in tmp subdir

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -154,6 +154,16 @@ def get_testdir(ctx=None):
     )
 
 
+def get_tmpdir():
+    """
+    :returns: A temporary directory for use by tests on the test node.
+    """
+    return config.get(
+        'test_tmpdir',
+        '/tmp/cephtest'
+    )
+
+
 def get_test_user(ctx=None):
     """
     :param ctx: Unused; accepted for compatibility

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -53,8 +53,10 @@ class RemoteShell(object):
 
         if suffix:
             args.append('--suffix=%s' % suffix)
-        if parentdir:
-            args.append('--tmpdir=%s' % parentdir)
+        if parentdir is None:
+            parentdir = misc.get_tmpdir()
+            self.sh(f"mkdir -p {parentdir}")
+        args.append('--tmpdir=%s' % parentdir)
 
         return self.sh(args).strip()
 
@@ -69,10 +71,13 @@ class RemoteShell(object):
         Returns: the path of the temp file created.
         """
         args = ['mktemp']
+
         if suffix:
             args.append('--suffix=%s' % suffix)
-        if parentdir:
-            args.append('--tmpdir=%s' % parentdir)
+        if parentdir is None:
+            parentdir = misc.get_tmpdir()
+            self.sh(f"mkdir -p {parentdir}")
+        args.append('--tmpdir=%s' % parentdir)
 
         path = self.sh(args).strip()
 


### PR DESCRIPTION
Due to protections turned on in Ubuntu 20.04 from [1], files created by
other users (e.g. ubuntu) can not be manipulated by other users, even
root.

Instead of using /tmp as the parent directory for `mktemp` files, use a
sub-directory under it instead.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=30aba6656f61ed44cba445a3c0d38b296fa9e8f5

Fixes: https://tracker.ceph.com/issues/51169
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>