### PR TITLE
teuthology/suite/run.py: set sha1 in parsed_yaml

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -493,6 +493,7 @@ class Run(object):
                         limit=limit))
                 break
 
+            parsed_yaml["sha1"] = self.base_config.sha1
             os_type = parsed_yaml.get('os_type') or self.base_config.os_type
             os_version = parsed_yaml.get('os_version') or self.base_config.os_version
             exclude_arch = parsed_yaml.get('exclude_arch')


### PR DESCRIPTION
Without this, job yaml would have old sha. This causes a regression when using `--newest` because it updated the ceph sha. 