### PR TITLE
fog: make timeouts configurable

### DIFF
--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -166,6 +166,8 @@ class TeuthologyConfig(YamlConfig):
         'src_base_path': os.path.expanduser('~/src'),
         'verify_host_keys': True,
         'watchdog_interval': 120,
+        'fog_reimage_timeout': 1800,
+        'fog_wait_for_ssh_timeout': 600,
         'kojihub_url': 'http://koji.fedoraproject.org/kojihub',
         'kojiroot_url': 'http://kojipkgs.fedoraproject.org/packages',
         'koji_task_url': 'https://kojipkgs.fedoraproject.org/work/',

--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -251,7 +251,7 @@ class FOG(object):
         completed)
         """
         self.log.info("Waiting for deploy to finish")
-        with safe_while(sleep=15, tries=120) as proceed:
+        with safe_while(sleep=15, tries=120, timeout=config.fog_reimage_timeout) as proceed:
             while proceed():
                 if not self.deploy_task_active(task_id):
                     break
@@ -267,7 +267,7 @@ class FOG(object):
 
     def _wait_for_ready(self):
         """ Attempt to connect to the machine via SSH """
-        with safe_while(sleep=6, tries=100) as proceed:
+        with safe_while(sleep=6, timeout=config.fog_wait_for_ssh_timeout) as proceed:
             while proceed():
                 try:
                     self.remote.connect()

--- a/teuthology/test/test_contextutil.py
+++ b/teuthology/test/test_contextutil.py
@@ -49,6 +49,29 @@ class TestSafeWhile(object):
 
         assert 'waiting for 105 seconds' in str(error)
 
+    def test_timeout(self):
+        # series of sleep, increment, timeout params to test
+        params = [(10, 0, 100),
+                  (1, 2, 30),
+                  (10, 0.5, 100),
+                  (2, 0, 5),
+                  (2, 3, 5),
+                  (10, 0, 15),
+                  (20, 10, 60)]
+        for sleep, increment, timeout in params:
+            print("trying ", sleep, increment, timeout)
+            with raises(contextutil.MaxWhileTries) as error:
+                with self.s_while(
+                        sleep=sleep,
+                        increment=increment,
+                        timeout=timeout,
+                        _sleeper=self.fake_sleep
+                ) as proceed:
+                    while proceed():
+                        pass
+
+            assert 'waiting for {timeout}'.format(timeout=timeout) in str(error)
+
     def test_action(self):
         with raises(contextutil.MaxWhileTries) as error:
             with self.s_while(


### PR DESCRIPTION
This will help with the sepia lab, being able to increase these
temporarily to handle a new fog server that is sometimes exceeding the
hardcoded timeouts.