### PR TITLE
docker-compose: Speed incremental builds by caching dependencies

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -149,9 +149,6 @@ fi
 # First, upgrade pip
 ./$VENV/bin/pip install --upgrade pip
 
-# Remove leftover .pyc files
-find teuthology -name '*.pyc' -exec rm {} \;
-
 # By default, install teuthology in editable mode
 ./$VENV/bin/pip install ${PIP_INSTALL_FLAGS:---editable '.[test]'}
 

--- a/bootstrap
+++ b/bootstrap
@@ -152,8 +152,8 @@ fi
 # Remove leftover .pyc files
 find teuthology -name '*.pyc' -exec rm {} \;
 
-# Install teuthology in editable mode
-./$VENV/bin/pip install --editable '.[test]'
+# By default, install teuthology in editable mode
+./$VENV/bin/pip install ${PIP_INSTALL_FLAGS:---editable '.[test]'}
 
 # Check to make sure requirements are met
 ./$VENV/bin/pip check

--- a/bootstrap
+++ b/bootstrap
@@ -23,7 +23,7 @@ case "$(uname -s)" in
 Linux)
     case "$(lsb_release --id --short)" in
     Ubuntu|Debian|LinuxMint)
-        deps=(qemu-utils python3-dev libssl-dev python3-pip python3-virtualenv libev-dev libvirt-dev libffi-dev libyaml-dev)
+        deps=(qemu-utils python3-dev libssl-dev python3-pip python3-venv libev-dev libvirt-dev libffi-dev libyaml-dev)
         for package in ${deps[@]}; do
             if [ "$(dpkg --status -- $package|sed -n 's/^Status: //p')" != "install ok installed" ]; then
                 # add a space after old values
@@ -44,7 +44,7 @@ Linux)
         fi
         ;;
     RedHatEnterpriseWorkstation|RedHatEnterpriseServer|RedHatEnterprise|CentOS)
-        deps=(python3-pip python3-devel python3-virtualenv mariadb-devel libev-devel libvirt-devel libffi-devel)
+        deps=(python3-pip python3-devel mariadb-devel libev-devel libvirt-devel libffi-devel)
         for package in ${deps[@]}; do
           if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
               missing="${missing:+$missing }$package"
@@ -64,7 +64,7 @@ Linux)
         fi
         ;;
     Fedora)
-        deps=(python3-pip python3-devel python3-virtualenv libev-devel libvirt-devel libffi-devel)
+        deps=(python3-pip python3-devel libev-devel libvirt-devel libffi-devel)
         for package in ${deps[@]}; do
           if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
               missing="${missing:+$missing }$package"
@@ -89,7 +89,7 @@ Linux)
         fi
         ;;
     "openSUSE project"|"SUSE LINUX"|"openSUSE")
-	deps=(python3-pip python3-devel python3-virtualenv libev-devel libvirt-devel libffi-devel)
+	deps=(python3-pip python3-devel python3 libev-devel libvirt-devel libffi-devel)
 	for package in ${deps[@]}; do
             if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
                 if [ "$(rpm -q --whatprovides $package)" == "no package provides $package" ]; then
@@ -135,19 +135,15 @@ Darwin)
     ;;
 esac
 
-# Forcibly remove old virtualenvs which used system site-packages
-if [ -e ./$VENV ]  && [ ! -e ./$VENV/lib/python*/no-global-site-packages.txt ]; then
-    echo "Removing old virtualenv because it uses system site-packages"
-    rm -rf ./$VENV
+# If the venv was set to use system site-packages, fix that
+if [ -f "$VENV/pyvenv.cfg" ]; then
+    sed -i'' -e 's/\(include-system-site-packages\s*=\s*\)true/\1false/g' $VENV/pyvenv.cfg
 fi
 
 export LC_ALL=en_US.UTF-8
 
 if [ -z "$NO_CLOBBER" ] || [ ! -e ./$VENV ]; then
-    if ! virtualenv --version &>/dev/null; then
-        pip install virtualenv
-    fi
-    virtualenv --python=$PYTHON $VENV
+    python3 -m venv $VENV
 fi
 
 # First, upgrade pip

