### PR TITLE
tasks/selinux: fix escaping on ignore_known_denials

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -141,7 +141,7 @@ class SELinux(Task):
         se_allowlist = self.config.get('allowlist', [])
         if se_allowlist:
             known_denials.extend(se_allowlist)
-        ignore_known_denials = r'\'\(' + str.join(r'\|', known_denials) + r'\)\''
+        ignore_known_denials = r"""'\(' + str.join(r'\|', known_denials) + r'\)'"""
         for remote in self.cluster.remotes.keys():
             proc = remote.run(
                 args=['sudo', 'grep', '-a', 'avc: .*denied',


### PR DESCRIPTION
a106217a swapped this line to use a raw string.  This left the initial and final ```\'``` in the output resulting in a grep -av line which didn't work as intended:

```
sudo grep -a 'avc: .*denied' /var/log/audit/audit.log | grep -av \'\(comm="dmidecode"\|chronyd.service\|name="cephtest"\|scontext=system_u:system_r:nrpe_t:s0\|scontext=system_u:system_r:pcp_pmlogger_t\|scontext=system_u:system_r:pcp_pmcd_t:s0\|comm="rhsmd"\|scontext=system_u:system_r:syslogd_t:s0\|tcontext=system_u:system_r:nrpe_t:s0\|comm="updatedb"\|comm="smartd"\|comm="rhsmcertd-worke"\|comm="setroubleshootd"\|comm="rpm"\|tcontext=system_u:object_r:container_runtime_exec_t:s0\|comm="ksmtuned"\|comm="sssd"\|comm="sss_cache"\|context=system_u:system_r:NetworkManager_dispatcher_t:s0\)\'

| grep -av \'
```

Instead, use r""" """ and don't escape the initial and trailing '.

Fixes: https://tracker.ceph.com/issues/58610
Introduced: a106217a990efa3b5af540d3cef712047f7b1d2a
Signed-off-by: Samuel Just <sjust@redhat.com>