### PR TITLE
suite: fix type error when description is none

### DIFF
--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -231,5 +231,5 @@ def wait(name, max_job_time, upload_url):
             url = os.path.join(upload_url, name, job['job_id'])
         else:
             url = job['log_href']
-        log.info(job['status'] + " " + url + " " + job['description'])
+        log.info(f"{job['status']} {url} {job['description']}")
     return exit_code


### PR DESCRIPTION
teuthology-watch fails when run is complete and jobs' description
gets None value

Example:

2022-06-07 16:41:22,538.538 INFO:teuthology.suite:waiting for the run runner-2022-06-07_16:41:04-suse:tier0-ses7p-none-default-ecp to complete
2022-06-07 16:41:22,539.539 DEBUG:teuthology.suite:the list of unfinished jobs will be displayed every 5.0 minutes
2022-06-07 16:46:22,599.599 DEBUG:teuthology.suite:wait for jobs ['654']
2022-06-07 16:51:22,633.633 DEBUG:teuthology.suite:wait for jobs ['654']
2022-06-07 16:51:22,686.686 INFO:teuthology.suite:wait is done
Traceback (most recent call last):
  File "/home/runner/src/teuthology_master/virtualenv/bin/teuthology-wait", line 33, in <module>
    sys.exit(load_entry_point('teuthology', 'console_scripts', 'teuthology-wait')())
  File "/home/runner/src/teuthology_master/scripts/wait.py", line 30, in main
    return teuthology.suite.wait(name, config.max_job_time, None)
  File "/home/runner/src/teuthology_master/teuthology/suite/__init__.py", line 234, in wait
    log.info(job['status'] + " " + url + " " + job['description'])
TypeError: must be str, not NoneType

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>