### PR TITLE
nuke.nuke: Rework lock-checking logic

### DIFF
--- a/teuthology/test/test_nuke.py
+++ b/teuthology/test/test_nuke.py
@@ -241,16 +241,18 @@ def test_nuke_internal():
         os_version='8.3',
         name='test_name',
     )
-    locks = [{'name': target, 'description': job_config['name']} for target
-             in job_config['targets'].keys()]
+    statuses = {
+        target: {'name': target, 'description': job_config['name']}
+        for target in job_config['targets'].keys()
+    }
     ctx = create_fake_context(job_config)
 
     # minimal call using defaults
     with patch.multiple(
             nuke,
             nuke_helper=DEFAULT,
-            list_locks=lambda: locks,
             unlock_one=DEFAULT,
+            get_status=lambda i: statuses[i],
             ) as m:
         nuke.nuke(ctx, True)
         m['nuke_helper'].assert_called_with(ANY, True, False, True)
@@ -260,8 +262,8 @@ def test_nuke_internal():
     with patch.multiple(
             nuke,
             nuke_helper=DEFAULT,
-            list_locks=lambda: locks,
             unlock_one=DEFAULT,
+            get_status=lambda i: statuses[i],
             ) as m:
         nuke.nuke(ctx, False)
         m['nuke_helper'].assert_called_with(ANY, False, False, True)
@@ -271,8 +273,8 @@ def test_nuke_internal():
     with patch.multiple(
             nuke,
             nuke_helper=DEFAULT,
-            list_locks=lambda: locks,
             unlock_one=DEFAULT,
+            get_status=lambda i: statuses[i],
             ) as m:
         nuke.nuke(ctx, False, True, False, True, False)
         m['nuke_helper'].assert_called_with(ANY, False, True, False)
@@ -284,6 +286,7 @@ def test_nuke_internal():
             nuke,
             nuke_helper=DEFAULT,
             unlock_one=DEFAULT,
+            get_status=lambda i: statuses[i],
             ) as m:
         nuke.nuke(ctx, True)
         m['nuke_helper'].assert_not_called()


### PR DESCRIPTION
Previously, we would call list_locks(), then iterate over the response,
each time iterating over the list of targets. If list_locks()
encountered an error and returned an empty response, we'd never actually
verify what we intended to. Instead, we should specifically query for
each target. This is far safer and faster.

Signed-off-by: Zack Cerza <zack@redhat.com>