### PR TITLE
ceph_ansible: Remove --system-site-packages

### DIFF
--- a/teuthology/task/ceph_ansible.py
+++ b/teuthology/task/ceph_ansible.py
@@ -404,7 +404,6 @@ class CephAnsible(Task):
             run.Raw('cd ~/ceph-ansible'),
             run.Raw(';'),
             'virtualenv',
-            run.Raw('--system-site-packages'),
             run.Raw('--python=python3'),
             'venv',
             run.Raw(';'),
@@ -426,6 +425,10 @@ class CephAnsible(Task):
             run.Raw('notario>=0.0.13'), # FIXME: use requirements.txt
             run.Raw('netaddr'),
             run.Raw('six'),
+            run.Raw(';'),
+            'LANG=en_US.utf8',
+            'pip',
+            'install',
             run.Raw(ansible_ver),
             run.Raw(';'),
             run.Raw(str_args)


### PR DESCRIPTION
Upgrading ansible is problematic as it conflicts with the installed
package on Ubuntu 20.04 so don't try to use system packages.

Add LANG environment variable to 'pip install ansible' command to work
around pip failing due to file names in ansible package with exotic
characters.

Fixes: https://tracker.ceph.com/issues/51856

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>