### PR TITLE
kernel: make get_image_version() work for rpm

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -1033,8 +1033,9 @@ def get_image_version(remote, path):
         raise UnsupportedPackageTypeError(remote)
 
     for file in files.split('\n'):
-        if '/boot/vmlinuz-' in file:
-            version = file.split('/boot/vmlinuz-')[1]
+        match = re.search('/lib/modules/(.*)/modules\.order$', file)
+        if match:
+            version = match.group(1)
             break
 
     log.debug("get_image_version: %s", version)


### PR DESCRIPTION
At some point in the past, the layout of the rpm package has changed. There is no file matching "/boot/vmlinuz-" there anymore, instead there is "vmlinuz" file at the root of the modules directory.  For reference:

deb:

-rw-r--r-- root/root  11527168 2024-02-13 16:25 ./boot/vmlinuz-6.8.0-rc4-ga64ccd305b28
-rw-r--r-- root/root     72614 2024-02-13 16:25 ./lib/modules/6.8.0-rc4-ga64ccd305b28/modules.order

rpm:

/lib/modules/6.8.0-rc4-ga64ccd305b28/modules.order
/lib/modules/6.8.0-rc4-ga64ccd305b28/vmlinuz