### PR TITLE
tox: Don't run openstack by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs, py3, flake8, openstack
+envlist = docs, py3, flake8
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
It's quite time-consuming, and we're not sure if it's in use at all.