### PR TITLE
orchestra/daemon: add finished() method in DaemonState and CephadmUnit

### DIFF
--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -35,9 +35,9 @@ class CephadmUnit(DaemonState):
 
     def kill_cmd(self, sig):
         return ' '.join([
-            'sudo', 'docker', 'kill',
+            'sudo', 'systemctl', 'kill',
             '-s', str(int(sig)),
-            'ceph-%s-%s.%s' % (self.fsid, self.type_, self.id_),
+            'ceph-%s@%s.%s' % (self.fsid, self.type_, self.id_),
         ])
 
     def _start_logger(self):

--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -112,6 +112,18 @@ class CephadmUnit(DaemonState):
         """
         return self.is_started
 
+    def finished(self):
+        """
+        Is the daemon finished? 
+        Return False if active.
+        """
+        proc = self.remote.run(
+            args=self.status_cmd,
+            check_status=False,
+            quiet=True,
+        )
+        return proc.returncode != 0
+
     def signal(self, sig, silent=False):
         """
         Send a signal to associated remote command

--- a/teuthology/orchestra/daemon/state.py
+++ b/teuthology/orchestra/daemon/state.py
@@ -97,6 +97,13 @@ class DaemonState(object):
         """
         return self.proc is not None
 
+    def finished(self):
+        """
+        Is the daemon finished? 
+        Return False if active.
+        """
+        return self.proc.finished if self.proc is not None else False
+
     def signal(self, sig, silent=False):
         """
         Send a signal to associated remote command.


### PR DESCRIPTION
The method is used by DaemonWatchdog to determine if DaemonState/CephadmUnit daemons are active or finished.

Use-case example: https://github.com/VallariAg/ceph/commit/8c2e7c00397ed4f7024fd8a492fbc5716f6de4c5

Run example: https://pulpito.ceph.com/vallariag-2024-06-28_12:47:41-rbd:nvmeof-ceph-nvmeof-mon-distro-default-smithi/