### PR TITLE
orchestra.connection: Look for 'ssh_key' in config

### DIFF
--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -226,6 +226,10 @@ Here is a sample configuration with many of the options set and documented::
     conserver_master: conserver.front.sepia.ceph.com
     conserver_port: 3109
 
+    # Optionally use a specific SSH private key to connect to test nodes.
+    # Takes precedence over any entries in ~/.ssh/config.
+    ssh_key: ~/.ssh/my_key.rsa
+
     # Settings for [nsupdate-web](https://github.com/zmc/nsupdate-web)
     # Used by the [libcloud](https://libcloud.apache.org/) backend
     nsupdate_url: http://nsupdate.front.sepia.ceph.com/update

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -191,6 +191,7 @@ class TeuthologyConfig(YamlConfig):
         },
         'rocketchat': None,
         'sleep_before_teardown': 0,
+        'ssh_key': None,
     }
 
     def __init__(self, yaml_path=None):

--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -79,8 +79,9 @@ def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,
         timeout=timeout
     )
 
+    key_filename = key_filename or config.ssh_key
     ssh_config_path = os.path.expanduser("~/.ssh/config")
-    if os.path.exists(ssh_config_path):
+    if not key_filename and os.path.exists(ssh_config_path):
         ssh_config = paramiko.SSHConfig()
         ssh_config.parse(open(ssh_config_path))
         opts = ssh_config.lookup(host)


### PR DESCRIPTION
On systems where SSH is configured using ~/.ssh/config.d/, we don't have a great way of locating and processing the full configuration, so we might not find the correct key to use. Allow the user to specify one key to use for all test nodes if they wish.

Signed-off-by: Zack Cerza <zack@redhat.com>