### PR TITLE
Specify PostgreSQL v14 to avoid permission errors.

### DIFF
--- a/docs/docker-compose/docker-compose.yml
+++ b/docs/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:14
     healthcheck:
       test: [ "CMD", "pg_isready", "-q", "-d", "paddles", "-U", "admin" ]
       timeout: 5s


### PR DESCRIPTION
PostgreSQL v15  has a notable change that revokes the CREATE permission from users except a database owner. So we can not execute paddles using it. As a workaround, I specify PostgreSQL version.

ref: https://www.postgresql.org/about/news/postgresql-15-released-2526/

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>