### PR TITLE
Revert "orchestra/daemon/cephadmunit.py: fix method kill_cmd()"

### DIFF
--- a/teuthology/orchestra/daemon/cephadmunit.py
+++ b/teuthology/orchestra/daemon/cephadmunit.py
@@ -35,9 +35,9 @@ class CephadmUnit(DaemonState):
 
     def kill_cmd(self, sig):
         return ' '.join([
-            'sudo', 'systemctl', 'kill',
+            'sudo', 'docker', 'kill',
             '-s', str(int(sig)),
-            'ceph-%s@%s.%s' % (self.fsid, self.type_, self.id_),
+            'ceph-%s-%s.%s' % (self.fsid, self.type_, self.id_),
         ])
 
     def _start_logger(self):


### PR DESCRIPTION
This reverts commit 2c6d64a222b4d38d4782ed407e045a86df0a6524.

Related tracker: https://tracker.ceph.com/issues/66883

See the tracker for analysis on how this commit causes unintended behavior in teuthology tests that involve thrashing.