### PR TITLE
task: allow internal.coredump find sysctl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.6, 3.9]
+        python: [3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -451,7 +451,7 @@ def coredump(ctx, config):
                 'install', '-d', '-m0755', '--',
                 '{adir}/coredump'.format(adir=archive_dir),
                 run.Raw('&&'),
-                'sudo', 'sysctl', '-w', 'kernel.core_pattern={adir}/coredump/%t.%p.core'.format(adir=archive_dir),
+                'sudo', '/usr/sbin/sysctl', '-w', 'kernel.core_pattern={adir}/coredump/%t.%p.core'.format(adir=archive_dir),
 		run.Raw('&&'),
 		'echo',
 		'kernel.core_pattern={adir}/coredump/%t.%p.core'.format(adir=archive_dir),
@@ -468,7 +468,7 @@ def coredump(ctx, config):
         run.wait(
             ctx.cluster.run(
                 args=[
-                    'sudo', 'sysctl', '-w', 'kernel.core_pattern=core',
+                    'sudo', '/usr/sbin/sysctl', '-w', 'kernel.core_pattern=core',
                     run.Raw('&&'),
                     'sudo', 'bash', '-c',
                     (f'for f in `find {archive_dir}/coredump -type f`; do '


### PR DESCRIPTION
This fix address error on SLE platform:

  sudo: sysctl: command not found

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>