### PR TITLE
lockfile: switch cloning branch name

### DIFF
--- a/teuthology/task/lockfile.py
+++ b/teuthology/task/lockfile.py
@@ -94,7 +94,7 @@ def task(ctx, config):
                     'wget',
                     '-nv',
                     '--no-check-certificate',
-                    'https://raw.github.com/gregsfortytwo/FileLocker/master/sclockandhold.cpp',
+                    'https://raw.github.com/gregsfortytwo/FileLocker/main/sclockandhold.cpp',
                     '-O', '{tdir}/lockfile/sclockandhold.cpp'.format(tdir=testdir),
                     run.Raw('&&'),
                     'g++', '{tdir}/lockfile/sclockandhold.cpp'.format(tdir=testdir),


### PR DESCRIPTION
Renamed the "FileLocker" utility's git branch to "main" to go along with the wider project's changes.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>