### PR TITLE
fix cephadmunit start() method

### DIFF
--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -136,7 +136,7 @@ class CephadmUnit(DaemonState):
             self.restart()
             return
         self._start_logger()
-        self.remote.run(self.start_cmd)
+        self.remote.run(args=self.start_cmd)
 
     def stop(self, timeout=300):
         """

--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -137,6 +137,7 @@ class CephadmUnit(DaemonState):
             return
         self._start_logger()
         self.remote.run(args=self.start_cmd)
+        self.is_started = True
 
     def stop(self, timeout=300):
         """


### PR DESCRIPTION
Fixes a couple of problems in CephadmUnit.start() method:

1. Explicitly pass `start_cmd` as "args" keyword because Remote.run expects keyword arguments.
Fixes: https://tracker.ceph.com/issues/65162

2. `is_started` isn't set to true. When running() is called after start(), then it would
return false, which is not correct since the daemon has been started by calling start().
