### PR TITLE
task/internal: open gzip file if core is compressed

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -12,6 +12,7 @@ import shutil
 import time
 import yaml
 import subprocess
+import tempfile
 
 import humanfriendly
 
@@ -318,7 +319,28 @@ def fetch_binaries_for_coredumps(path, remote):
             # 1422917770.7450.core: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, \
             # from 'radosgw --rgw-socket-path /home/ubuntu/cephtest/apache/tmp.client.0/fastcgi_soc'
             log.info(f' core looks like: {dump_out}')
-            dump_program = dump_out.split("from '")[1].split(' ')[0]
+
+            if 'gzip' in dump_out:
+                try:
+                    log.info("core is compressed, try accessing gzip file ...")
+                    with gzip.open(dump_path, 'rb') as f_in, \
+                         tempfile.NamedTemporaryFile(mode='w+b') as f_out:
+                         shutil.copyfileobj(f_in, f_out)
+                         dump_info = subprocess.Popen(['file', f_out.name],
+                                                        stdout=subprocess.PIPE)
+                         dump_out = dump_info.communicate()[0].decode()
+                         log.info(f' core looks like: {dump_out}')
+                except Exception as e:
+                    log.info('Something went wrong while opening the compressed file')
+                    log.error(e)
+                    continue
+            try:
+                dump_program = dump_out.split("from '")[1].split(' ')[0]
+                log.info(f' dump_program: {dump_program}')
+            except Exception as e:
+                log.info("core doesn't have the desired format, moving on ...")
+                log.error(e)
+                continue
 
             # Find path on remote server:
             remote_path = remote.sh(['which', dump_program]).rstrip()

--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -13,7 +13,7 @@ import time
 import yaml
 import subprocess
 import tempfile
-
+import re
 import humanfriendly
 
 import teuthology.lock.ops
@@ -335,7 +335,7 @@ def fetch_binaries_for_coredumps(path, remote):
                     log.error(e)
                     continue
             try:
-                dump_program = dump_out.split("from '")[1].split(' ')[0]
+                dump_program = re.findall("from '([^']+)'", dump_out)[0]
                 log.info(f' dump_program: {dump_program}')
             except Exception as e:
                 log.info("core doesn't have the desired format, moving on ...")

