### PR TITLE
ci: run dev_container build for PRs

### DIFF
--- a/.github/workflows/dev_container.yml
+++ b/.github/workflows/dev_container.yml
@@ -3,6 +3,9 @@ name: dev_container
 on:
   push:
     branches:
+      - 'main'
+  pull_request:
+    branches:
       - main
   workflow_dispatch:
 
@@ -17,6 +20,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
       - name: Login to Quay.io
+        if: github.event_name == 'push' && github.ref_name == 'main'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: quay.io
@@ -31,6 +35,6 @@ jobs:
           context: .
           file: containers/teuthology-dev/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           tags: ${{ env.QUAY_URI }}:${{ env.QUAY_TAG }}
           outputs: type=image,name=target


### PR DESCRIPTION
Build the image for PRs but do not push.
For pushes to main branch, push to registery.
To prevent situations like https://tracker.ceph.com/issues/72056

Depends on https://github.com/ceph/teuthology/pull/2063 