### PR TITLE
setup.cfg: fix teuthology-openstack dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     lxml
     ndg-httpsclient
     netaddr
+    openstacksdk # teuthology-openstack dependencies
     paramiko
     pexpect
     pip-tools
@@ -107,10 +108,10 @@ test =
     toml
     tox
     xmltodict
+# libcloud openstack dependencies
 openstack =
     python-openstackclient
     python-novaclient
-    openstacksdk
 
 [options.package_data]
 teuthology.openstack =


### PR DESCRIPTION
The PR #2050 "Revive teuthology-openstack" introduced new dependency after refactoring partly of teuthology.openstack instance classes to use api instead of command line. However the openstacksdk added to wrong section options.extras_require.openstack, that intended to be used for provisioning openstack nodes via libcloud, which is optional and is not installable by default.

I.e. `pip install -e ".[openstack]"` must be used in order to get it.

However the refactoring forced unconditional openstack requirement.

That's why this dependency should go to options.install_requires in order to make `pip install -e .` work again.

Fixes: 252ab4f6a44c0d64b1e4cfb2b86e9bf58b5d9ffb