### PR TITLE
containers: set image as ceph.containers.image

### DIFF
--- a/containers/teuthology-dev/.teuthology.yaml
+++ b/containers/teuthology-dev/.teuthology.yaml
@@ -7,3 +7,8 @@ teuthology_path: /teuthology
 archive_base: /archive_dir
 reserve_machines: 0
 lab_domain: ''
+
+defaults:
+  cephadm:
+    containers:
+      image: 'quay.ceph.io/ceph-ci/ceph'

--- a/containers/teuthology-dev/containerized_node.yaml
+++ b/containers/teuthology-dev/containerized_node.yaml
@@ -7,6 +7,5 @@ overrides:
       cm_user: root
       start_rpcbind: false
   cephadm:
-    image: quay.ceph.io/ceph-ci/ceph:main
     osd_method: raw
     no_cgroups_split: true


### PR DESCRIPTION
This needs to be changed as cephadm task overrides from `ceph.containers.image` (from `defaults` or `overrides`) instead of `ceph.image`: https://github.com/ceph/ceph/blob/ef15ecb8821fd79e24b046d2812696bd290c8489/qa/tasks/cephadm.py#L2301

Moved it to teuthology.yaml instead of containerised testnode yaml, so real testnodes can also benefit from this default setting. 