### PR TITLE
test/test_worker: fix test_prep_job teuth_config mocking

### DIFF
--- a/teuthology/test/test_worker.py
+++ b/teuthology/test/test_worker.py
@@ -179,8 +179,10 @@ class TestWorker(object):
 
     @patch("os.path.isdir")
     @patch("teuthology.worker.fetch_teuthology")
+    @patch("teuthology.worker.teuth_config")
     @patch("teuthology.worker.fetch_qa_suite")
     def test_prep_job(self, m_fetch_qa_suite,
+                      m_teuth_config,
                       m_fetch_teuthology, m_isdir):
         config = dict(
             name="the_name",
@@ -191,6 +193,7 @@ class TestWorker(object):
         m_fetch_teuthology.return_value = '/teuth/path'
         m_fetch_qa_suite.return_value = '/suite/path'
         m_isdir.return_value = True
+        m_teuth_config.teuthology_path = None
         got_config, teuth_bin_path = worker.prep_job(
             config,
             log_file_path,


### PR DESCRIPTION
When home directory contains .teuthology.yaml the test_prep_job
can pick unexpected values, like teuthology_path which makes
tests fail.

This fix overrides teuthology config to avoid unexpected behaviour.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>