### PR TITLE
remove(ntpd): remove the ntpd operation

### DIFF
--- a/teuthology/nuke/actions.py
+++ b/teuthology/nuke/actions.py
@@ -404,20 +404,13 @@ def synch_clocks(remotes):
     for remote in remotes:
         remote.run(
             args=[
-                'sudo', 'systemctl', 'stop', 'ntp.service', run.Raw('||'),
-                'sudo', 'systemctl', 'stop', 'ntpd.service', run.Raw('||'),
-                'sudo', 'systemctl', 'stop', 'chronyd.service',
+		'sudo', 'systemctl', 'restart', 'chronyd.service',
                 run.Raw('&&'),
-                'sudo', 'ntpdate-debian', run.Raw('||'),
-                'sudo', 'ntp', '-gq', run.Raw('||'),
-                'sudo', 'ntpd', '-gq', run.Raw('||'),
-                'sudo', 'chronyc', 'sources',
+		'sudo', 'chronyc', 'makestep',
                 run.Raw('&&'),
                 'sudo', 'hwclock', '--systohc', '--utc',
-                run.Raw('&&'),
-                'sudo', 'systemctl', 'start', 'ntp.service', run.Raw('||'),
-                'sudo', 'systemctl', 'start', 'ntpd.service', run.Raw('||'),
-                'sudo', 'systemctl', 'start', 'chronyd.service',
+                run.Raw(';'),
+		'sudo', 'chronyc', 'sources',
                 run.Raw('||'),
                 'true',    # ignore errors; we may be racing with ntpd startup
             ],

--- a/teuthology/task/clock.py
+++ b/teuthology/task/clock.py
@@ -41,18 +41,10 @@ def task(ctx, config):
     run.wait(
         cluster.run(
             args = [
-                'sudo', 'systemctl', 'stop', 'ntp.service', run.Raw('||'),
-                'sudo', 'systemctl', 'stop', 'ntpd.service', run.Raw('||'),
-                'sudo', 'systemctl', 'stop', 'chronyd.service',
+		'sudo', 'systemctl', 'restart', 'chronyd.service',
                 run.Raw(';'),
-                'sudo', 'ntpd', '-gq', run.Raw('||'),
                 'sudo', 'chronyc', 'makestep',
                 run.Raw(';'),
-                'sudo', 'systemctl', 'start', 'ntp.service', run.Raw('||'),
-                'sudo', 'systemctl', 'start', 'ntpd.service', run.Raw('||'),
-                'sudo', 'systemctl', 'start', 'chronyd.service',
-                run.Raw(';'),
-                'PATH=/usr/bin:/usr/sbin', 'ntpq', '-p', run.Raw('||'),
                 'PATH=/usr/bin:/usr/sbin', 'chronyc', 'sources',
                 run.Raw('||'),
                 'true'


### PR DESCRIPTION
Signed-off-by: Sun Junnan sunjunnan_yewu@cmss.chinamobile.com

The ntp service conflicts with the ntpdate-debian command.
(https://ubuntu.com/server/docs/network-ntp) 
Stop the ntp service to execute the ntpdate-debian command to synchronize the system time.
Then hwclock systohc writes the synchronized system time into the rtc hardware clock .
Finally restore the ntp service.