### PR TITLE
kill: get machine type from paddles for the run

### DIFF
--- a/teuthology/kill.py
+++ b/teuthology/kill.py
@@ -55,8 +55,15 @@ def kill_run(run_name, archive_base=None, owner=None, machine_type=None,
                 log.warning("Run archive used: %s" % run_archive_dir)
                 log.info("Using machine type '%s' and owner '%s'" % (machine_type, owner))
         elif machine_type is None:
-            raise RuntimeError("The run is still entirely enqueued; " +
-                               "you must also pass --machine-type")
+            # no jobs found in archive and no machine type specified,
+            # so we try paddles to see if there is anything scheduled
+            run_info = report.ResultsReporter().get_run(run_name)
+            machine_type = run_info.get('machine_type', None)
+            if machine_type:
+                log.info(f"Using machine type '{machine_type}' received from paddles.")
+            else:
+                raise RuntimeError(f"Cannot find machine type for the run {run_name}; " +
+                                    "you must also pass --machine-type")
 
     if not preserve_queue:
         remove_beanstalk_jobs(run_name, machine_type)


### PR DESCRIPTION
When calling kill for a run which is still in beanstalkd
queue there is no job directories created in archive
and there is no way to find out which machine type to use
the teuthology-kill reports that you must manually provide
machine type for the run, which is often borring and quite
inconvenient.

Instead of torturing user to recall a tube for the run name
we just ask paddles if it has anything logged and use the
machine type from what we receive from it.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>