### PR TITLE
docs/docker-compose: use ubuntu jammy for testnode

### DIFF
--- a/docs/docker-compose/testnode/Dockerfile
+++ b/docs/docker-compose/testnode/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
     apt -y install \

--- a/docs/docker-compose/testnode/testnode_start.sh
+++ b/docs/docker-compose/testnode/testnode_start.sh
@@ -3,7 +3,7 @@ set -x
 echo "$SSH_PUBKEY" > /root/.ssh/authorized_keys
 echo "$SSH_PUBKEY" > /home/ubuntu/.ssh/authorized_keys
 chown ubuntu /home/ubuntu/.ssh/authorized_keys
-payload="{\"name\": \"$(hostname)\", \"machine_type\": \"testnode\", \"up\": true, \"locked\": false, \"os_type\": \"ubuntu\", \"os_version\": \"20.04\"}"
+payload="{\"name\": \"$(hostname)\", \"machine_type\": \"testnode\", \"up\": true, \"locked\": false, \"os_type\": \"ubuntu\", \"os_version\": \"22.04\"}"
 for i in $(seq 1 5); do
     echo "attempt $i"
     curl -v -f -d "$payload" http://paddles:8080/nodes/ && break

--- a/docs/docker-compose/teuthology/teuthology.sh
+++ b/docs/docker-compose/teuthology/teuthology.sh
@@ -29,7 +29,7 @@ if [ -z "$TEUTHOLOGY_WAIT" ]; then
         -n 100 \
         --suite teuthology:no-ceph \
         --filter-out "libcephfs,kclient,stream,centos,rhel" \
-        -d ubuntu -D 20.04 \
+        -d ubuntu -D 22.04 \
         --suite-branch main \
         --subset 9000/100000 \
         -p 75 \


### PR DESCRIPTION
Integration test on teuthology repo are failing
because ceph build's support for ubuntu focal on main branch has ended.
This commit fixes this by changing the testnode images from ubuntu focal to jammy.