### PR TITLE
teuthology/task: drop packages that are not built

### DIFF
--- a/teuthology/task/install/packages.yaml
+++ b/teuthology/task/install/packages.yaml
@@ -7,7 +7,10 @@ ceph:
   - ceph-fuse
   - ceph-test
   - radosgw
-  - python3-ceph
+  - python3-rados
+  - python3-rgw
+  - python3-cephfs
+  - python3-rbd
   - libcephfs2
   - librados2
   - librbd1
@@ -28,6 +31,9 @@ ceph:
   - libcephfs2
   - librados2
   - librbd1
-  - python3-ceph
+  - python3-rados
+  - python3-rgw
+  - python3-cephfs
+  - python3-rbd
   - rbd-fuse
   - ceph-debuginfo


### PR DESCRIPTION
This is a followup fix of https://github.com/ceph/teuthology/pull/2005
Fixes the error `Unable to find a match: python3-ceph`.

Fixes: https://tracker.ceph.com/issues/68037