### PR TITLE
orchestra/remote: throw exception on reconnect failed

### DIFF
--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -505,7 +505,8 @@ class Remote(RemoteShell):
         if not self.ssh or \
            not self.ssh.get_transport() or \
            not self.ssh.get_transport().is_active():
-            self.reconnect()
+            if not self.reconnect():
+                raise Exception(f'Cannot connect to remote host {self.shortname}')
         r = self._runner(client=self.ssh, name=self.shortname, **kwargs)
         r.remote = self
         return r


### PR DESCRIPTION
In run method if a reconnect required there is a remote.reconnect
method called which is supposed to return True or False.
On failure it is the best to raise an exception early,
to make it clear what was the original error instead of
waiting until somewhere later teuthology fails with
some undeclared variables.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>