### PR TITLE
boostrap: Add support for CentOSStream

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -63,6 +63,26 @@ Linux)
             fi
         fi
         ;;
+    CentOSStream)
+        deps=(python3-pip python39-devel mariadb-devel libev-devel libvirt-devel libffi-devel)
+        for package in ${deps[@]}; do
+          if [ "$(rpm -q $package)" == "package $package is not installed" ]; then
+              missing="${missing:+$missing }$package"
+          fi
+        done
+        if [ -n "$missing" ]; then
+            echo "$0: missing required packages:" 1>&2
+            echo "$missing"
+            if [ "$install" = true ]; then
+                echo "Installing missing packages..."
+                sudo yum -y install $missing
+            else
+                echo "Please install missing packages or run './bootstrap install' if you have sudo"
+                echo "sudo yum -y install $missing"
+                exit 1
+            fi
+        fi
+        ;;
     Fedora)
         deps=(python3-pip python3-devel libev-devel libvirt-devel libffi-devel)
         for package in ${deps[@]}; do


### PR DESCRIPTION
Currently, we cannot do bootstrap for CentOSStream
so we are adding support for that.

Signed-off-by: Kamoltat Sirivadhna <ksirivad@redhat.com>