### PR TITLE
task/install/packages.yaml: Update packages.yaml from ceph/main 

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -145,10 +145,12 @@ def get_package_list(ctx, config):
             yaml_path = suite_packages_path
     # If packages.yaml isn't found in the suite_path, potentially use
     # teuthology's
-    yaml_path = yaml_path or os.path.join(
-        os.path.dirname(__file__),
-        'packages.yaml',
-    )
+    if not yaml_path:
+        log.info("Falling back to Teuthology's packages.yaml")
+        yaml_path = os.path.join(
+            os.path.dirname(__file__),
+            'packages.yaml',
+        )
     default_packages = yaml.safe_load(open(yaml_path))
     default_debs = default_packages.get(project, dict()).get('deb', [])
     default_rpms = default_packages.get(project, dict()).get('rpm', [])

--- a/teuthology/task/install/packages.yaml
+++ b/teuthology/task/install/packages.yaml
@@ -2,36 +2,84 @@
 ceph:
   deb:
   - ceph
+  - cephadm
   - ceph-mds
+  - ceph-mgr
   - ceph-common
   - ceph-fuse
   - ceph-test
+  - ceph-volume
   - radosgw
-  - python-ceph
-  - libcephfs1
-  - libcephfs-java
-  - libcephfs-jni
+  - python3-rados
+  - python3-rgw
+  - python3-cephfs
+  - python3-rbd
+  - libcephfs2
+  - libcephfs-dev
   - librados2
   - librbd1
   - rbd-fuse
-  - ceph-dbg
-  - ceph-mds-dbg
   - ceph-common-dbg
   - ceph-fuse-dbg
-  - radosgw-dbg
-  - libcephfs1-dbg
+  - ceph-mds-dbg
+  - ceph-mgr-dbg
+  - ceph-mon-dbg
+  - ceph-osd-dbg
+  - ceph-test-dbg
+  - libcephfs2-dbg
   - librados2-dbg
+  - libradosstriper1-dbg
   - librbd1-dbg
+  - librgw2-dbg
+  - radosgw-dbg
+  - rbd-fuse-dbg
+  - rbd-mirror-dbg
+  - rbd-nbd-dbg
   rpm:
   - ceph-radosgw
   - ceph-test
   - ceph
+  - ceph-base
+  - cephadm
+  - ceph-immutable-object-cache
+  - ceph-mgr
+  - ceph-mgr-dashboard
+  - ceph-mgr-diskprediction-local
+  - ceph-mgr-rook
+  - ceph-mgr-cephadm
   - ceph-fuse
-  - cephfs-java
-  - libcephfs_jni1
-  - libcephfs1
+  - ceph-volume
+  - librados-devel
+  - libcephfs2
+  - libcephfs-devel
   - librados2
   - librbd1
-  - python-ceph
+  - python3-rados
+  - python3-rgw
+  - python3-cephfs
+  - python3-rbd
   - rbd-fuse
-  - ceph-debuginfo
+  - rbd-mirror
+  - rbd-nbd
+  - ceph-base-debuginfo
+  - ceph-common-debuginfo
+  - ceph-immutable-object-cache-debuginfo
+  - ceph-radosgw-debuginfo
+  - ceph-test-debuginfo
+  - ceph-base-debuginfo
+  - ceph-mgr-debuginfo
+  - ceph-mds-debuginfo
+  - ceph-mon-debuginfo
+  - ceph-osd-debuginfo
+  - ceph-fuse-debuginfo
+  - librados-devel-debuginfo
+  - libcephfs2-debuginfo
+  - librados2-debuginfo
+  - librbd1-debuginfo
+  - python3-cephfs-debuginfo
+  - python3-rados-debuginfo
+  - python3-rbd-debuginfo
+  - python3-rgw-debuginfo
+  - rbd-fuse-debuginfo
+  - rbd-mirror-debuginfo
+  - rbd-nbd-debuginfo


### PR DESCRIPTION
From [get_package_list()](https://github.com/ceph/teuthology/blob/main/teuthology/task/install/__init__.py#LL133C5-L133C21), In the case where:
```
    # If packages.yaml isn't found in the suite_path, potentially use
    # teuthology's
```
Teuthology's `packages.yaml` will be used and since some unsupported packages (like `cephfs_java`) is listed in it - we will fail to install it in each job. (See https://github.com/ceph/ceph/pull/49711 for  `cephfs_java` removal discussion).
```
2023-04-30T12:53:36.334 DEBUG:teuthology.orchestra.run.smithi162:> sudo yum -y install cephfs-java
2023-04-30T12:53:37.090 INFO:teuthology.orchestra.run.smithi162.stdout:Last metadata expiration check: 0:21:53 ago on Sun 30 Apr 2023 12:31:44 PM UTC.
2023-04-30T12:53:38.205 INFO:teuthology.orchestra.run.smithi162.stdout:No match for argument: cephfs-java
2023-04-30T12:53:38.254 INFO:teuthology.orchestra.run.smithi162.stderr:Error: Unable to find a match: cephfs-java
2023-04-30T12:53:38.278 DEBUG:teuthology.orchestra.run:got remote process result: 1
```
From: https://pulpito.ceph.com/matan-2023-04-30_11:05:47-crimson-rados-main-distro-crimson-smithi/

Note: I'm not sure why the run attached here fell back to Teuthology's `packages.yaml` yet. However, this case shouldn't cause the whole run to fail. 

Signed-off-by: Matan Breizman <mbreizma@redhat.com>
