### PR TITLE
Fix dictionary update in try_push_job_info()

### DIFF
--- a/teuthology/report.py
+++ b/teuthology/report.py
@@ -495,8 +495,8 @@ def try_push_job_info(job_config, extra_info=None):
     job_id = job_config['job_id']
 
     if extra_info is not None:
-        job_info = extra_info.copy()
-        job_info.update(job_config)
+        job_info = job_config.copy()
+        job_info.update(extra_info)
     else:
         job_info = job_config
 


### PR DESCRIPTION
the function `try_push_job_info()` is not
updating `job_info` dictionary properly since
we want to update `job_info` with `extra_info`,
however, in lines 498 and 499 we are assigning
`job_info` to a copy of `extra_info` and updating
`job_info` with `job_config` which is incorrect.
Instead, we should assign `job_info` with
a copy of `job_config` and update `job_info` with
`extra_info`