### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -1026,7 +1026,8 @@ ssh access           : ssh {identity}{username}@{ip} # logs in /usr/share/nginx/
         cluster, based on a template where the OpenStack credentials
         and a few other values are substituted.
         """
-        path = tempfile.mktemp()
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
 
         with open(os.path.dirname(__file__) + '/bootstrap-teuthology.sh', 'rb') as f:
             b64_bootstrap = base64.b64encode(f.read())

--- a/teuthology/provision/openstack.py
+++ b/teuthology/provision/openstack.py
@@ -27,7 +27,8 @@ class ProvisionOpenStack(OpenStack):
     """
     def __init__(self):
         super(ProvisionOpenStack, self).__init__()
-        self.user_data = tempfile.mktemp()
+        fd, self.user_data = tempfile.mkstemp()
+        os.close(fd)
         log.debug("ProvisionOpenStack: " + str(config.openstack))
         self.basename = 'target'
         self.up_string = 'The system is finally up'


### PR DESCRIPTION
## Details
> In file: [__init__.py](https://github.com/ceph/teuthology/blob/main/teuthology/openstack/__init__.py#L1029), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.

> In file: [openstack.py](https://github.com/ceph/teuthology/blob/main/teuthology/provision/openstack.py#L30), there is a method that creates a temporary file using an unsafe API `mktemp`. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.


#### Resources Related to `mktemp`
- [POC - Improper Method Call - python - mktemp.mp4](https://drive.google.com/file/d/16YKuKgv7iItWcac2biRyi2Cm8upJ3HP_/view?usp=share_link)
- [MISC - Python - Taking a peek under the tempfile library.mp4](https://drive.google.com/file/d/1ns2_x_ZDvzFwj0eNNxyay-HUMclLasNT/view?usp=share_link)


## Changes
- Replaced `mktemp()` method with `mkstemp()`


## Previously Found & Fixed
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
