### PR TITLE
.readthedocs: add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+---
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+formats: []
+build:
+  image: latest
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - orchestra
+    - requirements: docs/requirements.txt
+sphinx:
+  builder: html
+  configuration: docs/conf.py


### PR DESCRIPTION
to address the missing document of
https://docs.ceph.com/projects/teuthology/en/latest/commands/list.html,

they require that teuthology cli tools accessible when building sphinx
document.

Signed-off-by: Kefu Chai <kchai@redhat.com>