### PR TITLE
suite: Do not send emails with --dry-run at schedule_fail

### DIFF
--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -109,14 +109,15 @@ def main(args):
     if conf.verbose:
         teuthology.log.setLevel(logging.DEBUG)
 
+    dry_run = conf.dry_run or None
     if not conf.machine_type or conf.machine_type == 'None':
         if not config.default_machine_type or config.default_machine_type == 'None':
-            schedule_fail("Must specify a machine_type")
+            schedule_fail("Must specify a machine_type", dry_run=dry_run)
         else:
            conf.machine_type = config.default_machine_type
     elif 'multi' in conf.machine_type:
         schedule_fail("'multi' is not a valid machine_type. " +
-                      "Maybe you want 'gibba,smithi,mira' or similar")
+                      "Maybe you want 'gibba,smithi,mira' or similar", dry_run=dry_run)
 
     if conf.email:
         config.results_email = conf.email

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -109,7 +109,7 @@ def main(args):
     if conf.verbose:
         teuthology.log.setLevel(logging.DEBUG)
 
-    dry_run = conf.dry_run or None
+    dry_run = conf.dry_run
     if not conf.machine_type or conf.machine_type == 'None':
         if not config.default_machine_type or config.default_machine_type == 'None':
             schedule_fail("Must specify a machine_type", dry_run=dry_run)

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -646,7 +646,7 @@ Note: If you still want to go ahead, use --job-threshold 0'''
                 new_sha1 = \
                     util.find_git_parent('ceph', self.base_config.sha1)
                 if new_sha1 is None:
-                    util.schedule_fail('Backtrack for --newest failed', name)
+                    util.schedule_fail('Backtrack for --newest failed', name, dry_run=self.args.dry_run)
                  # rebuild the base config to resubstitute sha1
                 self.config_input['ceph_hash'] = new_sha1
                 self.base_config = self.build_base_config()

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -141,6 +141,22 @@ class TestRun(object):
         with pytest.raises(ScheduleFailError):
             self.klass(self.args)
 
+    @patch('teuthology.suite.util.smtplib.SMTP')
+    @patch('teuthology.suite.util.git_ls_remote')
+    def test_teuthology_branch_nonexistent(
+        self,
+        m_git_ls_remote,
+        m_smtp,
+    ):
+        m_git_ls_remote.return_value = None
+        config.teuthology_path = None
+        config.results_email = "example@example.com"
+        self.args.dry_run = True
+        self.args.teuthology_branch = 'no_branch'
+        with pytest.raises(ScheduleFailError):
+            self.klass(self.args)
+        m_smtp.assert_not_called()
+
     @patch('teuthology.suite.run.util.fetch_repos')
     @patch('teuthology.suite.run.util.git_branch_exists')
     @patch('teuthology.suite.run.util.package_version_for_hash')

--- a/teuthology/suite/test/test_util.py
+++ b/teuthology/suite/test/test_util.py
@@ -8,6 +8,7 @@ from mock import Mock, patch
 from teuthology.config import config
 from teuthology.orchestra.opsys import OS
 from teuthology.suite import util
+from teuthology.exceptions import ScheduleFailError
 
 
 REPO_PROJECTS_AND_URLS = [
@@ -49,6 +50,40 @@ def git_repository(request):
 class TestUtil(object):
     def setup(self):
         config.use_shaman = False
+
+    @patch('teuthology.suite.util.smtplib.SMTP')
+    def test_schedule_fail(self, m_smtp):
+        config.results_email = "example@example.com"
+        with pytest.raises(ScheduleFailError) as exc:
+            util.schedule_fail(message="error msg", dry_run=False)
+        assert str(exc.value) == "Scheduling failed: error msg"
+        m_smtp.assert_called()
+
+    @patch('teuthology.suite.util.smtplib.SMTP')
+    def test_schedule_fail_dryrun(self, m_smtp):
+        config.results_email = "example@example.com"
+        with pytest.raises(ScheduleFailError) as exc:
+            util.schedule_fail(message="error msg", dry_run=True)
+        assert str(exc.value) == "Scheduling failed: error msg"
+        m_smtp.assert_not_called()
+
+    @patch('teuthology.suite.util.smtplib.SMTP')
+    def test_fetch_repo_no_branch(self, m_smtp):
+        config.results_email = "example@example.com"
+        with pytest.raises(ScheduleFailError) as exc:
+            util.fetch_repos("no-branch", "test1", dry_run=False)
+        assert str(exc.value) == "Scheduling test1 failed: \
+Branch 'no-branch' not found in repo: https://github.com/ceph/ceph-ci.git!"
+        m_smtp.assert_called()
+
+    @patch('teuthology.suite.util.smtplib.SMTP')
+    def test_fetch_repo_no_branch_dryrun(self, m_smtp):
+        config.results_email = "example@example.com"
+        with pytest.raises(ScheduleFailError) as exc:
+            util.fetch_repos("no-branch", "test1", dry_run=True)
+        assert str(exc.value) == "Scheduling test1 failed: \
+Branch 'no-branch' not found in repo: https://github.com/ceph/ceph-ci.git!"
+        m_smtp.assert_not_called()
 
     @patch('requests.get')
     def test_get_hash_success(self, m_get):

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -29,7 +29,7 @@ CONTAINER_DISTRO = 'centos/8'       # the one to check for build_complete
 CONTAINER_FLAVOR = 'default'
 
 
-def fetch_repos(branch, test_name):
+def fetch_repos(branch, test_name, dry_run):
     """
     Fetch the suite repo (and also the teuthology repo) so that we can use it
     to build jobs. Repos are stored in ~/src/.
@@ -51,17 +51,18 @@ def fetch_repos(branch, test_name):
                 fetch_teuthology('main')
         suite_repo_path = fetch_qa_suite(branch)
     except BranchNotFoundError as exc:
-        schedule_fail(message=str(exc), name=test_name)
+        schedule_fail(message=str(exc), name=test_name, dry_run=dry_run)
     return suite_repo_path
 
 
-def schedule_fail(message, name=''):
+def schedule_fail(message, name='', dry_run=None):
     """
     If an email address has been specified anywhere, send an alert there. Then
     raise a ScheduleFailError.
+    Don't send the mail if --dry-run has been passed.
     """
     email = config.results_email
-    if email:
+    if email and not dry_run:
         subject = "Failed to schedule {name}".format(name=name)
         msg = MIMEText(message)
         msg['Subject'] = subject


### PR DESCRIPTION
Do not send emails with `--dry-run` on schedule failures. 

Signed-off-by: Vallari Agrawal <val.agl002@gmail.com>