### PR TITLE
teuthology: fix the problem that git_build_url defaults to github

### DIFF
--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -51,9 +51,9 @@ def build_git_url(project, project_owner='ceph'):
     elif project == 'ceph':
         base = config.get_ceph_git_url()
     else:
-        base = 'https://github.com/{project_owner}/{project}'
+	base = '{ceph_git_base_url}/{project_owner}/{project}'
     url_templ = re.sub(r'\.git$', '', base)
-    return url_templ.format(project_owner=project_owner, project=project)
+    return url_templ.format(ceph_git_base_url=config.ceph_git_base_url, project_owner=project_owner, project=project)
 
 
 def ls_remote(url, ref):


### PR DESCRIPTION
Signed-off-by: Sun Junnan <sunjunnan_yewu@cmss.chinamobile.com>

The build_git_url function creates a github connection by default when the project name does not belong to one of ceph,ceph-cm-ansible,ceph-qa-suite. Modify the function to achieve that if project name is not one of the above three, create the ceph_git_base_url connection in the teutology.yaml file.