### PR TITLE
fog: suggest image names on error

### DIFF
--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -156,9 +156,20 @@ class FOG(object):
         obj = resp.json()
         if not obj['count']:
             raise RuntimeError(
-                "Could not find an image for %s %s" %
-                (self.os_type, self.os_version))
+                "Fog has no %s image. Available %s images: %s" %
+                (name, self.remote.machine_type, self.suggest_image_names()))
         return obj['images'][0]
+
+    def suggest_image_names(self):
+        """
+        Suggest available image names for this machine type.
+
+        :returns: A list of image names.
+        """
+        resp = self.do_request('/image/search/%s' % self.remote.machine_type)
+        obj = resp.json()
+        images = obj['images']
+        return [image['name'] for image in images]
 
     def set_image(self, host_id):
         """

--- a/teuthology/provision/test/test_fog.py
+++ b/teuthology/provision/test/test_fog.py
@@ -174,6 +174,22 @@ class TestFOG(object):
         assert req.body == '{"name": "type1_windows_xp"}'
         assert result == img_objs[0]
 
+    def test_suggest_image_names(self):
+        data = {'images': [
+            {'name': 'mira_rhel_9.1'},
+            {'name': 'mira_rhel_9.2'},
+        ]}
+        self.mocks['m_requests_Session_send']\
+            .return_value.json.return_value = data
+        self.mocks['m_Remote_machine_type'].return_value = 'mira'
+        # Not sure what this klass() is for here:
+        obj = self.klass('name.fqdn', 'mira', '1.0')
+        result = obj.suggest_image_names()
+        assert len(self.mocks['m_requests_Session_send'].call_args_list) == 1
+        req = self.mocks['m_requests_Session_send'].call_args_list[0][0][0]
+        assert req.url == test_config['fog']['endpoint'] + '/image/search/mira'
+        assert result == ['mira_rhel_9.1', 'mira_rhel_9.2']
+
     def test_set_image(self):
         self.mocks['m_Remote_hostname'].return_value = 'name.fqdn'
         self.mocks['m_Remote_machine_type'].return_value = 'type1'


### PR DESCRIPTION
Improve the error message when the user specifies a missing OS version for a machine type.

Old error message:

```
RuntimeError: Could not find an image for rhel 7.9
```

New error message:

```
RuntimeError: Fog has no cali_rhel_7.9 image. Available cali images: ['cali_rhel_8.6', 'cali_rhel_9.0']
```