### PR TITLE
task/internal/__init__: print core file output before splitting

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -317,6 +317,7 @@ def fetch_binaries_for_coredumps(path, remote):
             # Parse file output to get program, Example output:
             # 1422917770.7450.core: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, \
             # from 'radosgw --rgw-socket-path /home/ubuntu/cephtest/apache/tmp.client.0/fastcgi_soc'
+            log.info(f' core looks like: {dump_out}')
             dump_program = dump_out.split("from '")[1].split(' ')[0]
 
             # Find path on remote server:


### PR DESCRIPTION
Debugging this failure:

```
Traceback (most recent call last):
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_c56135d151713269e811ede3163c9743c2e269de/teuthology/run_tasks.py", line 176, in run_tasks
    suppress = manager.__exit__(*exc_info)
  File "/usr/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_c56135d151713269e811ede3163c9743c2e269de/teuthology/task/internal/__init__.py", line 398, in archive
    fetch_binaries_for_coredumps(path, rem)
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_c56135d151713269e811ede3163c9743c2e269de/teuthology/task/internal/__init__.py", line 320, in fetch_binaries_for_coredumps
    dump_program = dump_out.split("from '")[1].split(' ')[0]
IndexError: list index out of range
```

...on output that should look like this:

```
./remote/smithi084/coredump/1635398181.133353.core: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, from '/bin/podman stop ceph-462d7c58-37ab-11ec-8c28-001a4aab830c-node-exporter-smithi', real uid: 0, effective uid: 0, real gid: 0, effective gid: 0, execfn: '/bin/podman', platform: 'x86_64'
```

Signed-off-by: Sage Weil <sage@newdream.net>