### PR TITLE
Turn down logging for urllib3.util.retry

### DIFF
--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -53,6 +53,9 @@ logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(
 # if requests doesn't bundle it, shut it up anyway
 logging.getLogger('urllib3.connectionpool').setLevel(
     logging.WARN)
+# We also don't need the "Converted retries value" messages
+logging.getLogger('urllib3.util.retry').setLevel(
+    logging.WARN)
 
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
This quiets messages like: "Converted retries value: 10 ->
Retry(total=10, connect=None, read=None, redirect=None, status=None)"