### PR TITLE
misc._ssh_keyscan(): Drop '-t rsa'

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1127,7 +1127,7 @@ def _ssh_keyscan(hostname):
     :param hostname: The hostname
     :returns: The host key
     """
-    args = ['ssh-keyscan', '-T', '1', '-t', 'rsa', hostname]
+    args = ['ssh-keyscan', '-T', '1', hostname]
     p = subprocess.Popen(
         args=args,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
It appears to be unnecessary, and causes Ubuntu 22.04 to respond with
zero keys.

Signed-off-by: Zack Cerza <zack@redhat.com>