--- a/docs/docker-compose/docker-compose.yml
+++ b/docs/docker-compose/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       MACHINE_TYPE:
       TESTNODES:
       TEUTHOLOGY_WAIT:
+      TEUTH_BRANCH:
   testnode:
     build:
       context: ./testnode

--- a/docs/docker-compose/start.sh
+++ b/docs/docker-compose/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+export TEUTHOLOGY_BRANCH=${TEUTHOLOGY_BRANCH:-$(git branch --show-current)}
+export TEUTH_BRANCH=${TEUTHOLOGY_BRANCH}
 if [ -n "$ANSIBLE_INVENTORY_REPO" ]; then
     basename=$(basename $ANSIBLE_INVENTORY_REPO | cut -d. -f1)
     if [ ! -d "$basename" ]; then

--- a/docs/docker-compose/teuthology/Dockerfile
+++ b/docs/docker-compose/teuthology/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     libssl-dev \
     ipmitool \
     python3-pip \
-    python3-virtualenv \
+    python3-venv \
     vim \
     libev-dev \
     libvirt-dev \

--- a/docs/docker-compose/teuthology/Dockerfile
+++ b/docs/docker-compose/teuthology/Dockerfile
@@ -18,23 +18,26 @@ RUN apt-get update && \
     lsb-release && \
     apt-get clean all
 WORKDIR /teuthology
-COPY . /teuthology
+COPY requirements.txt bootstrap /teuthology/
 RUN \
     cd /teuthology && \
     mkdir ../archive_dir && \
     mkdir log && \
     chmod +x /teuthology/bootstrap && \
+    PIP_INSTALL_FLAGS="-r requirements.txt" ./bootstrap
+COPY . /teuthology
+RUN \
     ./bootstrap
 COPY docs/docker-compose/teuthology/containerized_node.yaml /teuthology
 COPY docs/docker-compose/teuthology/.teuthology.yaml /root
+COPY docs/docker-compose/teuthology/teuthology.sh /
+RUN mkdir -p /etc/ansible
+COPY docs/docker-compose/teuthology/ansible_inventory/hosts /etc/ansible/
+COPY docs/docker-compose/teuthology/ansible_inventory/secrets /etc/ansible/
 RUN \
     mkdir $HOME/.ssh && \
     touch $HOME/.ssh/${SSH_PRIVKEY_FILE} && \
     chmod 600 $HOME/.ssh/${SSH_PRIVKEY_FILE} && \
     echo "StrictHostKeyChecking=no" > $HOME/.ssh/config && \
     echo "UserKnownHostsFile=/dev/null" >> $HOME/.ssh/config
-COPY docs/docker-compose/teuthology/teuthology.sh /
-RUN mkdir -p /etc/ansible
-COPY docs/docker-compose/teuthology/ansible_inventory/hosts /etc/ansible/
-COPY docs/docker-compose/teuthology/ansible_inventory/secrets /etc/ansible/
 ENTRYPOINT /teuthology.sh

--- a/docs/docker-compose/teuthology/teuthology.sh
+++ b/docs/docker-compose/teuthology/teuthology.sh
@@ -5,8 +5,6 @@ if [ -n "$SSH_PRIVKEY_FILE" ]; then
 fi
 source /teuthology/virtualenv/bin/activate
 set -x
-cd /teuthology
-export TEUTHOLOGY_BRANCH=${TEUTHOLOGY_BRANCH:-$(git branch --show-current)}
 if [ -n "$TESTNODES" ]; then
     for node in $(echo $TESTNODES | tr , ' '); do
         teuthology-update-inventory -m $MACHINE_TYPE $node
@@ -18,7 +16,7 @@ fi
 export MACHINE_TYPE=${MACHINE_TYPE:-testnode}
 if [ -z "$TEUTHOLOGY_WAIT" ]; then
     teuthology-suite -v \
-        --teuthology-branch $TEUTHOLOGY_BRANCH \
+        --teuthology-branch $TEUTH_BRANCH \
         --ceph-repo https://github.com/ceph/ceph.git \
         --suite-repo https://github.com/ceph/ceph.git \
         -c master \

