### PR TITLE
Fix access denied from psutil on macOS

### DIFF
--- a/teuthology/dispatcher/__init__.py
+++ b/teuthology/dispatcher/__init__.py
@@ -205,6 +205,8 @@ def find_dispatcher_processes() -> Dict[str, List[psutil.Process]]:
     def match(proc):
         try:
             cmdline = proc.cmdline()
+        except psutil.AccessDenied:
+            return False
         except psutil.ZombieProcess:
             return False
         if len(cmdline) < 3:

--- a/teuthology/kill.py
+++ b/teuthology/kill.py
@@ -223,6 +223,8 @@ def process_matches_run(pid, run_name):
             return True
     except psutil.NoSuchProcess:
         pass
+    except psutil.AccessDenied:
+        pass
     return False
 
 


### PR DESCRIPTION
On macOS dispatcher while trying to go through process list gets stuck
on some of the system processes like launchd, logd, systemstats, etc.
and quites unexpectedly with PermissionError and psutil.AccessDenied
exceptions.

Fixes: https://tracker.ceph.com/issues/67313
