### PR TITLE
containers/teuthology-dev: Remove access token

### DIFF
--- a/containers/teuthology-dev/Dockerfile
+++ b/containers/teuthology-dev/Dockerfile
@@ -29,6 +29,7 @@ RUN \
     PIP_INSTALL_FLAGS="-r requirements.txt" ./bootstrap
 COPY . /teuthology
 RUN \
+    git config -f ./.git/config --unset 'http.https://github.com/.extraheader' && \
     ./bootstrap
 COPY containers/teuthology-dev/containerized_node.yaml /teuthology
 COPY containers/teuthology-dev/.teuthology.yaml /root


### PR DESCRIPTION
This container is built and pushed via GitHub Actions. GHA likes to provision a personal access token for each job that gives tightly-scoped access to the git repository to the job. When we build our container, we end up including `.git/config`, which contains the token. Later, in ceph-dev-stack's CI, an `ls-remote` is run against ceph.git, which ends up causing git to prompt for credentials even though the repo is public. Removing the token should allow reading all the relevant repos from the built container image.