### PR TITLE
teuthology-suite: --seed & --subset now also stored in teuthology.log, config.yaml and orig.config.yaml

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -121,7 +121,8 @@ Scheduler arguments:
                               contain each facet at least once) and schedule
                               piece <index>.  Scheduling 0/<outof>, 1/<outof>,
                               2/<outof> ... <outof>-1/<outof> will schedule all
-                              jobs in the suite (many more than once).
+                              jobs in the suite (many more than once). If specified,
+                              this value can be found in results.log.
   -p <priority>, --priority <priority>
                               Job priority (lower is sooner)
                               [default: 1000]
@@ -157,25 +158,28 @@ Scheduler arguments:
                               using the same logic as --filter.
                               Of all the flags that were passed when scheduling
                               the original run, the resulting one will only
-                              inherit the suite value. Any others must be
-                              passed as normal while scheduling with this
-                              feature. For random tests involving facet whose
-                              path ends with '$' operator, you might want to
-                              use --seed argument to repeat them.
+                              inherit the --suite value. Any other arguments
+                              must be passed again while scheduling. By default,
+                              'seed' and 'subset' will be taken from results.log,
+                              but can be overide if passed again.
+                              This is important for tests involving random facet
+                              (path ends with '$' operator).
  -R, --rerun-statuses <statuses>
                               A comma-separated list of statuses to be used
                               with --rerun. Supported statuses are: 'dead',
                               'fail', 'pass', 'queued', 'running', 'waiting'
                               [default: fail,dead]
  --seed SEED                  An random number mostly useful when used along
-                              with --rerun argument. This number can be found
-                              in the output of teuthology-suite command. -1
-                              for a random seed [default: -1].
+                              with --rerun argument to rerun the exact
+                              same jobs that can only be picked at random.
+                              This number can be found in the output of
+                              teuthology-suite command or in results.log.
+                              Pass -1 for a random seed [default: -1].
  --force-priority             Skip the priority check.
  --job-threshold <threshold>  Do not allow to schedule the run if the number
                               of jobs exceeds <threshold>. Use 0 to allow
                               any number [default: {default_job_threshold}].
- --no-nested-subset           Do not perform nested suite subsets.
+ --no-nested-subset           Do not perform nested suite subsets [default: false].
 
 +=================+=================================================================+
 | Priority        | Explanation                                                     |

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -166,8 +166,11 @@ def get_rerun_conf(conf):
     try:
         subset, no_nested_subset, seed = reporter.get_rerun_conf(conf.rerun)
     except IOError:
+        log.error('Error accessing results.log, file might be missing.')
+        log.warning('Using default/specified values for --seed, --subset and --no-nested-subset')
         return conf.subset, conf.no_nested_subset, conf.seed
     if seed is None:
+        log.warning('Missing seed in results.log, using default/specified values for --seed')
         return conf.subset, conf.no_nested_subset, conf.seed
     if conf.seed < 0:
         log.info('Using stored seed=%s', seed)
@@ -185,6 +188,7 @@ def get_rerun_conf(conf):
                   stored_subset=subset)
     if conf.no_nested_subset is True:
         log.info('Nested subsets disabled')
+        no_nested_subset = conf.no_nested_subset
     return subset, no_nested_subset, seed
 
 

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -343,6 +343,9 @@ class Run(object):
         job_config.user = self.user
         job_config.timestamp = self.timestamp
         job_config.priority = self.args.priority
+        job_config.seed = self.args.seed
+        if self.args.subset:
+            job_config.subset = '/'.join(str(i) for i in self.args.subset)
         if self.args.email:
             job_config.email = self.args.email
         if self.args.owner:


### PR DESCRIPTION
Notify the user if `results.log` is missing when
they issue a rerun.

1. Edited teuthology-suite doc to
inform the user about how `--rerun` by
default parse `--seed`, `--subset` and
`--no-nested-subset` from `results.log`
by default.

2. In addition to being stored in `results.log`
`--seed` and `--subset` are now also stored in:
`teuthlogy.log`, `config.yaml` and `orig.config.yaml`.
Therefore, in the case where `results.log` is missing, the user can explicitly pass `--seed` and `--subset`.


Fixes: https://tracker.ceph.com/issues/59118

Signed-off-by: Kamoltat <ksirivad@redhat.com>