### PR TITLE
boostrap: expect "FedoraLinux" along with "Fedora"

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -100,7 +100,7 @@ Linux)
             fi
         fi
         ;;
-    Fedora)
+    Fedora|FedoraLinux)
        PYTHON=python3.12
         deps=($PYTHON-pip $PYTHON-devel)
         deps=($PYTHON-pip $PYTHON-devel libev-devel libvirt-devel libffi-devel)


### PR DESCRIPTION
On Fedora 38 -

	$ cat /etc/os-release
	NAME="Fedora Linux"
	VERSION="38 (Workstation Edition)"
	ID=fedora
	VERSION_ID=38

Also see: https://fedoraproject.org/wiki/Changes/Fedora_Linux_in_os-release.

With this "./boostrap install" works fine on Fedora 38 at least.