### PR TITLE
task/internal/redhat: remove rh stage creds

### DIFF
--- a/teuthology/task/internal/redhat.py
+++ b/teuthology/task/internal/redhat.py
@@ -49,7 +49,7 @@ def _subscribe_stage_cdn(remote):
     cdn_config = teuthconfig.get('cdn-config', dict())
     server_url = cdn_config.get('server-url', 'subscription.rhsm.stage.redhat.com:443/subscription')
     base_url = cdn_config.get('base-url', 'https://cdn.stage.redhat.com')
-    username = cdn_config.get('username', 'cephuser')
+    username = cdn_config.get('username')
     password = cdn_config.get('password')
     remote.run(
         args=[


### PR DESCRIPTION
use rh  stage creds from config file

Signed-off-by: rakeshgm <rakeshgm@redhat.com>