### PR TITLE
teuthology/suite: pass the base config to scripts

### DIFF
--- a/teuthology/suite/merge.py
+++ b/teuthology/suite/merge.py
@@ -5,6 +5,7 @@ import os
 from types import MappingProxyType
 import yaml
 
+from teuthology.config import JobConfig
 from teuthology.suite.build_matrix import combine_path
 from teuthology.suite.util import strip_fragment_path
 from teuthology.misc import deep_merge
@@ -115,6 +116,7 @@ def config_merge(configs, suite_name=None, **kwargs):
     the entire job (config) from the list.
     """
     seed = kwargs.setdefault('seed', 1)
+    base_config = kwargs.setdefault('base_config', JobConfig())
     if not isinstance(seed, int):
         log.debug("no valid seed input: using 1")
         seed = 1
@@ -128,7 +130,7 @@ def config_merge(configs, suite_name=None, **kwargs):
         if suite_name is not None:
             desc = combine_path(suite_name, desc)
 
-        yaml_complete_obj = {}
+        yaml_complete_obj = copy.deepcopy(base_config.to_dict())
         deep_merge(yaml_complete_obj, dict(TEUTHOLOGY_TEMPLATE))
         for path in paths:
             if path not in yaml_cache:

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -9,7 +9,6 @@ import time
 
 from humanfriendly import format_timespan
 
-from tempfile import NamedTemporaryFile
 from teuthology import repo_utils
 
 from teuthology.config import config, JobConfig
@@ -639,16 +638,9 @@ Note: If you still want to go ahead, use --job-threshold 0'''
             filter_out=self.args.filter_out,
             filter_all=self.args.filter_all,
             filter_fragments=self.args.filter_fragments,
+            base_config=self.base_config,
             seed=self.args.seed,
             suite_name=suite_name))
-
-        # create, but do not write, the temp file here, so it can be
-        # added to the args in collect_jobs, but not filled until
-        # any backtracking is done
-        base_yaml_path = NamedTemporaryFile(
-            prefix='schedule_suite_', delete=False
-        ).name
-        self.base_yaml_paths.insert(0, base_yaml_path)
 
         # compute job limit in respect of --sleep-before-teardown
         job_limit = self.args.limit or 0
@@ -714,9 +706,6 @@ Note: If you still want to go ahead, use --job-threshold 0'''
                     dry_run=self.args.dry_run,
                 )
 
-        with open(base_yaml_path, 'w+b') as base_yaml:
-            base_yaml.write(str(self.base_config).encode())
-
         if jobs_to_schedule:
             self.write_rerun_memo()
 
@@ -727,8 +716,6 @@ Note: If you still want to go ahead, use --job-threshold 0'''
         self.check_num_jobs(len(jobs_to_schedule))
 
         self.schedule_jobs(jobs_missing_packages, jobs_to_schedule, name)
-
-        os.remove(base_yaml_path)
 
         count = len(jobs_to_schedule)
         missing_count = len(jobs_missing_packages)

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -622,6 +622,9 @@ Note: If you still want to go ahead, use --job-threshold 0'''
         log.debug('Suite %s in %s' % (suite_name, suite_path))
         log.debug(f"subset = {self.args.subset}")
         log.debug(f"no_nested_subset = {self.args.no_nested_subset}")
+        if self.args.dry_run:
+            log.debug("Base job config:\n%s" % self.base_config)
+
         configs = build_matrix(suite_path,
                                subset=self.args.subset,
                                no_nested_subset=self.args.no_nested_subset,
@@ -635,9 +638,6 @@ Note: If you still want to go ahead, use --job-threshold 0'''
             filter_fragments=self.args.filter_fragments,
             seed=self.args.seed,
             suite_name=suite_name))
-
-        if self.args.dry_run:
-            log.debug("Base job config:\n%s" % self.base_config)
 
         # create, but do not write, the temp file here, so it can be
         # added to the args in collect_jobs, but not filled until

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -167,13 +167,16 @@ class Run(object):
         # Put together a stanza specifying the kernel hash
         if self.args.kernel_branch == 'distro':
             kernel_hash = 'distro'
+            kernel_branch = 'distro'
         # Skip the stanza if '-k none' is given
         elif self.args.kernel_branch is None or \
              self.args.kernel_branch.lower() == 'none':
             kernel_hash = None
+            kernel_branch = None
         else:
+            kernel_branch = self.args.kernel_branch
             kernel_hash = util.get_gitbuilder_hash(
-                'kernel', self.args.kernel_branch, 'default',
+                'kernel', kernel_branch, 'default',
                 self.args.machine_type, self.args.distro,
                 self.args.distro_version,
             )
@@ -189,7 +192,7 @@ class Run(object):
 
         if kernel_hash:
             log.info("kernel sha1: {hash}".format(hash=kernel_hash))
-            kernel_dict = dict(kernel=dict(kdb=kdb, sha1=kernel_hash))
+            kernel_dict = dict(kernel=dict(branch=kernel_branch, kdb=kdb, sha1=kernel_hash))
             if kernel_hash != 'distro':
                 kernel_dict['kernel']['flavor'] = 'default'
         else:

--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -33,7 +33,7 @@ from teuthology.task.install.deb import install_dep_packages
 
 log = logging.getLogger(__name__)
 
-CONFIG_DEFAULT = {'branch': 'main'}
+CONFIG_DEFAULT = {'branch': 'distro', 'sha1': 'distro'}
 TIMEOUT_DEFAULT = 300
 
 VERSION_KEYS = ['branch', 'tag', 'sha1', 'deb', 'rpm', 'koji', 'koji_task']


### PR DESCRIPTION
This PR is to support: https://github.com/ceph/ceph/pull/60386

Also, this PR fixes a bug: `teuthology/tasks/kernel: default branch should be "distro"`. When the `kernel` dictionary is empty, the `kernel` task should assume `distro`.