### PR TITLE
Fix: handle attached_volumes field when fetching volumes from openstack

### DIFF
--- a/teuthology/openstack/__init__.py
+++ b/teuthology/openstack/__init__.py
@@ -128,8 +128,12 @@ class OpenStackInstance(object):
         Return the uuid of the volumes attached to the name_or_id
         OpenStack instance.
         """
-        volumes = self['os-extended-volumes:volumes_attached']
-        return [volume['id'] for volume in volumes ]
+        info = self.info or {}
+        vols = (info.get('os-extended-volumes:volumes_attached')
+                or info.get('attached_volumes') 
+                or [])
+        volumes = [v['id'] for v in vols if isinstance(v, dict) and 'id' in v]
+        return volumes
 
     def get_addresses(self):
         """


### PR DESCRIPTION
In some OpenStack deployments, the server JSON includes 'attached_volumes'
instead of `os-extended-volumes:volumes_attached`. The existing 
get_volumes function only checked the latter, which caused it to always 
return an empty list on these clouds.

This patch updates get_volumes() to:

- Safely access self.info without breaking
- Fallback to 'attached_volumes' if 'os-extended-volumes:volumes_attached'
  is not present
- Return the list of volume UUIDs consistently

With this change, teardown logic (volume cleanup on destroy) works 
correctly across both types of openstack responses.