### PR TITLE
lock.ops.unlock_one: Fail sooner on 403, with msg

### DIFF
--- a/teuthology/lock/ops.py
+++ b/teuthology/lock/ops.py
@@ -212,6 +212,8 @@ def unlock_one(ctx, name, user, description=None):
                 if response.ok:
                     log.info('unlocked: %s', name)
                     return response.ok
+                if response.status_code == 403:
+                    break
             # Work around https://github.com/kennethreitz/requests/issues/2364
             except requests.ConnectionError as e:
                 log.warning("Saw %s while unlocking; retrying...", str(e))


### PR DESCRIPTION
In the case of e.g. owners values not matching on an unlock attempt, we were exhausting all retries and failing to display the exact reason for the unlock failure. We can simply break on 403 errors and let the rest of the function do its thing.