### PR TITLE
suite/run: Add a option to specify suite sha1

### DIFF
--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -77,6 +77,8 @@ Standard arguments:
                               [default: qa]
   --suite-branch <suite_branch>
                               Use this suite branch instead of the ceph branch
+  --suite-sha1 <suite_sha1>   The suite sha1 to use for the tests (overrides
+                              --suite-branch)
   --suite-dir <suite_dir>     Use this alternative directory as-is when
                               assembling jobs from yaml fragments. This causes
                               <suite_branch> to be ignored for scheduling

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -98,7 +98,7 @@ class Run(object):
             self.suite_repo_path = self.args.suite_dir
         else:
             self.suite_repo_path = util.fetch_repos(
-                suite_branch, test_name=self.name, dry_run=self.args.dry_run)
+                suite_branch, test_name=self.name, dry_run=self.args.dry_run, commit=suite_hash)
         teuthology_branch, teuthology_sha1 = self.choose_teuthology_branch()
 
 
@@ -333,14 +333,27 @@ class Run(object):
 
     def choose_suite_hash(self, suite_branch):
         suite_repo_name = self.suite_repo_name
-        suite_repo_project_or_url = self.args.suite_repo or 'ceph-qa-suite'
-        suite_hash = util.git_ls_remote(
-            suite_repo_project_or_url,
-            suite_branch
-        )
-        if not suite_hash:
-            exc = BranchNotFoundError(suite_branch, suite_repo_name)
-            util.schedule_fail(message=str(exc), name=self.name, dry_run=self.args.dry_run)
+        suite_hash = None
+        if self.args.suite_sha1:
+            suite_hash = self.args.suite_sha1
+            if self.args.validate_sha1:
+                suite_hash = util.git_validate_sha1(suite_repo_name, suite_hash)
+            if not suite_hash:
+                exc = CommitNotFoundError(
+                    self.args.suite_sha1,
+                    '%s.git' % suite_repo_name
+                )
+                util.schedule_fail(message=str(exc), name=self.name, dry_run=self.args.dry_run)
+            log.info("suite sha1 explicitly supplied")
+        else:
+            suite_repo_project_or_url = self.args.suite_repo or 'ceph-qa-suite'
+            suite_hash = util.git_ls_remote(
+                suite_repo_project_or_url,
+                suite_branch
+            )
+            if not suite_hash:
+                exc = BranchNotFoundError(suite_branch, suite_repo_name)
+                util.schedule_fail(message=str(exc), name=self.name, dry_run=self.args.dry_run)
         log.info("%s branch: %s %s", suite_repo_name, suite_branch, suite_hash)
         return suite_hash
 

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -29,7 +29,7 @@ CONTAINER_DISTRO = 'centos/8'       # the one to check for build_complete
 CONTAINER_FLAVOR = 'default'
 
 
-def fetch_repos(branch, test_name, dry_run):
+def fetch_repos(branch, test_name, dry_run, commit=None):
     """
     Fetch the suite repo (and also the teuthology repo) so that we can use it
     to build jobs. Repos are stored in ~/src/.
@@ -49,7 +49,7 @@ def fetch_repos(branch, test_name, dry_run):
             # We use teuthology's main branch in all cases right now
             if config.teuthology_path is None:
                 fetch_teuthology('main')
-        suite_repo_path = fetch_qa_suite(branch)
+        suite_repo_path = fetch_qa_suite(branch, commit)
     except BranchNotFoundError as exc:
         schedule_fail(message=str(exc), name=test_name, dry_run=dry_run)
     return suite_repo_path


### PR DESCRIPTION
The option can be used to specify the workunit sha1, it will override the --suite-branch option if both are provided. If --suite-repo is specified, it will search for the --suite-sha1 in this repo otherwise it will look for the sha1 in the default suite repo.