--- a/teuthology/task/tests/test_fetch_coredumps.py
+++ b/teuthology/task/tests/test_fetch_coredumps.py
@@ -1,0 +1,116 @@
+from teuthology.task.internal import fetch_binaries_for_coredumps
+from unittest.mock import patch, Mock
+import gzip
+import os
+
+class TestFetchCoreDumps(object):
+    class MockDecode(object):
+        def __init__(self, ret):
+            self.ret = ret
+            pass
+
+        def decode(self):
+            return self.ret
+
+    class MockPopen(object):
+        def __init__(self, ret):
+            self.ret = ret
+
+        def communicate(self, input=None):
+            return [TestFetchCoreDumps.MockDecode(self.ret)]
+
+    def setup(self):
+        self.the_function = fetch_binaries_for_coredumps
+        with gzip.open('file.gz', 'wb') as f:
+            f.write(b'Hello world!')
+        self.core_dump_path = "file.gz"
+        self.m_remote = Mock()
+        self.uncompressed_correct = self.MockPopen(
+            "ELF 64-bit LSB core file,"\
+            " x86-64, version 1 (SYSV), SVR4-style, from 'ceph_test_rados_api_io',"\
+            " real uid: 1194, effective uid: 1194, real gid: 1194,"\
+            " effective gid: 1194, execfn: '/usr/bin/ceph_test_rados_api_io', platform: 'x86_64'"
+        )
+        self.uncompressed_incorrect = self.MockPopen("ASCII text")
+        self.compressed_correct = self.MockPopen(
+            "gzip compressed data, was "\
+            "'correct.format.core', last modified: Wed Jun 29"\
+            " 19:55:29 2022, from Unix, original size modulo 2^32 3167080"
+        )
+
+        self.compressed_incorrect = self.MockPopen(
+            "gzip compressed data, was "\
+            "'incorrect.format.core', last modified: Wed Jun 29"\
+            " 19:56:56 2022, from Unix, original size modulo 2^32 11"
+        )
+
+    # Core is not compressed and file is in the correct format
+    @patch('teuthology.task.internal.subprocess.Popen')
+    @patch('teuthology.task.internal.os')
+    def test_uncompressed_correct_format(self, m_os, m_subproc_popen):
+        m_subproc_popen.side_effect = [
+                self.uncompressed_correct,
+                Exception("We shouldn't be hitting this!")
+            ]
+        m_os.path.join.return_value = self.core_dump_path
+        m_os.path.sep = self.core_dump_path
+        m_os.path.isdir.return_value = True
+        m_os.path.dirname.return_value = self.core_dump_path
+        m_os.path.exists.return_value = True
+        m_os.listdir.return_value = [self.core_dump_path]
+        self.the_function(None, self.m_remote)
+        assert self.m_remote.get_file.called
+
+    # Core is not compressed and file is in the wrong format
+    @patch('teuthology.task.internal.subprocess.Popen')
+    @patch('teuthology.task.internal.os')
+    def test_uncompressed_incorrect_format(self, m_os, m_subproc_popen):
+        m_subproc_popen.side_effect = [
+                self.uncompressed_incorrect,
+                Exception("We shouldn't be hitting this!")
+            ]
+        m_os.path.join.return_value = self.core_dump_path
+        m_os.path.sep = self.core_dump_path
+        m_os.path.isdir.return_value = True
+        m_os.path.dirname.return_value = self.core_dump_path
+        m_os.path.exists.return_value = True
+        m_os.listdir.return_value = [self.core_dump_path]
+        self.the_function(None, self.m_remote)
+        assert self.m_remote.get_file.called == False
+
+    # Core is compressed and file is in the correct format
+    @patch('teuthology.task.internal.subprocess.Popen')
+    @patch('teuthology.task.internal.os')
+    def test_compressed_correct_format(self, m_os, m_subproc_popen):
+        m_subproc_popen.side_effect = [
+                self.compressed_correct,
+                self.uncompressed_correct
+            ]
+        m_os.path.join.return_value = self.core_dump_path
+        m_os.path.sep = self.core_dump_path
+        m_os.path.isdir.return_value = True
+        m_os.path.dirname.return_value = self.core_dump_path
+        m_os.path.exists.return_value = True
+        m_os.listdir.return_value = [self.core_dump_path]
+        self.the_function(None, self.m_remote)
+        assert self.m_remote.get_file.called
+
+    # Core is compressed and file is in the wrong format
+    @patch('teuthology.task.internal.subprocess.Popen')
+    @patch('teuthology.task.internal.os')
+    def test_compressed_incorrect_format(self, m_os, m_subproc_popen):
+        m_subproc_popen.side_effect = [
+                self.compressed_incorrect,
+                self.uncompressed_incorrect
+            ]
+        m_os.path.join.return_value = self.core_dump_path
+        m_os.path.sep = self.core_dump_path
+        m_os.path.isdir.return_value = True
+        m_os.path.dirname.return_value = self.core_dump_path
+        m_os.path.exists.return_value = True
+        m_os.listdir.return_value = [self.core_dump_path]
+        self.the_function(None, self.m_remote)
+        assert self.m_remote.get_file.called == False
+
+    def teardown(self):
+        os.remove(self.core_dump_path)


### PR DESCRIPTION
Added a case where if the core is compressed, then
we will try to open it as gzip and read the content
inside.

Also, add try and except when we are parsing
through the content to prevent the program from
crashing.

Create a unit test to test the function,
`fetch_binaries_for_coredumps()`

Fixes: https://tracker.ceph.com/issues/53206

Signed-off-by: Kamoltat <ksirivad@redhat.com>