### PR TITLE
DNM: orch/run: refactor and rename run.quote()

### DIFF
--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -62,7 +62,7 @@ class RemoteProcess(object):
         self.client = client
         self.args = args
         if isinstance(args, list):
-            self.command = quote(args)
+            self.command = convert_args_list_to_str(args)
         else:
             self.command = args
 
@@ -240,9 +240,11 @@ class Raw(object):
         return self.value == value
 
 
-def quote(args):
+def convert_args_list_to_str(args):
     """
-    Internal quote wrapper.
+    Convert list args to str args. While doing so, quote str instances to
+    disable special interpretation of characters and substitute Raw instances
+    with their actual values.
     """
     if isinstance(args, str):
         return args
@@ -430,9 +432,11 @@ def run(
         if transport:
             (host, port) = transport.getpeername()[0:2]
         else:
-            raise ConnectionLostError(command=quote(args), node=name)
+            raise ConnectionLostError(command=convert_args_list_to_str(args),
+                                      node=name)
     except socket.error:
-        raise ConnectionLostError(command=quote(args), node=name)
+        raise ConnectionLostError(command=convert_args_list_to_str(args),
+                                  node=name)
 
     if name is None:
         name = host

--- a/teuthology/orchestra/run.py
+++ b/teuthology/orchestra/run.py
@@ -244,19 +244,14 @@ def quote(args):
     """
     Internal quote wrapper.
     """
-    def _quote(args):
-        """
-        Handle quoted string, testing for raw charaters.
-        """
-        for a in args:
-            if isinstance(a, Raw):
-                yield a.value
-            else:
-                yield pipes.quote(a)
-    if isinstance(args, list):
-        return ' '.join(_quote(args))
-    else:
+    if isinstance(args, str):
         return args
+
+    assert isinstance(args, list)
+
+    args = [pipes.quote(a) if isinstance(a, str) else a.value for a in args]
+
+    return ' '.join(args)
 
 
 def copy_to_log(f, logger, loglevel=logging.INFO, capture=None, quiet=False):

--- a/teuthology/orchestra/test/test_run.py
+++ b/teuthology/orchestra/test/test_run.py
@@ -266,16 +266,16 @@ class TestRun(object):
 
 class TestQuote(object):
     def test_quote_simple(self):
-        got = run.quote(['a b', ' c', 'd e '])
+        got = run.convert_args_str_to_list(['a b', ' c', 'd e '])
         assert got == "'a b' ' c' 'd e '"
 
     def test_quote_and_quote(self):
-        got = run.quote(['echo', 'this && is embedded', '&&',
+        got = run.convert_args_str_to_list(['echo', 'this && is embedded', '&&',
                          'that was standalone'])
         assert got == "echo 'this && is embedded' '&&' 'that was standalone'"
 
     def test_quote_and_raw(self):
-        got = run.quote(['true', run.Raw('&&'), 'echo', 'yay'])
+        got = run.convert_args_str_to_list(['true', run.Raw('&&'), 'echo', 'yay'])
         assert got == "true && echo yay"
 
 

--- a/teuthology/orchestra/test/test_systemd.py
+++ b/teuthology/orchestra/test/test_systemd.py
@@ -4,7 +4,7 @@ import os
 from logging import debug
 from teuthology import misc
 from teuthology.orchestra import cluster
-from teuthology.orchestra.run import quote
+from teuthology.orchestra.run import convert_args_list_to_str
 from teuthology.orchestra.daemon.group import DaemonGroup
 import subprocess
 
@@ -27,7 +27,7 @@ def test_pid():
     def sh(args):
         args[0:2] = ["cat", ps_ef_output_path]
         debug(args)
-        return subprocess.getoutput(quote(args))
+        return subprocess.getoutput(convert_args_list_to_str(args))
 
     remote.sh = sh
     remote.init_system = 'systemd'


### PR DESCRIPTION
* Refactor to add extra checks and simply the current definition of method.
* Rename since method name and docstring doesn't describe anything.


TODO: update codebase at ceph's qa/ as soon as the PR merges.
DNM, wait for https://github.com/ceph/teuthology/pull/1663.