### PR TITLE
docs/docker-compose: paddles use quay.io image

### DIFF
--- a/docs/docker-compose/docker-compose.yml
+++ b/docs/docker-compose/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - 5432:5432
   paddles:
-    build: ./paddles
+    image: quay.io/ceph-infra/paddles
     environment: 
       PADDLES_SERVER_HOST: 0.0.0.0
       PADDLES_SQLALCHEMY_URL: postgresql+psycopg2://admin:password@postgres:5432/paddles
@@ -61,7 +61,7 @@ services:
   teuthology:
     build: ./teuthology
     depends_on:
-        pulpito:
+        paddles:
             condition: service_healthy
     links:
         - paddles

--- a/docs/docker-compose/start.sh
+++ b/docs/docker-compose/start.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Clone paddles and teuthology
 
-git clone https://github.com/ceph/paddles.git
-cd paddles
-cd ../
 git clone https://github.com/ceph/teuthology.git
 
 # Check for .teuthology.yaml file and copy it to teuthology


### PR DESCRIPTION
paddles use quay.io

docker-compose.yaml: teuthology depends on healthy
paddles rather pulpito

Signed-off-by: Kamoltat Sirivadhna <ksirivad@redhat.com>