### PR TITLE
teuthology: drop __future__ import for print

### DIFF
--- a/teuthology/__init__.py
+++ b/teuthology/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os, sys
 try:
     import importlib.metadata as importlib_metadata


### PR DESCRIPTION
We don't need to support backward compatibility with python 2.