### PR TITLE
Add timing instrumentation to the exporter

### DIFF
--- a/docs/exporter.rst
+++ b/docs/exporter.rst
@@ -1,0 +1,67 @@
+.. _exporter:
+
+==================================
+The Teuthology Prometheus Exporter
+==================================
+
+To help make it easier to determine the status of the lab, we've created a
+`Prometheus <https://prometheus.io/>`__ exporter (helpfully named
+`teuthology-exporter`. We use `Grafana <https://grafana.com/>`__ to visualize
+the data we collect.
+
+It listens on port 61764, and scrapes every 60 seconds by default.
+
+
+Exposed Metrics
+===============
+
+.. list-table::
+
+  * - Name
+    - Type
+    - Description
+    - Labels
+  * - beanstalk_queue_length
+    - Gauge
+    - The number of jobs in the beanstalkd queue
+    - machine type
+  * - beanstalk_queue_paused
+    - Gauge
+    - Whether or not the beanstalkd queue is paused
+    - machine type
+  * - teuthology_dispatchers
+    - Gauge
+    - The number of running teuthology-dispatcher instances
+    - machine type
+  * - teuthology_job_processes
+    - Gauge
+    - The number of running job *processes*
+    - 
+  * - teuthology_job_results_total
+    - Gauge
+    - The number of completed jobs
+    - status (pass/fail/dead)
+  * - teuthology_nodes
+    - Gauge
+    - The number of test nodes
+    - up, locked
+  * - teuthology_job_duration_seconds
+    - Summary
+    - The time it took to run a job
+    - suite
+  * - teuthology_task_duration_seconds
+    - Summary
+    - The time it took for each phase of each task to run
+    - name, phase (enter/exit)
+  * - teuthology_bootstrap_duration_seconds
+    - Summary
+    - The time it took to run teuthology's bootstrap script
+    - 
+  * - teuthology_node_locking_duration_seconds
+    - Summary
+    - The time it took to lock nodes
+    - machine type, count
+  * - teuthology_node_reimaging_duration_seconds
+    - Summary
+    - The time it took to reimage nodes
+    - machine type, count

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Content Index
    downburst_vms.rst
    INSTALL.rst
    LAB_SETUP.rst
+   exporter.rst
    commands/list.rst
    ChangeLog.rst
 

--- a/teuthology/dispatcher/__init__.py
+++ b/teuthology/dispatcher/__init__.py
@@ -14,6 +14,7 @@ from teuthology import (
     install_except_hook,
     # modules
     beanstalk,
+    exporter,
     nuke,
     report,
     repo_utils,
@@ -228,13 +229,16 @@ def find_dispatcher_processes() -> Dict[str, List[psutil.Process]]:
 def lock_machines(job_config):
     report.try_push_job_info(job_config, dict(status='running'))
     fake_ctx = supervisor.create_fake_context(job_config, block=True)
-    lock_ops.block_and_lock_machines(
-        fake_ctx,
-        len(job_config['roles']),
-        job_config['machine_type'],
-        tries=-1,
-        reimage=False,
-    )
+    machine_type = job_config["machine_type"]
+    count = len(job_config['roles'])
+    with exporter.NodeLockingTime.labels(machine_type, count).time():
+        lock_ops.block_and_lock_machines(
+            fake_ctx,
+            count,
+            machine_type,
+            tries=-1,
+            reimage=False,
+        )
     job_config = fake_ctx.config
     return job_config
 

--- a/teuthology/dispatcher/supervisor.py
+++ b/teuthology/dispatcher/supervisor.py
@@ -45,7 +45,17 @@ def main(args):
 
     # reimage target machines before running the job
     if 'targets' in job_config:
-        reimage(job_config)
+        node_count = len(job_config["targets"])
+        # If a job (e.g. from the nop suite) doesn't need nodes, avoid
+        # submitting a zero here.
+        if node_count:
+            with exporter.NodeReimagingTime.labels(
+                job_config["machine_type"],
+                node_count
+            ).time():
+                reimage(job_config)
+        else:
+            reimage(job_config)
         with open(config_file_path, 'w') as f:
             yaml.safe_dump(job_config, f, default_flow_style=False)
 

--- a/teuthology/dispatcher/supervisor.py
+++ b/teuthology/dispatcher/supervisor.py
@@ -8,7 +8,7 @@ import requests
 from urllib.parse import urljoin
 from datetime import datetime
 
-from teuthology import kill, nuke, report, safepath
+from teuthology import exporter, kill, nuke, report, safepath
 from teuthology.config import config as teuth_config
 from teuthology.exceptions import SkipJob, MaxWhileTries
 from teuthology import setup_log_file, install_except_hook
@@ -50,12 +50,13 @@ def main(args):
             yaml.safe_dump(job_config, f, default_flow_style=False)
 
     try:
-        return run_job(
-            job_config,
-            teuth_bin_path,
-            archive_dir,
-            verbose
-        )
+        with exporter.JobTime.labels(job_config["suite"]).time():
+            return run_job(
+                job_config,
+                teuth_bin_path,
+                archive_dir,
+                verbose
+            )
     except SkipJob:
         return 0
 

--- a/teuthology/exporter.py
+++ b/teuthology/exporter.py
@@ -169,7 +169,7 @@ class Nodes(TeuthologyMetric):
                 )
 
 
-class JobResults(TeuthologyMetric):
+class _JobResults(TeuthologyMetric):
     def __init__(self):
         self.metric = Counter(
             "teuthology_job_results",
@@ -181,6 +181,8 @@ class JobResults(TeuthologyMetric):
     def record(self, machine_type, status):
         self.metric.labels(machine_type=machine_type, status=status).inc()
 
+
+JobResults = _JobResults()
 
 NodeLockingTime = Summary(
     "teuthology_node_locking_duration_seconds",

--- a/teuthology/exporter.py
+++ b/teuthology/exporter.py
@@ -184,7 +184,13 @@ class JobResults(TeuthologyMetric):
 
 NodeLockingTime = Summary(
     "teuthology_node_locking_duration_seconds",
-    "Time spent waiting to lock a node",
+    "Time spent waiting to lock nodes",
+    ["machine_type", "count"],
+)
+
+NodeReimagingTime = Summary(
+    "teuthology_node_reimaging_duration_seconds",
+    "Time spent reimaging nodes",
     ["machine_type", "count"],
 )
 

--- a/teuthology/exporter.py
+++ b/teuthology/exporter.py
@@ -23,6 +23,7 @@ from prometheus_client import (  # noqa: E402
     start_http_server,
     Gauge,
     Counter,
+    Summary,
     multiprocess,
     CollectorRegistry,
 )
@@ -112,9 +113,7 @@ class BeanstalkQueue(TeuthologyMetric):
 
     def update(self):
         for machine_type in MACHINE_TYPES:
-            queue_stats = beanstalk.stats_tube(
-                beanstalk.connect(), machine_type
-            )
+            queue_stats = beanstalk.stats_tube(beanstalk.connect(), machine_type)
             self.length.labels(machine_type).set(queue_stats["count"])
             self.paused.labels(machine_type).set(1 if queue_stats["paused"] else 0)
 
@@ -181,6 +180,13 @@ class JobResults(TeuthologyMetric):
     # As this is to be used within job processes, we implement record() rather than update()
     def record(self, machine_type, status):
         self.metric.labels(machine_type=machine_type, status=status).inc()
+
+
+NodeLockingTime = Summary(
+    "teuthology_node_locking_duration_seconds",
+    "Time spent waiting to lock a node",
+    ["machine_type", "count"],
+)
 
 
 def main(args):

--- a/teuthology/exporter.py
+++ b/teuthology/exporter.py
@@ -200,6 +200,11 @@ TaskTime = Summary(
     ["name", "phase"],
 )
 
+BootstrapTime = Summary(
+    "teuthology_bootstrap_duration_seconds",
+    "Time spent running teuthology's bootstrap script",
+)
+
 
 def main(args):
     exporter = TeuthologyExporter(interval=int(args["--interval"]))

--- a/teuthology/exporter.py
+++ b/teuthology/exporter.py
@@ -194,6 +194,12 @@ JobTime = Summary(
     ["suite"],
 )
 
+TaskTime = Summary(
+    "teuthology_task_duration_seconds",
+    "Time spent executing a task",
+    ["name", "phase"],
+)
+
 
 def main(args):
     exporter = TeuthologyExporter(interval=int(args["--interval"]))

--- a/teuthology/exporter.py
+++ b/teuthology/exporter.py
@@ -188,6 +188,12 @@ NodeLockingTime = Summary(
     ["machine_type", "count"],
 )
 
+JobTime = Summary(
+    "teuthology_job_duration_seconds",
+    "Time spent executing a job",
+    ["suite"],
+)
+
 
 def main(args):
     exporter = TeuthologyExporter(interval=int(args["--interval"]))

--- a/teuthology/kill.py
+++ b/teuthology/kill.py
@@ -87,7 +87,7 @@ def kill_job(run_name, job_id, archive_base=None, owner=None, skip_nuke=False):
         owner = job_info['owner']
     kill_processes(run_name, [job_info.get('pid')])
     if 'machine_type' in job_info:
-        teuthology.exporter.JobResults().record(
+        teuthology.exporter.JobResults.record(
             job_info["machine_type"],
             job_info.get("status", "dead")
         )

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 import time
 
+import teuthology.exporter as exporter
+
 from teuthology import misc
 from teuthology.util.flock import FileLock
 from teuthology.config import config
@@ -438,6 +440,7 @@ def fetch_teuthology(branch, commit=None, lock=True):
 
 
 def bootstrap_teuthology(dest_path):
+    with exporter.BootstrapTime.time():
         log.info("Bootstrapping %s", dest_path)
         # This magic makes the bootstrap script not attempt to clobber an
         # existing virtualenv. But the branch's bootstrap needs to actually
@@ -445,11 +448,15 @@ def bootstrap_teuthology(dest_path):
         env = os.environ.copy()
         env['NO_CLOBBER'] = '1'
         cmd = './bootstrap'
-        boot_proc = subprocess.Popen(cmd, shell=True, cwd=dest_path, env=env,
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT,
-                                     universal_newlines=True)
-        out, err = boot_proc.communicate()
+        boot_proc = subprocess.Popen(
+            cmd, shell=True,
+            cwd=dest_path,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True
+        )
+        out, _ = boot_proc.communicate()
         returncode = boot_proc.wait()
         log.info("Bootstrap exited with status %s", returncode)
         if returncode != 0:

--- a/teuthology/report.py
+++ b/teuthology/report.py
@@ -474,7 +474,7 @@ def push_job_info(run_name, job_id, job_info, base_uri=None):
     reporter.report_job(run_name, job_id, job_info)
     status = get_status(job_info)
     if status in ["pass", "fail", "dead"] and "machine_type" in job_info:
-        teuthology.exporter.JobResults().record(job_info["machine_type"], status)
+        teuthology.exporter.JobResults.record(job_info["machine_type"], status)
 
 
 def try_push_job_info(job_config, extra_info=None):
@@ -584,7 +584,7 @@ def try_mark_run_dead(run_name):
                 log.info("Marking job {job_id} as dead".format(job_id=job_id))
                 reporter.report_job(run_name, job['job_id'], dead=True)
                 if "machine_type" in job:
-                    teuthology.exporter.JobResults().record(job["machine_type"], job["status"])
+                    teuthology.exporter.JobResults.record(job["machine_type"], job["status"])
             except report_exceptions:
                 log.exception("Could not mark job as dead: {job_id}".format(
                     job_id=job_id))

--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -17,8 +17,7 @@ import re
 import humanfriendly
 
 import teuthology.lock.ops
-from teuthology import misc
-from teuthology.packaging import get_builder_project
+from teuthology import misc, packaging
 from teuthology import report
 from teuthology.config import config as teuth_config
 from teuthology.exceptions import ConfigError, VersionNotFoundError
@@ -89,7 +88,7 @@ def check_packages(ctx, config):
     # We can only do this check if there are a defined sha1 and os_type
     # in the job config.
     if os_type and sha1:
-        package = get_builder_project()("ceph", ctx.config)
+        package = packaging.get_builder_project()("ceph", ctx.config)
         template = "Checking packages for os_type '{os}', " \
             "flavor '{flav}' and ceph hash '{ver}'"
         log.info(

--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -2,6 +2,7 @@
 Kernel installation task
 """
 
+import contextlib
 import logging
 import os
 import re
@@ -1130,6 +1131,7 @@ def get_sha1_from_pkg_name(path):
     return sha1
 
 
+@contextlib.contextmanager
 def task(ctx, config):
     """
     Make sure the specified kernel is installed.
@@ -1233,6 +1235,11 @@ def task(ctx, config):
     with parallel() as p:
         for role, role_config in config.items():
             p.spawn(process_role, ctx, config, timeout, role, role_config)
+
+    try:
+        yield
+    finally:
+        pass
 
 
 def process_role(ctx, config, timeout, role, role_config):


### PR DESCRIPTION
This adds data for time spent while:
* locking nodes
* reimaging nodes
* running the bootstrap script
* running a job
* running each phase of each task in a job