### PR TITLE
PhysicalConsole: Fix UTF-8 related failure

### DIFF
--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -76,6 +76,7 @@ class PhysicalConsole(RemoteConsole):
         p = pexpect.spawn(
             cmd,
             encoding='utf-8',
+            codec_errors="backslashreplace",
         )
         p.logfile_read = io.StringIO()
         return p

--- a/teuthology/orchestra/console.py
+++ b/teuthology/orchestra/console.py
@@ -196,8 +196,8 @@ class PhysicalConsole(RemoteConsole):
             # check for login prompt at console
             self._wait_for_login(timeout)
             return True
-        except Exception as e:
-            self.log.info('Failed to get ipmi console status: {e}'.format(e=e))
+        except Exception:
+            self.log.exception('Failed to get ipmi console status')
             return False
 
     def power_cycle(self, timeout=300):


### PR DESCRIPTION
This is a re-file of #1879.

Fixes: https://tracker.ceph.com/issues/62286

@dmick, I'm not sure if this was your intent, but we're logging a _lot_ more now after #1869. For example:
```
$ grep -a -A1 "console.*\(expect before\|output\):" /a/zack-2023-08-02_18:04:55-powercycle-reef-distro-default-smithi/7358307/teuthology.log > /tmp/7358307_console.txt
$ wc -l /tmp/7358307_console.txt
76 /tmp/7358307_console.txt
$ wc -c /tmp/7358307_console.txt
53344 /tmp/7358307_console.txt53344
```