### PR TITLE
suite: use owner value for user name

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -45,10 +45,8 @@ class Run(object):
         # We assume timestamp is a datetime.datetime object
         self.timestamp = self.args.timestamp or \
             datetime.datetime.now().strftime(TIMESTAMP_FMT)
-        self.user = self.args.user or pwd.getpwuid(os.getuid()).pw_name
-
+        self.user = self.args.owner or pwd.getpwuid(os.getuid()).pw_name
         self.name = self.make_run_name()
-
         if self.args.ceph_repo:
             config.ceph_git_url = self.args.ceph_repo
         if self.args.suite_repo:

--- a/teuthology/suite/test/test_run_.py
+++ b/teuthology/suite/test/test_run_.py
@@ -60,8 +60,8 @@ class TestRun(object):
         assert str(stamp) in name
 
     @patch('teuthology.suite.run.util.fetch_repos')
-    def test_name_user(self, m_fetch_repos):
-        self.args.user = 'USER'
+    def test_name_owner(self, m_fetch_repos):
+        self.args.owner = 'USER'
         with patch.object(run.Run, 'create_initial_config',
                           return_value=run.JobConfig()):
             name = run.Run(self.args).name


### PR DESCRIPTION
pulpito-ng is gaining the ability to kill runs, and for non-admin users will match the user's github username with the test run's owner value to decide if the user is allowed to kill the run (admin users can kill any run). To generate the run name, we normally use the active user account's name.

It could be confusing if a user passed `--owner` but then still sees their unix account name used to name the run; this change lets us use more consistent naming without adding yet another flag (`--user`) to `teuthology-suite`.

Edit: The pulpito-ng PR: https://github.com/ceph/pulpito-ng/pull/51