### PR TITLE
teuthology/__init__.py: don't patch threads when running via teuthology_api

### DIFF
--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import os
+import os, sys
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:
@@ -24,10 +24,15 @@ try:
 except ImportError:
     pass
 from gevent import monkey
+patch_threads=True
+for arg in sys.argv:
+    if "teuthology_api" in arg:
+        patch_threads=False
 monkey.patch_all(
     dns=False,
     # Don't patch subprocess to avoid http://tracker.ceph.com/issues/14990
     subprocess=False,
+    thread=patch_threads,
 )
 import sys
 from gevent.hub import Hub


### PR DESCRIPTION
The project [teuthology-api](https://github.com/ceph/teuthology-api) requires threads to be not patched.
Currently, we are using "teuth-api" branch of teuthology where threads are not patched. With this commit, we'll be able to use the "main" branch as a dependency.