### PR TITLE
bootstrap: fix VENV variable utilization

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -203,7 +203,7 @@ if [ -z $PYTHON_BIN -o ! -e $PYTHON_BIN -o ! -x $PYTHON_BIN ]; then
 fi
 PYTHON_VER_OUT=$($PYTHON_BIN --version)
 
-VENV=${VENV:-"virtualenv"}
+VENV=${VENV:-"./virtualenv"}
 # If the venv was set to use system site-packages, fix that
 if [ -f "$VENV/pyvenv.cfg" ]; then
     sed -i'' -e 's/\(include-system-site-packages\s*=\s*\)true/\1false/g' $VENV/pyvenv.cfg
@@ -214,38 +214,38 @@ export LANG=${LANG:-C.UTF-8}
 (echo $LANG | grep -qi utf-8) || export LC_ALL=$LANG.UTF-8
 
 if [ -z "$NO_CLOBBER" ] && \
-  [ ! -e "./$VENV/bin/pip" -o ! -e "./$VENV/bin/$PYTHON" ] || \
-  [ "${PYTHON_VER_OUT}" != "$(./$VENV/bin/$PYTHON --version)" ] \
+  [ ! -e "$VENV/bin/pip" -o ! -e "$VENV/bin/$PYTHON" ] || \
+  [ "${PYTHON_VER_OUT}" != "$($VENV/bin/$PYTHON --version)" ] \
   ; then
     rm -rf virtualenv
 fi
 
-if [ -z "$NO_CLOBBER" ] || [ ! -e ./$VENV ]; then
+if [ -z "$NO_CLOBBER" ] || [ ! -e $VENV ]; then
     $PYTHON_BIN -m venv $VENV
 fi
 
-./$VENV/bin/pip install packaging
+$VENV/bin/pip install packaging
 
 # It is impossible to upgrade ansible from 2.9 to 2.10 via pip.
 # See https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.10.html#known-issues
 if [ -f "$VENV/bin/ansible" ]; then
-    uninstall_ansible=$(./$VENV/bin/python3 -c "import ansible; from packaging.version import parse; print(parse(ansible.__version__) < parse('2.10.0'))")
+    uninstall_ansible=$($VENV/bin/python3 -c "import ansible; from packaging.version import parse; print(parse(ansible.__version__) < parse('2.10.0'))")
     if [ "$uninstall_ansible" = "True" ]; then
-        ./$VENV/bin/pip uninstall -y ansible
+        $VENV/bin/pip uninstall -y ansible
     fi
 fi
 
 # First, upgrade pip
-./$VENV/bin/pip install --upgrade pip
+$VENV/bin/pip install --upgrade pip
 
 # See https://github.com/pypa/pip/issues/8559
-./$VENV/bin/pip install -r requirements.txt --use-pep517
+$VENV/bin/pip install -r requirements.txt --use-pep517
 
 # By default, install teuthology in editable mode
-./$VENV/bin/pip install ${PIP_INSTALL_FLAGS:---editable '.[test]'}
+$VENV/bin/pip install ${PIP_INSTALL_FLAGS:---editable '.[test]'}
 
 # Check to make sure requirements are met
-./$VENV/bin/pip check
+$VENV/bin/pip check
 
 # Install ansible collections
-./$VENV/bin/ansible-galaxy install -r requirements.yml
+$VENV/bin/ansible-galaxy install -r requirements.yml


### PR DESCRIPTION
Allow bootstrap to use path outside of teuthology repo root directory for building virtualenv.