### PR TITLE
provision: Avoid a possible AttributeError

### DIFF
--- a/teuthology/provision/__init__.py
+++ b/teuthology/provision/__init__.py
@@ -50,7 +50,7 @@ def reimage(ctx, machine_name, machine_type):
         raise
     finally:
         teuthology.exporter.NodeReimagingResults.record(
-            ctx.config.get("machine_type"),
+            machine_type,
             status,
         )
     return result


### PR DESCRIPTION
This fixes a regression introuced in #1851. It hadn't been noticed because it only affects manual locking.