### PR TITLE
fixes for running non-scheduled jobs 

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -88,7 +88,7 @@ def fetch_tasks_if_needed(job_config):
     suite_sha1 = job_config.get('suite_sha1')
     suite_path = os.path.normpath(os.path.join(
         fetch_qa_suite(suite_branch, commit=suite_sha1),
-        job_config.get('suite_relpath', ''),
+        job_config.get('suite_relpath', 'qa'),
     ))
     sys.path.insert(1, suite_path)
     return suite_path

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -114,8 +114,9 @@ class Ansible(Task):
         self.generated_inventory = False
         self.generated_playbook = False
         self.log = logging.Logger(__name__)
-        self.log.addHandler(logging.FileHandler(
-            os.path.join(ctx.archive, "ansible.log")))
+        if ctx.archive:
+            self.log.addHandler(logging.FileHandler(
+                os.path.join(ctx.archive, "ansible.log")))
 
     def setup(self):
         super(Ansible, self).setup()

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -115,7 +115,7 @@ class TestRun(object):
         m_fetch_qa_suite.return_value = "/some/other/suite/path"
         result = run.fetch_tasks_if_needed(config)
         m_fetch_qa_suite.assert_called_with("feature_branch", commit="commit")
-        assert result == "/some/other/suite/path"
+        assert result == "/some/other/suite/path/qa"
 
     @patch("teuthology.run.get_status")
     @patch("teuthology.run.nuke")


### PR DESCRIPTION
Fetching tasks automatically did not work for non-scheduled jobs because it never actually imported them, like scheduled jobs (which have suite_path set) do a few lines earlier.