### PR TITLE
config: import MuableMapping based on python version

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -1,7 +1,10 @@
 import os
 import yaml
 import logging
-import collections
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 
 def init_logging():
@@ -11,7 +14,7 @@ def init_logging():
 log = init_logging()
 
 
-class YamlConfig(collections.MutableMapping):
+class YamlConfig(MutableMapping):
     """
     A configuration object populated by parsing a yaml file, with optional
     default values.


### PR DESCRIPTION
MutableMapping has been moved from collections to collections.abc.