### PR TITLE
contextutil.safe_while does not sleep between tries if needed to loop infinitely

### DIFF
--- a/teuthology/contextutil.py
+++ b/teuthology/contextutil.py
@@ -115,20 +115,20 @@ class safe_while(object):
 
         msg = msg.format(
             action=self.action,
-            tries=self.counter,
+            tries=self.counter - 1,
             total=self.total_seconds,
         )
         return msg
 
     def __call__(self):
-        if self.tries < 0:
-            return True
         self.counter += 1
         if self.counter == 1:
             return True
+        def must_stop():
+            return self.tries > 0 and self.counter > self.tries
         if ((self.timeout > 0 and
              self.total_seconds >= self.timeout) or
-            (self.timeout == 0 and self.counter > self.tries)):
+            (self.timeout == 0 and must_stop())):
             error_msg = self._make_error_msg()
             if self._raise:
                 raise MaxWhileTries(error_msg)

--- a/teuthology/lock/query.py
+++ b/teuthology/lock/query.py
@@ -68,7 +68,7 @@ def list_locks(keyed_by_name=False, tries=10, **kwargs):
     with safe_while(
             sleep=1,
             increment=0.5,
-            tries=-1,
+            tries=tries,
             action='list_locks'
     ) as proceed:
         while proceed():

--- a/teuthology/suite/test/test_util.py
+++ b/teuthology/suite/test/test_util.py
@@ -103,7 +103,7 @@ Branch 'no-branch' not found in repo: https://github.com/ceph/ceph-ci.git!"
     def test_get_arch_fail(self, m_query):
         m_query.list_locks.return_value = False
         util.get_arch('magna')
-        m_query.list_locks.assert_called_with(machine_type="magna", count=1)
+        m_query.list_locks.assert_called_with(machine_type="magna", count=1, tries=1)
 
     @patch('teuthology.lock.query')
     def test_get_arch_success(self, m_query):
@@ -111,7 +111,7 @@ Branch 'no-branch' not found in repo: https://github.com/ceph/ceph-ci.git!"
         result = util.get_arch('magna')
         m_query.list_locks.assert_called_with(
             machine_type="magna",
-            count=1
+            count=1, tries=1
         )
         assert result == "arch"
 

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -263,7 +263,7 @@ def get_arch(machine_type):
 
     :returns: A string or None
     """
-    result = teuthology.lock.query.list_locks(machine_type=machine_type, count=1)
+    result = teuthology.lock.query.list_locks(machine_type=machine_type, count=1, tries=1)
     if not result:
         log.warning("No machines found with machine_type %s!", machine_type)
     else:


### PR DESCRIPTION
This PR provides fixes for several issues introduced in #1816:

1) make use of `tries` argument in `list_lock()` instead of hardcoded infinite loop
2) make `safe_while()` sleep between tries again when `tries` < 0, i.e. in case of infinite retries
3) (unrelated) report number of spent tries by safe_while correctly
4) try to get `list_lock()` only once when we're trying get architectures by given machine type for `teuthology-suite`.

https://tracker.ceph.com/issues/67377