### PR TITLE
teuthology/scrape.py: Remove empty string in _get_service_types

### DIFF
--- a/teuthology/scrape.py
+++ b/teuthology/scrape.py
@@ -410,7 +410,10 @@ class ValgrindReason(Reason):
         result = defaultdict(list)
         # Lines like:
         # 2014-08-22T20:07:18.668 ERROR:tasks.ceph:saw valgrind issue   <kind>Leak_DefinitelyLost</kind> in /var/log/ceph/valgrind/osd.3.log.gz
-        for line in grep(os.path.join(job.path, "teuthology.log"), "</kind> in "):
+        valgrind_err_line = grep(os.path.join(job.path, "teuthology.log"), "</kind> in ")
+        # removes blank space, empty string and None
+        valgrind_err_line = [line for line in valgrind_err_line if line and line.strip()]
+        for line in valgrind_err_line:
             match = re.search("<kind>(.+)</kind> in .+/(.+)", line)
             if not match:
                 log.warning("Misunderstood line: {0}".format(line))


### PR DESCRIPTION
Problem:

the function grep returns a list contianing empty string which results in scrape.py throwing the warning "Misunderstood line: ".

Solution:

filter out empty strings, blank space and None
before getting match with regex.

Fixes: https://tracker.ceph.com/issues/62534