### PR TITLE
stdin-killer: do not setpgrp is already leader

### DIFF
--- a/teuthology/task/install/bin/stdin-killer
+++ b/teuthology/task/install/bin/stdin-killer
@@ -210,8 +210,10 @@ if __name__ == "__main__":
     }
 
     if NS.setpgrp == "self":
-        os.setpgrp()
         pgrp = os.getpgrp()
+        if pgrp != os.getpid():
+            os.setpgrp()
+            pgrp = os.getpgrp()
     elif NS.setpgrp == "child":
         popen_kwargs["preexec_fn"] = os.setpgrp
         pgrp = None


### PR DESCRIPTION
Fixes bugs in https://pulpito.ceph.com/pdonnell-2023-08-03_19:12:12-fs-wip-batrick-testing-20230803.140718-distro-default-smithi/

```
2023-08-03T19:40:10.942
INFO:teuthology.orchestra.run.smithi100.stderr:Traceback (most recent
call last):
2023-08-03T19:40:10.942
INFO:teuthology.orchestra.run.smithi100.stderr:  File
"/usr/bin/stdin-killer", line 213, in <module>
2023-08-03T19:40:10.943
INFO:teuthology.orchestra.run.smithi100.stderr:    os.setpgrp()
2023-08-03T19:40:10.943
INFO:teuthology.orchestra.run.smithi100.stderr:PermissionError: [Errno
1] Operation not permitted
```