### PR TITLE
github actions: Run docs build during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,5 @@ jobs:
         run: tox -e flake8
       - name: Run unit tests
         run: tox -e py3
+      - name: Run docs build
+        run: tox -e docs


### PR DESCRIPTION
If we do this, we can drop the Jenkins job. The openstack tests are
currently all skipped, so we can just leave them out for now.

Signed-off-by: Zack Cerza <zack@redhat.com>