### PR TITLE
fog: Increase timeout in wait_for_deploy_task()

### DIFF
--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -251,7 +251,7 @@ class FOG(object):
         completed)
         """
         self.log.info("Waiting for deploy to finish")
-        with safe_while(sleep=15, tries=60) as proceed:
+        with safe_while(sleep=15, tries=120) as proceed:
             while proceed():
                 if not self.deploy_task_active(task_id):
                     break

--- a/teuthology/provision/test/test_fog.py
+++ b/teuthology/provision/test/test_fog.py
@@ -267,7 +267,7 @@ class TestFOG(object):
 
     @mark.parametrize(
         'tries',
-        [3, 61],
+        [3, 121],
     )
     def test_wait_for_deploy_task(self, tries):
         wait_results = [True for i in range(tries)] + [False]


### PR DESCRIPTION
When too many reimaging ops are running concurrently, we're seeing timeouts. This isn't a true fix, but should help things until we've got one.