### PR TITLE
provision/fog.py: log exceptions while looping for ssh

### DIFF
--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -278,7 +278,12 @@ class FOG(object):
                     NoValidConnectionsError,
                     MaxWhileTries,
                     EOFError,
-                ):
+                ) as e:
+                    # log this, because otherwise lots of failures just
+                    # keep retrying without any notification (like, say,
+                    # a mismatched host key in ~/.ssh/known_hosts, or
+                    # something)
+                    log.warning(e)
                     pass
         sentinel_file = config.fog.get('sentinel_file', None)
         if sentinel_file:


### PR DESCRIPTION
Make sure the user knows of potential configuration problems, etc.

Fixes: https://tracker.ceph.com/issues/58015
Signed-off-by: Dan Mick <dmick@redhat.com>