### PR TITLE
orchestra/cluster: make run parallel and wait

### DIFF
--- a/teuthology/orchestra/cluster.py
+++ b/teuthology/orchestra/cluster.py
@@ -3,7 +3,7 @@ Cluster definition
 part of context, Cluster is used to save connection information.
 """
 import teuthology.misc
-
+from teuthology.orchestra import run
 
 class Cluster(object):
     """
@@ -50,18 +50,47 @@ class Cluster(object):
                 )
         self.remotes[remote] = list(roles)
 
-    def run(self, **kwargs):
+    def run(self, wait=True, parallel=False, **kwargs):
         """
         Run a command on all the nodes in this cluster.
 
         Goes through nodes in alphabetical order.
 
-        If you don't specify wait=False, this will be sequentially.
+        The default usage is when parallel=False and wait=True,
+        which is a sequential run for each node one by one.
+
+        If you specify parallel=True, it will be in parallel.
+
+        If you specify wait=False, it returns immediately.
+        Since it is not possible to run sequentially and
+        do not wait each command run finished, the parallel value
+        is ignored and treated as True.
 
         Returns a list of `RemoteProcess`.
         """
+        # -+-------+----------+----------+------------+---------------
+        #  | wait  | parallel | run.wait | remote.run | comments
+        # -+-------+----------+----------+------------+---------------
+        # 1|*True  |*False    | no       | wait=True  | sequentially
+        # 2| True  | True     | yes      | wait=False | parallel
+        # 3| False | True     | no       | wait=False | parallel
+        # 4| False | False    | no       | wait=False | same as above
+
+        # We always run in parallel if wait=False,
+        # that is why (4) is equivalent to (3).
+
+        # We wait from remote.run only if run sequentially.
+        _wait = (parallel == False and wait == True)
+
         remotes = sorted(self.remotes.keys(), key=lambda rem: rem.name)
-        return [remote.run(**kwargs) for remote in remotes]
+        procs = [remote.run(**kwargs, wait=_wait) for remote in remotes]
+
+        # We do run.wait only if parallel=True, because if parallel=False,
+        # we have run sequentially and all processes are complete.
+
+        if parallel and wait:
+            run.wait(procs)
+        return procs
 
     def sh(self, script, **kwargs):
         """

--- a/teuthology/orchestra/cluster.py
+++ b/teuthology/orchestra/cluster.py
@@ -2,7 +2,6 @@
 Cluster definition
 part of context, Cluster is used to save connection information.
 """
-import teuthology.misc
 from teuthology.orchestra import run
 
 class Cluster(object):
@@ -115,11 +114,12 @@ class Cluster(object):
         remotes = sorted(self.remotes.keys(), key=lambda rem: rem.name)
         for remote in remotes:
             if sudo:
-                teuthology.misc.sudo_write_file(remote, file_name, content, perms=perms, owner=owner)
+                remote.write_file(file_name, content,
+                                  sudo=True, mode=perms, owner=owner)
             else:
                 if perms is not None or owner is not None:
                     raise ValueError("To specify perms or owner, sudo must be True")
-                teuthology.misc.write_file(remote, file_name, content)
+                remote.write_file(file_name, content)
 
     def only(self, *roles):
         """

--- a/teuthology/orchestra/test/test_cluster.py
+++ b/teuthology/orchestra/test/test_cluster.py
@@ -198,22 +198,22 @@ class TestWriteFile(object):
             ],
         )
 
-    @patch("teuthology.misc.write_file")
+    @patch("teuthology.orchestra.remote.RemoteShell.write_file")
     def test_write_file(self, m_write_file):
         self.c.write_file("filename", "content")
-        m_write_file.assert_called_with(self.r1, "filename", "content")
+        m_write_file.assert_called_with("filename", "content")
 
-    @patch("teuthology.misc.write_file")
+    @patch("teuthology.orchestra.remote.RemoteShell.write_file")
     def test_fails_with_invalid_perms(self, m_write_file):
         with pytest.raises(ValueError):
             self.c.write_file("filename", "content", sudo=False, perms="invalid")
 
-    @patch("teuthology.misc.write_file")
+    @patch("teuthology.orchestra.remote.RemoteShell.write_file")
     def test_fails_with_invalid_owner(self, m_write_file):
         with pytest.raises(ValueError):
             self.c.write_file("filename", "content", sudo=False, owner="invalid")
 
-    @patch("teuthology.misc.sudo_write_file")
-    def test_with_sudo(self, m_sudo_write_file):
+    @patch("teuthology.orchestra.remote.RemoteShell.write_file")
+    def test_with_sudo(self, m_write_file):
         self.c.write_file("filename", "content", sudo=True)
-        m_sudo_write_file.assert_called_with(self.r1, "filename", "content", owner=None, perms=None)
+        m_write_file.assert_called_with("filename", "content", sudo=True, owner=None, mode=None)


### PR DESCRIPTION
Make cluster.run able to execute a command in parallel on all
nodes and wait for completion.

In order to run a command in parallel on all nodes of the
cluster, instead of combination:
```
  run.wait(cluster.run(wait=False, args=...))
```
this patch makes it possible to do the same just by:
```
  cluster.run(parallel=True, args=...)
```
the `wait` arguments defaults to True in this case.

Also, the behavior of the method is not changed
when `wait` is set to False (like in the first example),
so it is supposed to be backward compatible.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>