### PR TITLE
teuthology/tasks/kernel: switch firmware branch name

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -288,7 +288,7 @@ def install_firmware(ctx, config):
                 run.Raw('&&'),
                 'sudo', 'git', 'fetch', 'origin',
                 run.Raw('&&'),
-                'sudo', 'git', 'reset', '--hard', 'origin/master'
+                'sudo', 'git', 'reset', '--hard', 'origin/main'
                 ],
             )
 


### PR DESCRIPTION
It is now "main".

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>