### PR TITLE
teuthology/beanstalk: workaround yaml load deprecation

### DIFF
--- a/teuthology/beanstalk.py
+++ b/teuthology/beanstalk.py
@@ -18,7 +18,7 @@ def connect():
         raise RuntimeError(
             'Beanstalk queue information not found in {conf_path}'.format(
                 conf_path=config.teuthology_yaml))
-    return beanstalkc.Connection(host=host, port=port)
+    return beanstalkc.Connection(host=host, port=port, parse_yaml=yaml.safe_load)
 
 
 def watch_tube(connection, tube_name):


### PR DESCRIPTION
There is a deprecation error when beanstalk parser called:
```
  YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe
```
Since beanstalkc3 does not want to apply a fix for that
we can override yaml parser to suppress the error message
from the log.

Fixes: https://tracker.ceph.com/issues/44225

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>