### PR TITLE
teuthology/suite: initialize lua prng using run's seed

### DIFF
--- a/teuthology/describe_tests.py
+++ b/teuthology/describe_tests.py
@@ -137,7 +137,8 @@ def output_summary(path, limit=0,
                                  filter_in=filter_in,
                                  filter_out=filter_out,
                                  filter_all=filter_all,
-                                 filter_fragments=filter_fragments)
+                                 filter_fragments=filter_fragments,
+                                 seed=seed)
     for c in configs:
         if limit and count >= limit:
             break
@@ -185,7 +186,8 @@ def get_combinations(suite_dir,
                                  filter_in=filter_in,
                                  filter_out=filter_out,
                                  filter_all=filter_all,
-                                 filter_fragments=filter_fragments)
+                                 filter_fragments=filter_fragments,
+                                 seed=seed)
     for _, fragment_paths, __ in configs:
         if limit > 0 and num_listed >= limit:
             break

--- a/teuthology/suite/merge.py
+++ b/teuthology/suite/merge.py
@@ -115,6 +115,12 @@ def config_merge(configs, suite_name=None, **kwargs):
     the entire job (config) from the list.
     """
 
+    seed = kwargs.setdefault('seed', 1)
+    if not isinstance(seed, int):
+        log.debug("no valid seed input: using 1")
+        seed = 1
+    log.debug("configuring Lua randomseed to %d", seed)
+    L.execute(f'local math = require"math"; math.randomseed({seed});')
     new_script = L.eval('new_script')
     yaml_cache = {}
     for desc, paths in configs:

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -591,6 +591,7 @@ Note: If you still want to go ahead, use --job-threshold 0'''
             filter_out=self.args.filter_out,
             filter_all=self.args.filter_all,
             filter_fragments=self.args.filter_fragments,
+            seed=self.args.seed,
             suite_name=suite_name))
 
         if self.args.dry_run:


### PR DESCRIPTION
When a script may use Lua's prng, we want it to produce the same sequence during a rerun.

Looks like:

```
2024-03-19 16:33:08,391.391 INFO:teuthology.suite:Using random seed=8131
2024-03-19 16:33:08,392.392 INFO:teuthology.suite.run:kernel sha1: distro
2024-03-19 16:33:08,716.716 DEBUG:teuthology.repo_utils:git ls-remote https://git.ceph.com/ceph-ci.git wip-batrick-testing-20240318.181317 -> b6ae24918b03b1b8a19c9263a50655bba80bb810
2024-03-19 16:33:08,716.716 INFO:teuthology.suite.run:ceph sha1: b6ae24918b03b1b8a19c9263a50655bba80bb810
2024-03-19 16:33:08,717.717 DEBUG:teuthology.packaging:Querying https://shaman.ceph.com/api/search?status=ready&project=ceph&flavor=default&distros=centos%2F8%2Fx86_64&sha1=b6ae24918b03b1b8a19c9263a50655bba80bb810
2024-03-19 16:33:09,010.010 DEBUG:teuthology.packaging:looking for centos/8 x86_64 default
2024-03-19 16:33:09,010.010 DEBUG:teuthology.packaging:build: centos/8 arm64 default
2024-03-19 16:33:09,010.010 DEBUG:teuthology.packaging:build: centos/8 x86_64 crimson
2024-03-19 16:33:09,011.011 DEBUG:teuthology.packaging:build: centos/9 x86_64 default
2024-03-19 16:33:09,011.011 DEBUG:teuthology.packaging:build: centos/9 x86_64 crimson
2024-03-19 16:33:09,011.011 DEBUG:teuthology.packaging:build: ubuntu/22.04 x86_64 default
2024-03-19 16:33:09,011.011 DEBUG:teuthology.packaging:build: ubuntu/20.04 x86_64 default
2024-03-19 16:33:09,011.011 DEBUG:teuthology.packaging:build: centos/8 x86_64 default
2024-03-19 16:33:09,014.014 INFO:teuthology.suite.run:ceph version: 19.0.0-2206.gb6ae2491
2024-03-19 16:33:09,142.142 DEBUG:teuthology.repo_utils:git ls-remote https://github.com/batrick/ceph wip-batrick-testing-20240318.181317 -> a76be9e33cc5b22f5135f29be5c73cd2ad978d87
2024-03-19 16:33:09,142.142 INFO:teuthology.suite.run:ceph branch: wip-batrick-testing-20240318.181317 a76be9e33cc5b22f5135f29be5c73cd2ad978d87
2024-03-19 16:33:09,144.144 DEBUG:teuthology.repo_utils:Resetting repo at /cephfs/home/pdonnell/src/github.com_batrick_ceph_wip-batrick-testing-20240318.181317 to origin/wip-batrick-testing-20240318.181317
2024-03-19 16:33:09,393.393 DEBUG:teuthology.repo_utils:git ls-remote https://github.com/ceph/teuthology lua-prng -> af04998bf273ab00c53c2ed79d93564778800149
2024-03-19 16:33:09,393.393 INFO:teuthology.suite.run:teuthology branch: lua-prng af04998bf273ab00c53c2ed79d93564778800149
2024-03-19 16:33:09,417.417 DEBUG:teuthology.suite.run:Suite fs in /cephfs/home/pdonnell/src/github.com_batrick_ceph_wip-batrick-testing-20240318.181317/qa/suites/fs
2024-03-19 16:33:09,417.417 DEBUG:teuthology.suite.run:subset = (483, 512)
2024-03-19 16:33:09,418.418 DEBUG:teuthology.suite.run:no_nested_subset = False
2024-03-19 16:33:09,418.418 INFO:teuthology.suite.build_matrix:Subset=483/512
2024-03-19 16:33:09,742.742 INFO:teuthology.suite.run:Suite fs in /cephfs/home/pdonnell/src/github.com_batrick_ceph_wip-batrick-testing-20240318.181317/qa/suites/fs generated 265 jobs (not yet filtered or merged)
2024-03-19 16:33:09,742.742 DEBUG:teuthology.suite.merge:configuring Lua randomseed to 8131
```