### PR TITLE
teuthology/suite/run.py, scripts/suite.py: disallow scheduling too many jobs

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -172,6 +172,11 @@ Scheduler arguments:
                               in the output of teuthology-suite command. -1
                               for a random seed [default: -1].
  --force-priority             Skip the priority check.
+ --disable-num-jobs-check     Skip the number of jobs check. By default,
+                              teuthology will not allow you to schedule more
+                              than JOBS_TO_SCHEDULE_THRESHOLD=500 jobs, because
+                              it is too high. Use this if you need to schedule
+                              more than 500 jobs.
 
 """.format(
     default_machine_type=config.default_machine_type,

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 class Run(object):
     WAIT_MAX_JOB_TIME = 30 * 60
     WAIT_PAUSE = 5 * 60
+    JOBS_TO_SCHEDULE_THRESHOLD = 500
     __slots__ = (
         'args', 'name', 'base_config', 'suite_repo_path', 'base_yaml_paths',
         'base_args', 'package_versions', 'kernel_dict', 'config_input',
@@ -525,6 +526,13 @@ Note: To force run, use --force-priority'''
         elif priority < 150 and jobs_to_schedule > 100:
             util.schedule_fail(msg)
 
+    def check_num_jobs(self, jobs_to_schedule):
+        msg=f'''Unable to schedule {jobs_to_schedule} jobs, too many jobs.
+
+Note: If you still want to go ahead, use --disable-num-jobs-check'''
+        if jobs_to_schedule > Run.JOBS_TO_SCHEDULE_THRESHOLD:
+            util.schedule_fail(msg)
+
     def schedule_suite(self):
         """
         Schedule the suite-run. Returns the number of jobs scheduled.
@@ -640,6 +648,10 @@ Note: To force run, use --force-priority'''
         # Before scheduling jobs, check the priority
         if self.args.priority and jobs_to_schedule and not self.args.force_priority:
             self.check_priority(len(jobs_to_schedule))
+
+        # Before scheduling jobs, check number of jobs to avoid scheduling 1000s
+        if jobs_to_schedule and not self.args.disable_num_jobs_check:
+            self.check_num_jobs(len(jobs_to_schedule))
 
         self.schedule_jobs(jobs_missing_packages, jobs_to_schedule, name)
 


### PR DESCRIPTION
Add check_num_jobs() to prevent users from accidentally scheduling too many jobs, like
in rfriedma-2021-06-26_19:32:15-rados-wip-ronenf-scrubs-config-distro-basic-smithi.
JOBS_TO_SCHEDULE_THRESHOLD, set to 500 (most runs have fewer jobs than this),
will disallow users from scheduling more than 500 jobs. Users can schedule
more than 500 jobs by disabling this check using the --disable-num-jobs-check flag.

Testing:

- Default behavior

```
2021-07-09 21:52:27,306.306 INFO:teuthology.suite.util:Memo: ./virtualenv/bin/teuthology-schedule --name nojha-2021-07-09_21:52:08-rados-wip-51354-3-distro-basic-smithi --worker smithi --dry-run --priority 60 -v --first-in-suite --subset 1/5000 --seed 7987
Traceback (most recent call last):
  File "./virtualenv/bin/teuthology-suite", line 11, in <module>
    load_entry_point('teuthology', 'console_scripts', 'teuthology-suite')()
  File "/home/nojha/py3_teuthology/scripts/suite.py", line 194, in main
    return teuthology.suite.main(args)
  File "/home/nojha/py3_teuthology/teuthology/suite/__init__.py", line 146, in main
    run.prepare_and_schedule()
  File "/home/nojha/py3_teuthology/teuthology/suite/run.py", line 398, in prepare_and_schedule
    num_jobs = self.schedule_suite()
  File "/home/nojha/py3_teuthology/teuthology/suite/run.py", line 654, in schedule_suite
    self.check_num_jobs(len(jobs_to_schedule))
  File "/home/nojha/py3_teuthology/teuthology/suite/run.py", line 534, in check_num_jobs
    util.schedule_fail(msg)
  File "/home/nojha/py3_teuthology/teuthology/suite/util.py", line 76, in schedule_fail
    raise ScheduleFailError(message, name)
teuthology.exceptions.ScheduleFailError: Scheduling failed: Unable to schedule 637 jobs, too many jobs.

Note: If you still want to go ahead, use --disable-num-jobs-check
```
- With --disable-num-jobs-check
```
./virtualenv/bin/teuthology-suite -v -s rados -p 60 --subset 1/5000 -c wip-51354-3   --force-priority  -m smithi --disable-num-jobs-check  --dry-run 
2021-07-09 21:56:44,410.410 INFO:teuthology.suite.run:Suite rados in /home/nojha/src/git.ceph.com_ceph-c_wip-51354-3/qa/suites/rados scheduled 637 jobs.
```

Signed-off-by: Neha Ojha <nojha@redhat.com>