### PR TITLE
openstack: Do not immediately throw ImportError

### DIFF
--- a/teuthology/orchestra/test/test_connection.py
+++ b/teuthology/orchestra/test/test_connection.py
@@ -31,6 +31,7 @@ class TestConnection(object):
     def clear_config(self):
         config.config.teuthology_yaml = ''
         config.config.load()
+        config.config.ssh_key = None
 
     def test_split_user_just_host(self):
         got = connection.split_user('somehost.example.com')


### PR DESCRIPTION
We would rather not have openstacksdk be a requirement for all installs, since
most do not use it. This change will not disturb people who install the
openstack extra, which pulls in that and other packages.

Signed-off-by: Zack Cerza <zack@cerza.org>