### PR TITLE
misc.ssh_keyscan: Always retry, and retry more

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1099,7 +1099,8 @@ def ssh_keyscan(hostnames, _raise=True):
     for hostname in hostnames:
         with safe_while(
             sleep=1,
-            tries=5 if _raise else 1,
+            tries=15 if _raise else 1,
+            increment=1,
             _raise=_raise,
             action="ssh_keyscan " + hostname,
         ) as proceed:


### PR DESCRIPTION
We started seeing reimage failures with errors like: "teuthology.exceptions.MaxWhileTries: 'ssh_keyscan $host' reached maximum tries (6) after waiting for 5 seconds"

Let's be quite a bit more generous.