### PR TITLE
bootstrap: Tolerate a missing lsb_release

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -128,7 +128,8 @@ Linux)
         fi
         ;;
     "openSUSE project"|"SUSE LINUX"|"openSUSE"|"openSUSELeap"|"openSUSETumbleweed")
-	deps=(python3-pip python3-devel python3 libev-devel libvirt-devel libffi-devel)
+	PYTHON=python3.12
+	deps=(python312-pip python312-devel python312 libev-devel libvirt-devel libffi-devel)
 	for package in ${deps[@]}; do
             if ! rpm -q --whatprovides $package; then
                 if [ "$(rpm -q --whatprovides $package)" == "no package provides $package" ]; then

--- a/bootstrap
+++ b/bootstrap
@@ -127,7 +127,7 @@ Linux)
             fi
         fi
         ;;
-    "openSUSE project"|"SUSE LINUX"|"openSUSE")
+    "openSUSE project"|"SUSE LINUX"|"openSUSE"|"openSUSELeap"|"openSUSETumbleweed")
 	deps=(python3-pip python3-devel python3 libev-devel libvirt-devel libffi-devel)
 	for package in ${deps[@]}; do
             if ! rpm -q --whatprovides $package; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,7 +83,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lupa==2.0
+lupa==2.2
     # via teuthology (pyproject.toml)
 lxml==4.9.4
     # via teuthology (pyproject.toml)


### PR DESCRIPTION
Add missing keywords for openSUSE Leap and Tumbleweed

Fixes: ce77b04aabe8e17e6bd70ad5812233b5772c50bc