### PR TITLE
teuthology/misc: use parallel gzip to compress logs

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1367,7 +1367,7 @@ def compress_logs(ctx, remote_dir):
     run.wait(
         ctx.cluster.run(
             args=(f"sudo find {remote_dir} -name *.log -print0 | "
-                  f"sudo xargs --max-args=1 --max-procs=0 --verbose -0 --no-run-if-empty -- gzip --"),
+                  f"sudo xargs --max-args=1 --max-procs=0 --verbose -0 --no-run-if-empty -- gzip -5 --"),
             wait=False,
         ),
     )

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -745,8 +745,8 @@ def pull_directory(remote, remotedir, localdir, write_to=copy_fileobj):
               remote.shortname, remotedir, localdir)
     if not os.path.exists(localdir):
         os.mkdir(localdir)
-    r = remote.get_tar_stream(remotedir, sudo=True)
-    tar = tarfile.open(mode='r|gz', fileobj=r.stdout)
+    r = remote.get_tar_stream(remotedir, sudo=True, compress=False)
+    tar = tarfile.open(mode='r|', fileobj=r.stdout)
     while True:
         ti = tar.next()
         if ti is None:

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1367,7 +1367,7 @@ def compress_logs(ctx, remote_dir):
     run.wait(
         ctx.cluster.run(
             args=(f"sudo find {remote_dir} -name *.log -print0 | "
-                  f"sudo xargs -0 --no-run-if-empty -- gzip --"),
+                  f"sudo xargs --max-args=1 --max-procs=0 --verbose -0 --no-run-if-empty -- gzip --"),
             wait=False,
         ),
     )

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1367,7 +1367,7 @@ def compress_logs(ctx, remote_dir):
     run.wait(
         ctx.cluster.run(
             args=(f"sudo find {remote_dir} -name *.log -print0 | "
-                  f"sudo xargs --max-args=1 --max-procs=0 --verbose -0 --no-run-if-empty -- gzip -5 --"),
+                  f"sudo xargs --max-args=1 --max-procs=0 --verbose -0 --no-run-if-empty -- gzip -5 --verbose --"),
             wait=False,
         ),
     )

--- a/teuthology/orchestra/remote.py
+++ b/teuthology/orchestra/remote.py
@@ -622,7 +622,7 @@ class Remote(RemoteShell):
             self.remove(path)
         return local_path
 
-    def get_tar(self, path, to_path, sudo=False):
+    def get_tar(self, path, to_path, sudo=False, compress=True):
         """
         Tar a remote directory and copy it locally
         """
@@ -632,7 +632,7 @@ class Remote(RemoteShell):
             args.append('sudo')
         args.extend([
             'tar',
-            'cz',
+            'cz' if compress else 'c',
             '-f', '-',
             '-C', path,
             '--',
@@ -645,7 +645,7 @@ class Remote(RemoteShell):
         self._sftp_get_file(remote_temp_path, to_path)
         self.remove(remote_temp_path)
 
-    def get_tar_stream(self, path, sudo=False):
+    def get_tar_stream(self, path, sudo=False, compress=True):
         """
         Tar-compress a remote directory and return the RemoteProcess
         for streaming
@@ -655,7 +655,7 @@ class Remote(RemoteShell):
             args.append('sudo')
         args.extend([
             'tar',
-            'cz',
+            'cz' if compress else 'c',
             '-f', '-',
             '-C', path,
             '--',


### PR DESCRIPTION
I was hoping to evaluate this in testing but apparently this is one of those parts of teuthology that needs merged into main to run. Anyway, I expect this should dramatically reduce the time teuthology spends compressing logs at the end of long tests.