### PR TITLE
task/ansible: move ansible logs to ansible.log

### DIFF
--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -15,8 +15,8 @@ from teuthology.repo_utils import fetch_repo
 
 from teuthology.task import Task
 
-log = logging.getLogger(__name__)
-
+log = logging.Logger(__name__)
+log.setLevel(logging.INFO)
 
 class LoggerFile(object):
     """
@@ -115,6 +115,8 @@ class Ansible(Task):
         self.log = log
         self.generated_inventory = False
         self.generated_playbook = False
+        log.addHandler(logging.FileHandler(os.path.join(ctx.archive,
+                                                     "ansible.log")))
 
     def setup(self):
         super(Ansible, self).setup()
@@ -278,11 +280,10 @@ class Ansible(Task):
         command = ' '.join(args)
         log.debug("Running %s", command)
 
-        out_log = self.log.getChild('out')
         out, status = pexpect.run(
             command,
             cwd=self.repo_path,
-            logfile=_logfile or LoggerFile(out_log, logging.INFO),
+            logfile=_logfile or LoggerFile(log, logging.INFO),
             withexitstatus=True,
             timeout=None,
         )

--- a/teuthology/test/task/test_ansible.py
+++ b/teuthology/test/task/test_ansible.py
@@ -33,6 +33,7 @@ class TestAnsibleTask(TestTask):
         self.ctx.cluster.add(Remote('user@remote2'), ['role2'])
         self.ctx.config = dict()
         self.ctx.summary = dict()
+        self.ctx.archive = '../'
         self.task_config = dict(playbook=[])
         self.start_patchers()
 

--- a/teuthology/test/task/test_ceph_ansible.py
+++ b/teuthology/test/task/test_ceph_ansible.py
@@ -29,6 +29,7 @@ class TestCephAnsibleTask(TestTask):
         self.ctx.cluster.add(Remote('user@remote3'), ['osd.0'])
         self.ctx.summary = dict()
         self.ctx.config = dict()
+        self.ctx.archive = '../'
         self.task_config = dict()
         self.start_patchers()
 


### PR DESCRIPTION
Currently ansible tasks are logging to
teuthology.log. We want to separate this to
it's own log files for better readability.

Signed-off-by: Kamoltat Sirivadhna <ksirivad@redhat.com>