### PR TITLE
bootstrap: Correct python3 package names for EL8/9

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -59,7 +59,7 @@ Linux)
         fi
         ;;
     RedHatEnterpriseWorkstation|RedHatEnterpriseServer|RedHatEnterprise|CentOS)
-        deps=(python3-pip python3-devel mariadb-devel libev-devel libvirt-devel libffi-devel)
+        deps=(python39-pip python39-devel mariadb-devel libev-devel libvirt-devel libffi-devel)
         for package in ${deps[@]}; do
           if ! rpm -q --whatprovides $package ; then
               missing="${missing:+$missing }$package"


### PR DESCRIPTION
`python3-devel` is only provided by `python36-devel` for whatever reason, and 3.6 is not new enough.