### PR TITLE
suite/run: Log total number of jobs scheduled

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -682,6 +682,9 @@ Note: If you still want to go ahead, use --job-threshold 0'''
 
         count = len(jobs_to_schedule)
         missing_count = len(jobs_missing_packages)
+        total_count = count
+        if self.args.num:
+            total_count *= self.args.num
         log.info(
             'Suite %s in %s scheduled %d jobs.' %
             (suite_name, suite_path, count)
@@ -692,4 +695,5 @@ Note: If you still want to go ahead, use --job-threshold 0'''
         if missing_count:
             log.warning('Scheduled %d/%d jobs that are missing packages!',
                      missing_count, count)
+        log.info('Scheduled %d jobs in total.', total_count)
         return count


### PR DESCRIPTION
Log total number of jobs scheduled, taking `--num` into consideration.

For a command with `--num 5`:
Previously -
```
2022-07-03 09:56:12,974.974 INFO:teuthology.suite.run:Suite smoke in /home/vallariag/src/github.com_vallariag_ceph-c_vallariag-testing-1768/qa/suites/smoke scheduled 2 jobs.
2022-07-03 09:56:12,974.974 INFO:teuthology.suite.run:22/24 jobs were filtered out.
```
Changed to -
```
2022-07-03 09:56:12,974.974 INFO:teuthology.suite.run:Suite smoke in /home/vallariag/src/github.com_vallariag_ceph-c_vallariag-testing-1768/qa/suites/smoke scheduled 2 jobs.
2022-07-03 09:56:12,974.974 INFO:teuthology.suite.run:22/24 jobs were filtered out.
2022-07-03 09:56:12,975.975 INFO:teuthology.suite.run:Scheduled 10 jobs in total.
```

Signed-off-by: Vallari Agrawal <val.agl002@gmail.com>