### PR TITLE
suite/run.py: suite_hash should use backtracked sha1

### DIFF
--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -690,7 +690,13 @@ Note: If you still want to go ahead, use --job-threshold 0'''
                     sha1s = util.find_git_parents('ceph', str(self.base_config.sha1), self.args.newest)
                 if not sha1s:
                     util.schedule_fail('Backtrack for --newest failed', name, dry_run=self.args.dry_run)
-                self.config_input['ceph_hash'] = sha1s.pop(0)
+                cur_sha1 = sha1s.pop(0)
+                self.config_input['ceph_hash'] = cur_sha1
+                # If ceph_branch and suite_branch are the same and
+                # ceph_repo and suite_repo are the same, update suite_hash
+                if (self.args.ceph_repo == self.args.suite_repo) and \
+                   (self.args.ceph_branch == self.args.suite_branch):
+                    self.config_input['suite_hash'] = cur_sha1
                 self.base_config = self.build_base_config()
                 backtrack += 1
                 continue


### PR DESCRIPTION
In schedule_suite() we only try to find backtracked sha1
for ceph sha1 when --newest is provided and packages are
not found in shaman. However, what about suite_sha1?
Currently, we do not use the backtracked sha1 for suite_sha1.
This commit will make sure that suite_sha1 is using
the backtracked sha1 when ceph_branch and suite_branch are the same and
ceph_repo and suite_repo are the same. This ensures that suite_sha1
only use the backtracked sha1 when the user clearly expects
shaman to not have the latest sha1 and want to use the --newest sha1
for both the ceph code base and suite qa code base.

Additionally, the unit-test in this PR will also cover the changes in:
https://github.com/ceph/teuthology/pull/2054

Fixes: https://tracker.ceph.com/issues/71668