### PR TITLE
Update pynacl

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ pexpect
 docopt
 netaddr
 paramiko
+pynacl >= 1.5.0  # for universal2 wheel
 psutil >= 2.1.0
 configparser
 ansible>=2.8,<2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -234,8 +234,10 @@ pycparser==2.20
     # via cffi
 pyjwt==2.1.0
     # via teuthology
-pynacl==1.4.0
-    # via paramiko
+pynacl==1.5.0
+    # via
+    #   teuthology
+    #   paramiko
 pyopenssl==20.0.1
     # via
     #   teuthology
@@ -304,7 +306,6 @@ six==1.16.0
     #   keystoneauth1
     #   munch
     #   oslo.i18n
-    #   pynacl
     #   pyopenssl
     #   pytest
     #   python-dateutil

--- a/update-requirements.sh
+++ b/update-requirements.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-pip-compile $@ requirements.in -qo- | sed -e '/^-e / d' -e 's/-r requirements.in/teuthology/g' > requirements.txt
+pip-compile $@ requirements.in
+sed -i'' -e '/^-e / d' -e 's/-r requirements.in/teuthology/g' requirements.txt


### PR DESCRIPTION
This is mainly to make anyone running on, say, aarch64 have an easier time. On my M1 Mac I was having to compile pynacl from source any time I ran bootstrap. With this change, we can take advantage of the universal2 binary wheel the project began shipping in 1.5.0.