### PR TITLE
provision/downburst: add ntp to cloud-init packages

### DIFF
--- a/teuthology/provision/downburst.py
+++ b/teuthology/provision/downburst.py
@@ -245,6 +245,7 @@ class Downburst(object):
         user_info['packages'].extend([
             'git',
             'wget',
+            'ntp',
         ])
         # On CentOS/RHEL/Fedora, write the correct mac address and
         # install redhab-lsb-core for `lsb_release`


### PR DESCRIPTION
Since downburst may use default cloud images which mostly miss ntp by default, make sure we preinstall ntp service required for ceph cluster to sync the date time, otherwise osd self scrub check will fail.