### PR TITLE
nuke: ignore internal directory listing when scanning for stale mount…

### DIFF
--- a/teuthology/nuke/actions.py
+++ b/teuthology/nuke/actions.py
@@ -134,6 +134,10 @@ def stale_kernel_mount(remote):
             'sudo', 'find',
             '/sys/kernel/debug/ceph',
             '-mindepth', '1',
+            run.Raw('!'),
+            '-path', '/sys/kernel/debug/ceph/meta',
+            run.Raw('!'),
+            '-path', '/sys/kernel/debug/ceph/meta/client_features',
             '-type', 'd',
             run.Raw('|'),
             'read'


### PR DESCRIPTION
…s in debugfs directory

kclient patchset:

    https://patchwork.kernel.org/project/ceph-devel/list/?series=556049

introduces meta directory to add debugging entries. This needs to be filtered
when scanning ceph debugfs directory.

Signed-off-by: Venky Shankar <vshankar@redhat.com>