### PR TITLE
restore py36 support

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -67,7 +67,7 @@ Linux)
         fi
         ;;
     RedHatEnterpriseWorkstation|RedHatEnterpriseServer|RedHatEnterprise|CentOS)
-        deps=(python39-pip python39-devel mariadb-devel libev-devel libvirt-devel libffi-devel)
+        deps=(python36-pip python36-devel mariadb-devel libev-devel libvirt-devel libffi-devel)
         for package in ${deps[@]}; do
           if ! rpm -q --whatprovides $package ; then
               missing="${missing:+$missing }$package"

--- a/requirements.txt
+++ b/requirements.txt
@@ -178,7 +178,7 @@ oslo-utils==4.12.2
     #   python-keystoneclient
     #   python-novaclient
     #   python-openstackclient
-packaging==22.0
+packaging==21.3
     # via
     #   ansible-base
     #   build
@@ -207,7 +207,7 @@ pep517==0.11.0
     # via build
 pexpect==4.8.0
     # via teuthology (pyproject.toml)
-pip-tools==6.11.0
+pip-tools==6.4.0
     # via teuthology (pyproject.toml)
 platformdirs==2.4.0
     # via virtualenv
@@ -329,7 +329,7 @@ toml==0.10.2
     # via
     #   teuthology (pyproject.toml)
     #   tox
-tomli==2.0.1
+tomli==1.2.3
     # via
     #   build
     #   pep517
@@ -347,7 +347,7 @@ wcwidth==0.2.5
     # via
     #   cmd2
     #   prettytable
-wheel==0.38.1
+wheel==0.37.1
     # via pip-tools
 wrapt==1.12.1
     # via debtcollector

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -46,7 +47,7 @@ install_requires =
     netaddr
     paramiko
     pexpect
-    pip-tools>=6.10.0
+    pip-tools>=6.4.0
     prettytable
     psutil>=2.1.0
     pyasn1

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -5,8 +5,6 @@ import shutil
 import subprocess
 import time
 
-import teuthology.exporter as exporter
-
 from teuthology import misc
 from teuthology.util.flock import FileLock
 from teuthology.config import config
@@ -440,6 +438,9 @@ def fetch_teuthology(branch, commit=None, lock=True):
 
 
 def bootstrap_teuthology(dest_path):
+    # avoid circular imports
+    import teuthology.exporter as exporter
+
     with exporter.BootstrapTime.time():
         log.info("Bootstrapping %s", dest_path)
         # This magic makes the bootstrap script not attempt to clobber an


### PR DESCRIPTION
Upstream still builds on RHEL 8 and its derivatives. Teuthology should continue to build/function with the standard py3.6. Importantly, this avoids build problems with cmake discovering python3.9 during rebuilds which causes build failures like:

    $ cmake --build build/ --verbose
    [0/1] /usr/bin/cmake --regenerate-during-build -S/home/pdonnell/ceph -B/home/pdonnell/scratch/build
    -- Building with ccache: /usr/bin/ccache, CCACHE_DIR=
    -- allocator selected: tcmalloc
    CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
      Could NOT find Python3: Found unsuitable version "3.9.13", but required is
      exact version "3.6" (found /usr/bin/python3, found components: Interpreter)
    Call Stack (most recent call first):
      /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:592 (_FPHSA_FAILURE_MESSAGE)
      cmake/modules/FindPython/Support.cmake:1181 (find_package_handle_standard_args)
      cmake/modules/FindPython3.cmake:181 (include)
      CMakeLists.txt:517 (find_package)

    -- Configuring incomplete, errors occurred!
    See also "/home/pdonnell/scratch/build/CMakeFiles/CMakeOutput.log".
    See also "/home/pdonnell/scratch/build/CMakeFiles/CMakeError.log".
    FAILED: build.ninja
    /usr/bin/cmake --regenerate-during-build -S/home/pdonnell/ceph -B/home/pdonnell/scratch/build
    ninja: error: rebuilding 'build.ninja': subcommand failed