### PR TITLE
tox.ini: set a UTF-8 locale for decoding non-latin chars

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -147,6 +147,8 @@ if [ -e ./$VENV ]  && [ ! -e ./$VENV/lib/python*/no-global-site-packages.txt ]; 
     rm -rf ./$VENV
 fi
 
+export LC_ALL=en_US.UTF-8
+
 if [ -z "$NO_CLOBBER" ] || [ ! -e ./$VENV ]; then
     if ! virtualenv --version &>/dev/null; then
         pip install virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
 envlist = docs, py3, flake8, openstack
 
+[testenv]
+setenv =
+    LC_ALL=en_US.UTF-8
+    LANG=en_US
+
 [testenv:py3]
 basepython=python3
 install_command = pip install --upgrade {opts} {packages}


### PR DESCRIPTION
Python3 uses locale.getdefaultlocale() to get the locale, which is used
to determine the encoding of filenames. 

see https://docs.python.org/3/library/locale.html

there is chance that the
specified locale is not capable of decoding the filenames encoded in
non-latin-1 characters, in that case, pip just fails to decompress that
file, like:

```
me/jenkins-build/build/workspace/teuthology-pull-requests/.tox/flake8/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 508, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "/home/jenkins-build/build/workspace/teuthology-pull-requests/.tox/flake8/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 550, in _prepare_linked_requirement
    local_file = unpack_url(
  File "/home/jenkins-build/build/workspace/teuthology-pull-requests/.tox/flake8/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 249, in unpack_url
    unpack_file(file.path, location, file.content_type)
  File "/home/jenkins-build/build/workspace/teuthology-pull-requests/.tox/flake8/lib/python3.8/site-packages/pip/_internal/utils/unpacking.py", line 256, in unpack_file
    untar_file(filename, location)
  File "/home/jenkins-build/build/workspace/teuthology-pull-requests/.tox/flake8/lib/python3.8/site-packages/pip/_internal/utils/unpacking.py", line 226, in untar_file
    with open(path, "wb") as destfp:
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 137-140: ordinal not in range(256)
```
in this change, UTF-8 is used, and also change the lang part to
en_US, so the output should be readable to who can read English.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>