--- a/teuthology/exceptions.py
+++ b/teuthology/exceptions.py
@@ -12,6 +12,18 @@ class BranchNotFoundError(ValueError):
             branch=self.branch, repo_str=repo_str)
 
 
+class BranchMismatchError(ValueError):
+    def __init__(self, branch, repo, reason=None):
+        self.branch = branch
+        self.repo = repo
+        self.reason = reason
+
+    def __str__(self):
+        msg = f"Cannot use branch {self.branch} with repo {self.repo}"
+        if self.reason:
+            msg = f"{msg} because {self.reason}"
+        return msg
+
 class CommitNotFoundError(ValueError):
     def __init__(self, commit, repo=None):
         self.commit = commit

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -70,6 +70,27 @@ def ls_remote(url, ref):
     return sha1
 
 
+def current_branch(path: str) -> str:
+    """
+    Return the current branch for a given on-disk repository.
+
+    :returns: the current branch, or an empty string if none is found.
+    """
+    # git branch --show-current was added in 2.22.0, and we can't assume
+    # our version is new enough.
+    cmd = "git rev-parse --abbrev-ref HEAD"
+    result = subprocess.Popen(
+        cmd,
+        shell=True,
+        cwd=path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        ).communicate()[0].strip().decode()
+    if result == "HEAD":
+        return ""
+    return result
+
+
 def enforce_repo_state(repo_url, dest_path, branch, commit=None, remove_on_error=True):
     """
     Use git to either clone or update a given repo, forcing it to switch to the

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -10,10 +10,12 @@ from humanfriendly import format_timespan
 
 from datetime import datetime
 from tempfile import NamedTemporaryFile
+from teuthology import repo_utils
 
 from teuthology.config import config, JobConfig
 from teuthology.exceptions import (
-    BranchNotFoundError, CommitNotFoundError, VersionNotFoundError
+    BranchMismatchError, BranchNotFoundError, CommitNotFoundError,
+    VersionNotFoundError
 )
 from teuthology.misc import deep_merge, get_results_url
 from teuthology.orchestra.opsys import OS
@@ -246,10 +248,23 @@ class Run(object):
         if not teuthology_branch:
             teuthology_branch = config.get('teuthology_branch', 'master')
 
-        teuthology_sha1 = util.git_ls_remote(
-            'teuthology',
-            teuthology_branch
-        )
+        if config.teuthology_path is None:
+            teuthology_sha1 = util.git_ls_remote(
+                'teuthology',
+                teuthology_branch
+            )
+        else:
+            actual_branch = repo_utils.current_branch(config.teuthology_path)
+            if actual_branch != teuthology_branch:
+                raise BranchMismatchError(
+                    teuthology_branch,
+                    config.teuthology_path,
+                    "config.teuthology_path is set",
+                )
+            teuthology_sha1 = util.git_ls_remote(
+                f"file://{config.teuthology_path}",
+                teuthology_branch
+            )
         if not teuthology_sha1:
             exc = BranchNotFoundError(teuthology_branch, build_git_url('teuthology'))
             util.schedule_fail(message=str(exc), name=self.name)

--- a/teuthology/test/test_repo_utils.py
+++ b/teuthology/test/test_repo_utils.py
@@ -223,3 +223,9 @@ class TestRepoUtils(object):
     @mark.parametrize("input_, expected", URLS_AND_DIRNAMES)
     def test_url_to_dirname(self, input_, expected):
         assert repo_utils.url_to_dirname(input_) == expected
+
+    def test_current_branch(self):
+        #repo_utils.enforce_repo_state(self.repo_url, self.dest_path,
+        #                              'master', self.commit)
+        repo_utils.clone_repo(self.repo_url, self.dest_path, 'master', self.commit)
+        assert repo_utils.current_branch(self.dest_path) == "master"


### PR DESCRIPTION
Previously, we'd invalidate the build cache any time the source tree changed; that meant reinstalling every python dependency. This change splits dependency installation from the rest of the bootstrap process, so that we can avoid reinstalling deps unless `requirements.txt` or `bootstrap` changes.