### PR TITLE
When downburst used, command cloud-init to install ntp or chrony for time sync 

### DIFF
--- a/teuthology/provision/downburst.py
+++ b/teuthology/provision/downburst.py
@@ -246,6 +246,15 @@ class Downburst(object):
             'git',
             'wget',
         ])
+        if os_type in ('centos', 'opensuse'):
+            user_info['packages'].extend([
+                'chrony',
+            ])
+        if os_type in ('ubuntu', 'debian'):
+            user_info['packages'].extend([
+                'ntp',
+            ])
+
         # On CentOS/RHEL/Fedora, write the correct mac address and
         # install redhab-lsb-core for `lsb_release`
         if os_type in ['centos', 'rhel', 'fedora']:

--- a/teuthology/provision/downburst.py
+++ b/teuthology/provision/downburst.py
@@ -256,13 +256,11 @@ class Downburst(object):
             ])
 
         # On CentOS/RHEL/Fedora, write the correct mac address and
-        # install redhab-lsb-core for `lsb_release`
         if os_type in ['centos', 'rhel', 'fedora']:
             user_info['runcmd'].extend([
                 ['sed', '-ie', 's/HWADDR=".*"/HWADDR="%s"/' % mac_address,
                  '/etc/sysconfig/network-scripts/ifcfg-eth0'],
             ])
-            user_info['packages'].append('redhat-lsb-core')
         # On Ubuntu, starting with 16.04, and Fedora, starting with 24, we need
         # to install 'python' to get python2.7, which ansible needs
         if os_type in ('ubuntu', 'fedora'):


### PR DESCRIPTION
Allow cloud-init preinstall ntp or chrony because we may want not to use ceph-cm-ansible (which is not installing it now as well) so nodes can sync time in order to run all the test successfully when bare cloud images are used.