### PR TITLE
Draft: Fix integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,4 +12,5 @@ jobs:
         working-directory: ./docs/docker-compose
       - name: Debug containers
         if: ${{ failure() }}
-        run: docker container ls --all --format='{{json .}}'
+        run: ./debug.sh
+        working-directory: ./docs/docker-compose

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,3 +10,6 @@ jobs:
       - name: Test using docker-compose
         run: ./start.sh
         working-directory: ./docs/docker-compose
+      - name: Debug containers
+        if: ${{ failure() }}
+        run: docker container ls --all --format='{{json .}}'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Test using docker-compose

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Test using docker-compose
         run: ./start.sh
         working-directory: ./docs/docker-compose

--- a/docs/docker-compose/debug.sh
+++ b/docs/docker-compose/debug.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -x
+for container in postgres paddles pulpito beanstalk teuthology testnode; do
+  name="docker-compose_${container}_1"
+  echo "=== logs $name"
+  docker logs $name
+  echo "=== end logs $name"
+  echo "=== inspect $name"
+  docker inspect $name
+  echo "=== end inspect $name"
+done

--- a/docs/docker-compose/docker-compose.yml
+++ b/docs/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:14
     healthcheck:
       test: [ "CMD", "pg_isready", "-q", "-d", "paddles", "-U", "admin" ]
       timeout: 5s

--- a/docs/docker-compose/start.sh
+++ b/docs/docker-compose/start.sh
@@ -42,7 +42,8 @@ fi
 export TEUTHOLOGY_WAIT
 
 trap "docker-compose down" SIGINT
+docker-compose build
+docker-compose create
 docker-compose up \
-    --build \
     $DC_EXIT_FLAG
 $DC_AUTO_DOWN_CMD


### PR DESCRIPTION
I can't reproduce this failure locally, and it doesn't even happen every time I manually invoke the workflow outside of a PR.

edit: Well how's this for an intermittent failure
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1244, in _execute_context
    cursor, statement, parameters, context
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.InsufficientPrivilege: permission denied for schema public
LINE 2: CREATE TABLE nodes (
                     ^
```

edit: for posterity, the above was caused by the docker-compose file using postgres:latest; pinning to v14 fixed that error.