### PR TITLE
suite: Speed up 'newest' feature

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -644,16 +644,16 @@ Note: If you still want to go ahead, use --job-threshold 0'''
         # if not, do it once
         backtrack = 0
         limit = self.args.newest
+        sha1s = []
         while backtrack <= limit:
             jobs_missing_packages, jobs_to_schedule = \
                 self.collect_jobs(arch, configs, self.args.newest, job_limit)
             if jobs_missing_packages and self.args.newest:
-                new_sha1 = \
-                    util.find_git_parent('ceph', self.base_config.sha1)
-                if new_sha1 is None:
+                if not sha1s:
+                    sha1s = util.find_git_parents('ceph', str(self.base_config.sha1), self.args.newest)
+                if not sha1s:
                     util.schedule_fail('Backtrack for --newest failed', name, dry_run=self.args.dry_run)
-                 # rebuild the base config to resubstitute sha1
-                self.config_input['ceph_hash'] = new_sha1
+                self.config_input['ceph_hash'] = sha1s.pop(0)
                 self.base_config = self.build_base_config()
                 backtrack += 1
                 continue

--- a/teuthology/suite/test/test_util.py
+++ b/teuthology/suite/test/test_util.py
@@ -172,14 +172,14 @@ Branch 'no-branch' not found in repo: https://github.com/ceph/ceph-ci.git!"
         assert util.git_ls_remote('ceph', 'main') is not None
 
     @patch('teuthology.suite.util.requests.get')
-    def test_find_git_parent(self, m_requests_get):
+    def test_find_git_parents(self, m_requests_get):
         refresh_resp = Mock(ok=True)
         history_resp = Mock(ok=True)
         history_resp.json.return_value = {'sha1s': ['sha1', 'sha1_p']}
         m_requests_get.side_effect = [refresh_resp, history_resp]
-        parent_sha1 = util.find_git_parent('ceph', 'sha1')
+        parent_sha1s = util.find_git_parents('ceph', 'sha1')
         assert len(m_requests_get.mock_calls) == 2
-        assert parent_sha1 == 'sha1_p'
+        assert parent_sha1s == ['sha1_p']
 
 
 class TestFlavor(object):


### PR DESCRIPTION
For a 'newest' value of N, we were calling find_git_parent N times. find_git_parent was invoking githelper's 'refresh' endpoint each time, which in my testing took 20-30 seconds. So, for a sha1 that needed 20 backtracks, I was seeing teuthology-suite take eight minutes to complete. With this change, it took 30 seconds for the same teuthology-suite invocation.

We were also not including the trailing slash on the 'refresh' endpoint, resulting in a 308 redirect each time - doubling the request count. That's fixed as well.

Signed-off-by: Zack Cerza <zack@redhat.com>