### PR TITLE
setup.cfg: exclude tests from wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -137,5 +137,15 @@ teuthology.task.install =
 teuthology.task.internal =
     edit_sudoers.sh
 
+[options.packages.find]
+exclude =
+    teuthology.test
+    teuthology.test.*
+    teuthology.lock.test
+    teuthology.task.tests
+    teuthology.openstack.test
+    teuthology.orchestra.test
+    teuthology.orchestra.test.*
+
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
When building wheel for teuthology using `python3 -m build` there are generated two dist files tar.gz and whl for redistribution, both include test files.

This makes test files excluded from 'whl' package, but leave them in tar.gz.