### PR TITLE
opsys.py: Make Ubuntu 22.04 default

### DIFF
--- a/teuthology/orchestra/opsys.py
+++ b/teuthology/orchestra/opsys.py
@@ -62,7 +62,7 @@ DISTRO_CODENAME_MAP = {
 }
 
 DEFAULT_OS_VERSION = dict(
-    ubuntu="20.04",
+    ubuntu="22.04",
     fedora="25",
     centos="8.stream",
     opensuse="15.0",

--- a/teuthology/test/test_get_distro_version.py
+++ b/teuthology/test/test_get_distro_version.py
@@ -20,7 +20,7 @@ class TestGetDistroVersion(object):
         # Default distro is ubuntu, default version of ubuntu is 20.04
         self.fake_ctx.os_version = None
         distroversion = get_distro_version(self.fake_ctx)
-        assert distroversion == '20.04'
+        assert distroversion == '22.04'
 
     def test_argument_version(self):
         self.fake_ctx.os_version = '13.04'


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>