### PR TITLE
Stop using LogRecord.asctime (not stable); move to pytest 6.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -248,7 +248,7 @@ pyparsing==2.4.7
     #   packaging
 pyperclip==1.8.2
     # via cmd2
-pytest==3.7.1
+pytest==6.2.5
     # via teuthology
 python-cinderclient==8.0.0
     # via python-openstackclient

--- a/teuthology/test/test_misc.py
+++ b/teuthology/test/test_misc.py
@@ -1,5 +1,4 @@
 import argparse
-from datetime import datetime
 
 from unittest.mock import Mock, patch
 from teuthology.orchestra import cluster
@@ -45,9 +44,7 @@ def test_sh_progress(caplog):
     # there must be at least 2 seconds between the log record
     # of the first message and the log record of the second one
     #
-    t1 = datetime.strptime(records[1].asctime.split(',')[0], "%Y-%m-%d %H:%M:%S")
-    t2 = datetime.strptime(records[2].asctime.split(',')[0], "%Y-%m-%d %H:%M:%S")
-    assert (t2 - t1).total_seconds() > 2
+    assert (records[2].created - records[1].created) > 2
 
 
 def test_wait_until_osds_up():


### PR DESCRIPTION
See commit messages for details.  Pytest 6.2.5 exposed the use of asctime, which may not be present on a LogRecord.  Luckily it's much simpler to use crtime, and then we can update pytest.