### PR TITLE
orchestra/remote: add resolve_ip method

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -34,6 +34,10 @@ jobs:
           cd ./virtualenv/lib/python*
           touch no-global-site-packages.txt
         working-directory: ./teuthology
+      - name: Refresh system repos
+        run: |
+          sudo apt update -y
+          sudo apt upgrade -y
       - name: Initial bootstrap
         run: ./bootstrap install
         working-directory: ./teuthology

--- a/bootstrap
+++ b/bootstrap
@@ -128,7 +128,7 @@ PY_MAJOR=$($VENV/bin/python -c "import sys; print(sys.version_info[0])")
 PY_MINOR=$($VENV/bin/python -c "import sys; print(sys.version_info[1])")
 
 # Python version check
-if [ "$PY_MAJOR" -ne 3 || "$PY_MINOR" -lt 10 ]; then
+if [[ "$PY_MAJOR" -ne 3 || "$PY_MINOR" -lt 10 ]]; then
     echo "Python version should be 3.10 or higher, found $PY_MAJOR.$PY_MINOR"
     exit 1
 fi

--- a/containers/teuthology-dev/Dockerfile
+++ b/containers/teuthology-dev/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     PIP_INSTALL_FLAGS="-r requirements.txt" ./bootstrap
 COPY . /teuthology
 RUN \
-    git config -f ./.git/config --unset 'http.https://github.com/.extraheader' && \
+    (git config -f ./.git/config --unset 'http.https://github.com/.extraheader' || true ) && \
     ./bootstrap
 COPY containers/teuthology-dev/containerized_node.yaml /teuthology
 COPY containers/teuthology-dev/.teuthology.yaml /root


### PR DESCRIPTION
Add utility method to resolve a hostname from within remote host. This is useful to resolve ip address of the remote host itself, because getting ip address from transport object of ssh is not suitable because it may have only bastion host and port, which is not relevant for the purpose of configuring a cluster.