### PR TITLE
ci: save integration logs artifacts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,25 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - name: Make archive directory
+        run: mkdir /tmp/archive_dir
       - name: Test using docker-compose
         run: ./start.sh
         working-directory: ./docs/docker-compose
+      - name: Rename Directory
+        # Replace ":" with "_" everywhere in directory path.
+        # This needs to be done because GA does not support ":" colon character in artifacts (like in /root-2025-03-06_18:47:26-teuthology:no-ceph-main-distro-default-testnode).
+        # Invalid characters include:  Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?, Carriage return \r, Line feed \n
+        if: always()
+        run: |
+          DIR=$(ls -d /tmp/archive_dir/root-*)
+          SAFE_DIR=${DIR//:/_}  # Replace ":" with "_"
+          mv "$DIR" "$SAFE_DIR"
+          echo "ARCHIVE_DIR=$SAFE_DIR" >> $GITHUB_ENV
+      - name: Upload teuthology archive logs 
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: teuthology-logs 
+          path: |
+            ${{ env.ARCHIVE_DIR }}/*

--- a/docs/docker-compose/docker-compose.yml
+++ b/docs/docker-compose/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       TESTNODES:
       TEUTHOLOGY_WAIT:
       TEUTH_BRANCH:
+    volumes:
+      - /tmp/archive_dir:/archive_dir:rw
   testnode:
     build:
       context: ./testnode


### PR DESCRIPTION
Mount volume for archive_dir and then
upload it's logfiles as GA artifacts,
so we can use download-artifacts action
to download logs.