### PR TITLE
nuke: Avoid a TypeError w/ null node description

### DIFF
--- a/teuthology/nuke/__init__.py
+++ b/teuthology/nuke/__init__.py
@@ -245,11 +245,11 @@ def nuke(ctx, should_unlock, sync_clocks=True, noipmi=False, keep_logs=False, sh
     with parallel() as p:
         for target, hostkey in ctx.config['targets'].items():
             status = get_status(target)
-            if ctx.name and ctx.name not in status.get('description', ""):
+            if ctx.name and ctx.name not in (status.get('description') or ""):
                 total_unnuked[target] = hostkey
                 log.info(
                     f"Not nuking {target} because description doesn't match: "
-                    f"{ctx.name} != {status['description']}"
+                    f"{ctx.name} != {status.get('description')}"
                 )
                 continue
             elif status.get('up') is False:


### PR DESCRIPTION
This avoids a `TypeError: argument of type 'NoneType' is not iterable` when nuking a node whose description is None.

ex: https://sentry.ceph.com/share/issue/91172146663f4c71a6cbfe43725b2e07/