### PR TITLE
teuthology/schedule.py: update parsed_yaml with base_config

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -514,6 +514,8 @@ class Run(object):
                 '--',
             ])
             arg.extend(self.base_yaml_paths)
+            full_job_config = copy.deepcopy(self.base_config.to_dict())
+            deep_merge(parsed_yaml, full_job_config)
 
             parsed_yaml_txt = yaml.dump(parsed_yaml)
             arg.append('-')
@@ -529,9 +531,7 @@ class Run(object):
             sha1 = self.base_config.sha1
             if parsed_yaml.get('verify_ceph_hash',
                                config.suite_verify_ceph_hash):
-                full_job_config = copy.deepcopy(self.base_config.to_dict())
-                deep_merge(full_job_config, parsed_yaml)
-                flavor = util.get_install_task_flavor(full_job_config)
+                flavor = util.get_install_task_flavor(parsed_yaml)
                 version = util.package_version_for_hash(sha1, flavor, os_type,
                     os_version, self.args.machine_type)
                 if not version:


### PR DESCRIPTION
In `schedule_suite` method,
`self.base_config` gets updated many times while backtracking when using "--newest" flag. These changes were never updated to `parsed_yaml` (job yaml) in `configs`.
As `configs` is intialised before backtracking.

Before, we used to write base_config to a tmp
file and pass that to teuthology-schedule
which used to take care of updates to base_config. But this logic was removed in https://github.com/ceph/teuthology/pull/2008/files so the updates to base_config then never make
it to job yaml anymore.

Fixes: https://tracker.ceph.com/issues/71612