### PR TITLE
Add job expiration dates

### DIFF
--- a/containers/teuthology-dev/teuthology.sh
+++ b/containers/teuthology-dev/teuthology.sh
@@ -28,6 +28,7 @@ if [ "$TEUTHOLOGY_SUITE" != "none" ]; then
         --filter-out "libcephfs,kclient" \
         --force-priority \
         --seed 349 \
+        ${TEUTHOLOGY_SUITE_EXTRA_ARGS} \
         $TEUTHOLOGY_CONF
     DISPATCHER_EXIT_FLAG='--exit-on-empty-queue'
     teuthology-queue -m $TEUTHOLOGY_MACHINE_TYPE -s | \

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -85,6 +85,10 @@ Here is a sample configuration with many of the options set and documented::
     # processes
     watchdog_interval: 120
 
+    # How old a scheduled job can be, in seconds, before the dispatcher
+    # considers it 'expired', skipping it.
+    max_job_age: 1209600
+
     # How long a scheduled job should be allowed to run, in seconds, before 
     # it is killed by the supervisor process.
     max_job_time: 259200

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -81,12 +81,12 @@ Here is a sample configuration with many of the options set and documented::
     # itself from git. This is disabled by default.
     automated_scheduling: false
 
-    # How often, in seconds, teuthology-worker should poll its child job 
+    # How often, in seconds, teuthology-supervisor should poll its child job
     # processes
     watchdog_interval: 120
 
     # How long a scheduled job should be allowed to run, in seconds, before 
-    # it is killed by the worker process.
+    # it is killed by the supervisor process.
     max_job_time: 259200
 
     # The template from which the URL of the repository containing packages

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -112,6 +112,10 @@ Scheduler arguments:
                               When tests finish or time out, send an email
                               here. May also be specified in ~/.teuthology.yaml
                               as 'results_email'
+  --expire <datetime>         Do not execute jobs in the run if they have not
+                              completed by this time. Valid formats include
+                              ISO 8601, and relative offsets like '90s', '30m',
+                              '1h', '3d', or '1w'
   --rocketchat <rocketchat>   Comma separated list of Rocket.Chat channels where
                               to send a message when tests finished or time out.
                               To be used with --sleep-before-teardown option.

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -33,12 +33,13 @@ class YamlConfig(MutableMapping):
             self._conf = dict()
 
     def load(self, conf=None):
-        if conf:
+        if conf is not None:
             if isinstance(conf, dict):
                 self._conf = conf
-            else:
+                return
+            elif conf:
                 self._conf = yaml.safe_load(conf)
-            return
+                return
         if os.path.exists(self.yaml_path):
             with open(self.yaml_path) as f:
                 self._conf = yaml.safe_load(f)

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -158,6 +158,7 @@ class TeuthologyConfig(YamlConfig):
         'job_threshold': 500,
         'lab_domain': 'front.sepia.ceph.com',
         'lock_server': 'http://paddles.front.sepia.ceph.com/',
+        'max_job_age': 1209600,  # 2 weeks
         'max_job_time': 259200,  # 3 days
         'nsupdate_url': 'http://nsupdate.front.sepia.ceph.com/update',
         'results_server': 'http://paddles.front.sepia.ceph.com/',

--- a/teuthology/suite/__init__.py
+++ b/teuthology/suite/__init__.py
@@ -63,6 +63,9 @@ def process_args(args):
         elif key == 'subset' and value is not None:
             # take input string '2/3' and turn into (2, 3)
             value = tuple(map(int, value.split('/')))
+        elif key == 'expire' and value is None:
+            # Skip empty 'expire' values
+            continue
         elif key in ('filter_all', 'filter_in', 'filter_out', 'rerun_statuses'):
             if not value:
                 value = []

