### PR TITLE
tasks/kernel: fix missing arg to install_kernel

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -518,7 +518,7 @@ def install_and_reboot(ctx, need_install, config):
                     '--replacepkgs',
                     remote_pkg_path(role_remote),
                 ])
-            install_kernel(role_remote, remote_pkg_path(role_remote))
+            install_kernel(role_remote, config[role], path=remote_pkg_path(role_remote))
             continue
 
         # TODO: Refactor this into install_kernel() so that it handles all


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/52944
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>