### PR TITLE
teuthology/task/selinux: ignore denials in agetty

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -137,6 +137,7 @@ class SELinux(Task):
             'comm="sssd"',
             'comm="sss_cache"',
             'context=system_u:system_r:NetworkManager_dispatcher_t:s0',
+            'context=system_u:system_r:getty_t:s0',
         ]
         se_allowlist = self.config.get('allowlist', [])
         if se_allowlist:


### PR DESCRIPTION
This was tracked in [1], but the addition of the context to the allowlist in ceph.git commit 7a6389272aff ("qa: ignore container checkpoint/restore related selinux denials for centos9") doesn't cover krbd suite which doesn't pull in any distro snippets.

Since this denial has nothing to do with Ceph [2], let's ignore it globally.

[1] http://tracker.ceph.com/issues/64616
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2259622