--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -45,6 +45,7 @@ def substitute_placeholders(input_dict, values_dict):
 # Template for the config that becomes the base for each generated job config
 dict_templ = {
     'branch': Placeholder('ceph_branch'),
+    'expire': Placeholder('expire'),
     'sha1': Placeholder('ceph_hash'),
     'teuthology_branch': Placeholder('teuthology_branch'),
     'teuthology_sha1': Placeholder('teuthology_sha1'),

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -24,6 +24,7 @@ from teuthology.suite import util
 from teuthology.suite.merge import config_merge
 from teuthology.suite.build_matrix import build_matrix
 from teuthology.suite.placeholder import substitute_placeholders, dict_templ
+from teuthology.util.time import TIMESTAMP_FMT
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class Run(object):
         self.args = args
         # We assume timestamp is a datetime.datetime object
         self.timestamp = self.args.timestamp or \
-            datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+            datetime.datetime.now().strftime(TIMESTAMP_FMT)
         self.user = self.args.user or pwd.getpwuid(os.getuid()).pw_name
 
         self.name = self.make_run_name()

--- a/teuthology/suite/test/conftest.py
+++ b/teuthology/suite/test/conftest.py
@@ -1,0 +1,4 @@
+from teuthology.config import config
+
+def pytest_runtest_setup():
+    config.load({})

--- a/teuthology/suite/test/test_placeholder.py
+++ b/teuthology/suite/test/test_placeholder.py
@@ -22,7 +22,8 @@ class TestPlaceholder(object):
             suite_repo='https://example.com/ceph/suite.git',
             suite_relpath='',
             ceph_repo='https://example.com/ceph/ceph.git',
-            flavor='default'
+            flavor='default',
+            expire='expire',
         )
         output_dict = substitute_placeholders(dict_templ, input_dict)
         assert output_dict['suite'] == 'suite'
@@ -50,6 +51,7 @@ class TestPlaceholder(object):
             suite_relpath='',
             ceph_repo='https://example.com/ceph/ceph.git',
             flavor=None,
+            expire='expire',
         )
         output_dict = substitute_placeholders(dict_templ, input_dict)
         assert 'os_type' not in output_dict

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -4,7 +4,7 @@ import requests
 import contextlib
 import yaml
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from mock import patch, call, ANY
 from io import StringIO
 from io import BytesIO
@@ -89,6 +89,45 @@ class TestRun(object):
         self.args.ceph_sha1 = None
         with pytest.raises(ScheduleFailError):
             self.klass(self.args)
+
+    @pytest.mark.parametrize(
+        ["expire", "delta", "result"],
+        [
+            [None, timedelta(), False],
+            ["1m", timedelta(), True],
+            ["1m", timedelta(minutes=-2), False],
+            ["1m", timedelta(minutes=2), True],
+            ["7d", timedelta(days=-14), False],
+        ]
+    )
+    @patch('teuthology.repo_utils.fetch_repo')
+    @patch('teuthology.suite.run.util.git_branch_exists')
+    @patch('teuthology.suite.run.util.package_version_for_hash')
+    @patch('teuthology.suite.run.util.git_ls_remote')
+    def test_get_expiration(
+        self,
+        m_git_ls_remote,
+        m_package_version_for_hash,
+        m_git_branch_exists,
+        m_fetch_repo,
+        expire,
+        delta,
+        result,
+    ):
+        m_git_ls_remote.side_effect = 'hash'
+        m_package_version_for_hash.return_value = 'a_version'
+        m_git_branch_exists.return_value = True
+        self.args.expire = expire
+        obj = self.klass(self.args)
+        now = datetime.now(timezone.utc)
+        expires_result = obj.get_expiration(_base_time=now + delta)
+        if expire is None:
+            assert expires_result is None
+            assert obj.base_config['expire'] is None
+        else:
+            assert expires_result is not None
+            assert (now < expires_result) is result
+            assert obj.base_config['expire']
 
     @patch('teuthology.suite.run.util.fetch_repos')
     @patch('requests.head')

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -12,6 +12,7 @@ from io import BytesIO
 from teuthology.config import config, YamlConfig
 from teuthology.exceptions import ScheduleFailError
 from teuthology.suite import run
+from teuthology.util.time import TIMESTAMP_FMT
 
 
 class TestRun(object):
@@ -52,7 +53,7 @@ class TestRun(object):
 
     @patch('teuthology.suite.run.util.fetch_repos')
     def test_name(self, m_fetch_repos):
-        stamp = datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+        stamp = datetime.now().strftime(TIMESTAMP_FMT)
         with patch.object(run.Run, 'create_initial_config',
                           return_value=run.JobConfig()):
             name = run.Run(self.args).name

