### PR TITLE
teuthology: use test user name from the config

### DIFF
--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -51,7 +51,13 @@ def host_shortname(hostname):
     else:
         return hostname.split('.', 1)[0]
 
-def canonicalize_hostname(hostname, user: Optional[str] ='ubuntu'):
+# sentinel value to indicate the default user value is to be used.
+# None and the empty string are reserved for specifying no user value
+# to be backwards compatible with older code.
+_default_user = '.'
+
+def canonicalize_hostname(hostname, user: Optional[str] = _default_user):
+    user = get_test_user() if user == _default_user else user
     hostname_expr = hostname_expr_templ.format(
         lab_domain=config.lab_domain.replace('.', r'\.'))
     match = re.match(hostname_expr, hostname)

--- a/teuthology/task/ssh_keys.py
+++ b/teuthology/task/ssh_keys.py
@@ -93,21 +93,22 @@ def tweak_ssh_config(ctx, config):
     """
     Turn off StrictHostKeyChecking
     """
+    user = misc.get_test_user()
     run.wait(
         ctx.cluster.run(
             args=[
                 'echo',
                 'StrictHostKeyChecking no\n',
                 run.Raw('>'),
-                run.Raw('/home/ubuntu/.ssh/config'),
+                run.Raw(f'/home/{user}/.ssh/config'),
                 run.Raw('&&'),
                 'echo',
                 'UserKnownHostsFile ',
                 run.Raw('/dev/null'),
                 run.Raw('>>'),
-                run.Raw('/home/ubuntu/.ssh/config'),
+                run.Raw(f'/home/{user}/.ssh/config'),
                 run.Raw('&&'),
-                run.Raw('chmod 600 /home/ubuntu/.ssh/config'),
+                run.Raw(f'chmod 600 /home/{user}/.ssh/config'),
             ],
             wait=False,
         )
@@ -119,7 +120,7 @@ def tweak_ssh_config(ctx, config):
     finally:
         run.wait(
             ctx.cluster.run(
-                args=['rm',run.Raw('/home/ubuntu/.ssh/config')],
+                args=['rm',run.Raw(f'/home/{user}/.ssh/config')],
             wait=False
             ),
         )


### PR DESCRIPTION
A few places in the code try to use a configurable name but others effectively hard-code "ubuntu". Fix these cases to support more flexible user naming.