### PR TITLE
task: install supports enable_coprs array

### DIFF
--- a/teuthology/task/install/__init__.py
+++ b/teuthology/task/install/__init__.py
@@ -458,6 +458,12 @@ def task(ctx, config):
     are welcome to add support for other distros.
 
 
+    Enable Fedora copr repositories using enable_coprs:
+
+    - install:
+        enable_coprs: [ceph/el9]
+
+
     Overrides are project specific:
 
     overrides:
@@ -599,6 +605,7 @@ def task(ctx, config):
                 extra_packages=config.get('extra_packages', []),
                 extra_system_packages=config.get('extra_system_packages', []),
                 extras=config.get('extras', None),
+                enable_coprs=config.get('enable_coprs', []),
                 flavor=flavor,
                 install_ceph_packages=config.get('install_ceph_packages', True),
                 packages=config.get('packages', dict()),

--- a/teuthology/task/install/rpm.py
+++ b/teuthology/task/install/rpm.py
@@ -173,6 +173,13 @@ def _update_package_list_and_install(ctx, remote, rpm, config):
     :param rpm: list of packages names to install
     :param config: the config dict
     """
+
+    enable_coprs = config.get('enable_coprs', [])
+    if len(enable_coprs):
+        remote.run(args=['sudo', 'dnf', '-y', 'install', 'dnf-command(copr)'])
+        for copr in enable_coprs:
+            remote.run(args=['sudo', 'dnf', '-y', 'copr', 'enable', copr])
+
     # rpm does not force installation of a particular version of the project
     # packages, so we can put extra_system_packages together with the rest
     system_pkglist = config.get('extra_system_packages')
@@ -368,6 +375,8 @@ def _remove_sources_list(ctx, config, remote):
     if remote.os.name not in ['opensuse', 'sle']:
         _yum_unset_check_obsoletes(remote)
 
+    for copr in config.get('enable_coprs', []):
+        remote.run(args=['sudo', 'dnf', '-y', 'copr', 'disable', copr])
 
 def _upgrade_packages(ctx, config, remote, pkgs):
     """


### PR DESCRIPTION
enable the installation of packages in fedora copr repositories

this should unblock testing against centos9 by using the `ceph/el9` copr for missing python packages

in ceph, https://github.com/ceph/ceph/pull/50441 adds a `centos_9.stream.yaml` file, and i plan to add an override there:
```yaml
overrides:
  install:
    ceph:
      enable_coprs: [ceph/el9]
```