--- a/teuthology/util/test/test_time.py
+++ b/teuthology/util/test/test_time.py
@@ -1,0 +1,30 @@
+import pytest
+
+from datetime import timedelta
+from typing import Type
+
+from teuthology.util import time
+
+
+@pytest.mark.parametrize(
+    ["offset", "result"],
+    [
+        ["1s", timedelta(seconds=1)],
+        ["1m", timedelta(minutes=1)],
+        ["1h", timedelta(hours=1)],
+        ["1d", timedelta(days=1)],
+        ["1w", timedelta(weeks=1)],
+        ["365d", timedelta(days=365)],
+        ["1x", ValueError],
+        ["-1m", ValueError],
+        ["0xde", ValueError],
+        ["frog", ValueError],
+        ["7dwarfs", ValueError],
+    ]
+)
+def test_parse_offset(offset: str, result: timedelta | Type[Exception]):
+    if isinstance(result, timedelta):
+        assert time.parse_offset(offset) == result
+    else:
+        with pytest.raises(result):
+            time.parse_offset(offset)

--- a/teuthology/util/test/test_time.py
+++ b/teuthology/util/test/test_time.py
@@ -1,9 +1,33 @@
 import pytest
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Type
 
 from teuthology.util import time
+
+
+@pytest.mark.parametrize(
+    ["timestamp", "result"],
+    [
+        ["1999-12-31_23:59:59", datetime(1999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)],
+        ["1999-12-31_23:59", datetime(1999, 12, 31, 23, 59, 0, tzinfo=timezone.utc)],
+        ["1999-12-31T23:59:59", datetime(1999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)],
+        ["1999-12-31T23:59:59+00:00", datetime(1999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)],
+        ["1999-12-31T17:59:59-06:00", datetime(1999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)],
+        ["2024-01-01", datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)],
+        ["tomorrow", ValueError],
+        ["1d", ValueError],
+        ["", ValueError],
+        ["2024", ValueError],
+
+    ]
+)
+def test_parse_timestamp(timestamp: str, result: datetime | Type[Exception]):
+    if isinstance(result, datetime):
+        assert time.parse_timestamp(timestamp) == result
+    else:
+        with pytest.raises(result):
+            time.parse_timestamp(timestamp)
 
 
 @pytest.mark.parametrize(

--- a/teuthology/util/time.py
+++ b/teuthology/util/time.py
@@ -1,0 +1,34 @@
+import re
+
+from datetime import timedelta
+
+def parse_offset(offset: str) -> timedelta:
+    """
+    offset: A string consisting of digits followed by one of the following
+            characters:
+                s: seconds
+                m: minutes
+                h: hours
+                d: days
+                w: weeks
+    """
+    err_msg = "Offsets must either be an ISO 8601-formatted timestamp or " \
+        f"a relative value like '2w', '1d', '7h', '45m', '90s'. Got: {offset}"
+    match = re.match(r'(\d+)(s|m|h|d|w)$', offset)
+    if match is None:
+        raise ValueError(err_msg)
+    num = int(match.groups()[0])
+    unit = match.groups()[1]
+    match unit:
+        case 's':
+            return timedelta(seconds=num)
+        case 'm':
+            return timedelta(minutes=num)
+        case 'h':
+            return timedelta(hours=num)
+        case 'd':
+            return timedelta(days=num)
+        case 'w':
+            return timedelta(weeks=num)
+        case _:
+            raise ValueError(err_msg)

--- a/teuthology/util/time.py
+++ b/teuthology/util/time.py
@@ -1,6 +1,24 @@
 import re
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
+
+# When we're not using ISO format, we're using this
+TIMESTAMP_FMT = "%Y-%m-%d_%H:%M:%S"
+
+def parse_timestamp(timestamp: str) -> datetime:
+    """
+    timestamp: A string either in ISO 8601 format or TIMESTAMP_FMT.
+               If no timezone is specified, UTC is assumed.
+
+    :returns: a datetime object
+    """
+    try:
+        dt = datetime.fromisoformat(timestamp)
+    except ValueError:
+        dt = datetime.strptime(timestamp, TIMESTAMP_FMT)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 def parse_offset(offset: str) -> timedelta:
     """


### PR DESCRIPTION
This feature has two parts:
* Specifying expiration dates when scheduling test runs
* A global maximum age

Expiration dates are provided by passing `--expire` to `teuthology-suite` with
a relative value like `1d` (one day), `1w` (one week), or an absolute value like
`1999-12-31_23:59:59`.

A new configuration item, `max_job_age`, is specified in seconds. This defaults
to two weeks.

When the dispatcher checks the queue for the next job to run, it will first
compare the job's `timestamp` value - which reflects the time the job was
scheduled. If more than `max_job_age` seconds have passed, the job is skipped
and marked dead. It next checks for an `expire` value; if that value is in the
past, the job is skipped and marked dead. Otherwise, it will be run as usual.