### PR TITLE
suite: rename disable-num-jobs-check to job-threshold

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -242,3 +242,7 @@ Here is a sample configuration with many of the options set and documented::
     pelagos:
       endpoint: http://head.ses.suse.de:5000/
       machine_types: ['type1', 'type2', 'type3']
+
+    # Do not allow more than that many jobs in a single run by default.
+    # To disable this check use 0.
+    job_threshold: 500

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -172,11 +172,9 @@ Scheduler arguments:
                               in the output of teuthology-suite command. -1
                               for a random seed [default: -1].
  --force-priority             Skip the priority check.
- --disable-num-jobs-check     Skip the number of jobs check. By default,
-                              teuthology will not allow you to schedule more
-                              than JOBS_TO_SCHEDULE_THRESHOLD=500 jobs, because
-                              it is too high. Use this if you need to schedule
-                              more than 500 jobs.
+ --job-threshold <threshold>  Do not allow to schedule the run if the number
+                              of jobs exceeds <threshold>. Use 0 to allow
+                              any number [default: {default_job_threshold}].
 
 """.format(
     default_machine_type=config.default_machine_type,
@@ -186,6 +184,7 @@ Scheduler arguments:
     default_suite_repo=defaults('--suite-repo',
                             config.get_ceph_qa_suite_git_url()),
     default_ceph_branch=defaults('--ceph-branch', 'master'),
+    default_job_threshold=config.job_threshold,
 )
 
 

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -151,6 +151,7 @@ class TeuthologyConfig(YamlConfig):
         'gitbuilder_host': 'gitbuilder.ceph.com',
         'githelper_base_url': 'http://git.ceph.com:8080',
         'check_package_signatures': True,
+        'job_threshold': 500,
         'lab_domain': 'front.sepia.ceph.com',
         'lock_server': 'http://paddles.front.sepia.ceph.com/',
         'max_job_time': 259200,  # 3 days

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -59,7 +59,7 @@ def process_args(args):
             value = normalize_suite_name(value)
         if key == 'suite_relpath' and value is None:
             value = ''
-        elif key in ('limit', 'priority', 'num', 'newest', 'seed'):
+        elif key in ('limit', 'priority', 'num', 'newest', 'seed', 'job_threshold'):
             value = int(value)
         elif key == 'subset' and value is not None:
             # take input string '2/3' and turn into (2, 3)


### PR DESCRIPTION
Rename --disable-num-jobs-check to --job-threshold:
- for shorter recallable name;
- to allow change threshold value via parameter;
- to allow define default threshold value in teuthology config.

Use `--job-threshold 0` to disable job threshold check.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>