### PR TITLE
selinux.py: Ignore both contexts for NetworkManager_dispatcher_t

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -133,7 +133,7 @@ class SELinux(Task):
             'comm="ksmtuned"',
             'comm="sssd"',
             'comm="sss_cache"',
-            'scontext=system_u:system_r:NetworkManager_dispatcher_t:s0',
+            'context=system_u:system_r:NetworkManager_dispatcher_t:s0',
         ]
         se_whitelist = self.config.get('whitelist', [])
         if se_whitelist:


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>