### PR TITLE
Add containers/teuthology-dev

### DIFF
--- a/containers/teuthology-dev/.teuthology.yaml
+++ b/containers/teuthology-dev/.teuthology.yaml
@@ -1,0 +1,9 @@
+queue_host: beanstalk
+queue_port: 11300
+lock_server: http://paddles:8080
+results_server: http://paddles:8080
+results_ui_server: http://pulpito:8081/
+teuthology_path: /teuthology
+archive_base: /archive_dir
+reserve_machines: 0
+lab_domain: ''

--- a/containers/teuthology-dev/Dockerfile
+++ b/containers/teuthology-dev/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:focal
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    qemu-utils \
+    python3-dev \
+    libssl-dev \
+    ipmitool \
+    python3-pip \
+    python3-venv \
+    vim \
+    libev-dev \
+    libvirt-dev \
+    libffi-dev \
+    libyaml-dev \
+    lsb-release && \
+    apt-get clean all
+WORKDIR /teuthology
+COPY requirements.txt bootstrap /teuthology/
+RUN \
+    cd /teuthology && \
+    mkdir ../archive_dir && \
+    mkdir log && \
+    chmod +x /teuthology/bootstrap && \
+    PIP_INSTALL_FLAGS="-r requirements.txt" ./bootstrap
+COPY . /teuthology
+RUN \
+    ./bootstrap
+COPY containers/teuthology-dev/containerized_node.yaml /teuthology
+COPY containers/teuthology-dev/.teuthology.yaml /root
+COPY containers/teuthology-dev/teuthology.sh /
+RUN \
+    mkdir $HOME/.ssh && \
+    touch $HOME/.ssh/id_rsa && \
+    chmod 600 $HOME/.ssh/id_rsa && \
+    echo "StrictHostKeyChecking=no" > $HOME/.ssh/config && \
+    echo "UserKnownHostsFile=/dev/null" >> $HOME/.ssh/config
+ENTRYPOINT /teuthology.sh

--- a/containers/teuthology-dev/containerized_node.yaml
+++ b/containers/teuthology-dev/containerized_node.yaml
@@ -1,0 +1,12 @@
+overrides:
+  ansible.cephlab:
+    skip_tags: "timezone,nagios,monitoring-scripts,ssh,hostname,pubkeys,zap,sudoers,kerberos,selinux,lvm,ntp-client,resolvconf,packages,cpan,nfs"
+    vars:
+      containerized_node: true
+      ansible_user: root
+      cm_user: root
+      start_rpcbind: false
+  cephadm:
+    image: quay.ceph.io/ceph-ci/ceph:main
+    osd_method: raw
+    no_cgroups_split: true

--- a/containers/teuthology-dev/teuthology.sh
+++ b/containers/teuthology-dev/teuthology.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+set -e
+source /teuthology/virtualenv/bin/activate
+set -x
+cat /run/secrets/id_rsa > $HOME/.ssh/id_rsa
+if [ -n "$TEUTHOLOGY_TESTNODES" ]; then
+    for node in $(echo $TEUTHOLOGY_TESTNODES | tr , ' '); do
+        teuthology-update-inventory -m "$TEUTHOLOGY_MACHINE_TYPE" "$node"
+    done
+    TEUTHOLOGY_CONF=${TEUTHOLOGY_CONF:-}
+else
+    TEUTHOLOGY_CONF=/teuthology/containerized_node.yaml
+fi
+export TEUTHOLOGY_MACHINE_TYPE=${TEUTHOLOGY_MACHINE_TYPE:-testnode}
+if [ "$TEUTHOLOGY_SUITE" != "none" ]; then
+    if [ -n "$TEUTHOLOGY_BRANCH" ]; then
+      TEUTH_BRANCH_FLAG="--teuthology-branch $TEUTHOLOGY_BRANCH"
+    fi
+    teuthology-suite -v \
+        $TEUTH_BRANCH_FLAG \
+        -m "$TEUTHOLOGY_MACHINE_TYPE" \
+        --newest 100 \
+        --ceph "${TEUTHOLOGY_CEPH_BRANCH:-main}" \
+        --ceph-repo "${TEUTHOLOGY_CEPH_REPO:-https://github.com/ceph/ceph.git}" \
+        --suite "${TEUTHOLOGY_SUITE:-teuthology:no-ceph}" \
+        --suite-branch "${TEUTHOLOGY_SUITE_BRANCH:-main}" \
+        --suite-repo "${TEUTHOLOGY_SUITE_REPO:-https://github.com/ceph/ceph.git}" \
+        --filter-out "libcephfs,kclient" \
+        --force-priority \
+        --seed 349 \
+        $TEUTHOLOGY_CONF
+    DISPATCHER_EXIT_FLAG='--exit-on-empty-queue'
+    teuthology-queue -m $TEUTHOLOGY_MACHINE_TYPE -s | \
+      python3 -c "import sys, json; assert json.loads(sys.stdin.read())['count'] > 0, 'queue is empty!'"
+fi
+teuthology-dispatcher -v \
+    --log-dir /teuthology/log \
+    --tube "$TEUTHOLOGY_MACHINE_TYPE" \
+    $DISPATCHER_EXIT_FLAG


### PR DESCRIPTION
This is nearly identical to docs/docker-compose/teuthology, but with some changes to better work with ceph-devstack. The bits in docs/docker-compose should be able to be adapted easily to work with this container.