### PR TITLE
qa: correct line processing logic

### DIFF
--- a/teuthology/report.py
+++ b/teuthology/report.py
@@ -413,10 +413,8 @@ class ResultsReporter(object):
                     subset = self._parse_log_line(line, 'subset:')
                 if no_nested_subset is None:
                     no_nested_subset = self._parse_log_line(line, 'no_nested_subset:')
-                elif seed is None:
+                if seed is None:
                     seed = self._parse_log_line(line, 'seed:')
-                else:
-                    break
         if subset is not None:
             subset = tuple(int(i) for i in subset.split('/'))
         if no_nested_subset is not None:


### PR DESCRIPTION
Most runs don't use --no-nested-subset and for those that used --subset,
the if conditions would correctly pickup "seed" (when it mattered).
However, when --subset was not specified in the original run, the "seed"
was not correctly picked up. Therefore, the result of inserting the "if
no_nested_subset is None:" before the "elif seed is None:" caused it to
never read the seed for most folks teuthology runs.

Fixes: https://tracker.ceph.com/issues/55815
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>