### PR TITLE
Fix docs build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ long_description_content_type = text/x-rst
 url = https://github.com/ceph/teuthology
 author = Red Hat, Inc.
 license = MIT
-license_file = LICENSE
 classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ install_command = pip install --upgrade {opts} {packages}
 changedir=docs
 deps=
   -r{toxinidir}/requirements.txt
-  sphinx
+  sphinx != 7.2.0, != 7.2.1, != 7.2.2
   sphinxcontrib-programoutput
 commands=
     sphinx-apidoc -f -o . ../teuthology ../teuthology/test ../teuthology/orchestra/test ../teuthology/task/test


### PR DESCRIPTION
- Drop license_file: It's deprecated in favor of `license_files`, but the default value is
sufficient.
- tox: Avoid buggy sphinx versions 
