### PR TITLE
[dnm] dispatcher: do not put targets in orig config

### DIFF
--- a/teuthology/dispatcher/__init__.py
+++ b/teuthology/dispatcher/__init__.py
@@ -161,9 +161,9 @@ def main(args):
             log.info('Creating job\'s archive dir %s', job_archive_path)
             safepath.makedirs('/', job_archive_path)
 
-            orig_job_config_path = os.path.join(job_archive_path, 'orig.config.yaml')
+            initial_job_config_path = os.path.join(job_archive_path, 'initial.config.yaml')
             # Write initial job config in job archive dir
-            with open(orig_job_config_path, 'w') as f:
+            with open(initial_job_config_path, 'w') as f:
                 yaml.safe_dump(job_config, f, default_flow_style=False)
 
 
@@ -214,7 +214,7 @@ def main(args):
                     )
                     continue
             else:
-                run_args.extend(["--job-config", orig_job_config_path])
+                run_args.extend(["--job-config", initial_job_config_path])
 
             report.try_push_job_info(job_config, dict(status='running'))
             try:

--- a/teuthology/dispatcher/__init__.py
+++ b/teuthology/dispatcher/__init__.py
@@ -155,10 +155,37 @@ def main(args):
             except SkipJob:
                 continue
 
+            # Create run archive directory if not already created and
+            # job's archive directory
+            job_archive_path = job_config['archive_path']
+            log.info('Creating job\'s archive dir %s', job_archive_path)
+            safepath.makedirs('/', job_archive_path)
+
+            orig_job_config_path = os.path.join(job_archive_path, 'orig.config.yaml')
+            # Write initial job config in job archive dir
+            with open(orig_job_config_path, 'w') as f:
+                yaml.safe_dump(job_config, f, default_flow_style=False)
+
+
+            run_args = [
+                os.path.join(teuth_bin_path, 'teuthology-supervisor'),
+                '-v',
+                '--bin-path', teuth_bin_path,
+                '--archive-dir', archive_dir,
+            ]
+
             # lock machines but do not reimage them
+            targets_job_config = None
             if 'roles' in job_config:
                 try:
-                    job_config = lock_machines(job_config)
+                    targets_job_config = lock_machines(job_config)
+                    job_config_path = os.path.join(job_archive_path, 'targets.config.yaml')
+
+                    with open(job_config_path, 'w') as f:
+                        yaml.safe_dump(targets_job_config, f, default_flow_style=False)
+
+                    run_args.extend(["--job-config", job_config_path])
+
                 except LoopExit as e:
                     log.critical(
                         "Caught gevent LoopExit exception during lock_machines for job %s. "
@@ -186,27 +213,10 @@ def main(args):
                         )
                     )
                     continue
+            else:
+                run_args.extend(["--job-config", orig_job_config_path])
 
-            run_args = [
-                os.path.join(teuth_bin_path, 'teuthology-supervisor'),
-                '-v',
-                '--bin-path', teuth_bin_path,
-                '--archive-dir', archive_dir,
-            ]
-
-            # Create run archive directory if not already created and
-            # job's archive directory
-            create_job_archive(job_config['name'],
-                               job_config['archive_path'],
-                               archive_dir)
-            job_config_path = os.path.join(job_config['archive_path'], 'orig.config.yaml')
-
-            # Write initial job config in job archive dir
-            with open(job_config_path, 'w') as f:
-                yaml.safe_dump(job_config, f, default_flow_style=False)
-
-            run_args.extend(["--job-config", job_config_path])
-
+            report.try_push_job_info(job_config, dict(status='running'))
             try:
                 # Use start_new_session=True to ensure child processes are isolated
                 # from the dispatcher's process group. This prevents accidental
@@ -222,8 +232,8 @@ def main(args):
             except Exception:
                 error_message = "Saw error while trying to spawn supervisor."
                 log.exception(error_message)
-                if 'targets' in job_config:
-                    node_names = job_config["targets"].keys()
+                if targets_job_config and 'targets' in targets_job_config:
+                    node_names = targets_job_config["targets"].keys()
                     lock_ops.unlock_safe(
                         node_names,
                         job_config["owner"],
@@ -420,7 +430,6 @@ def check_job_expiration(job_config):
 
 
 def lock_machines(job_config):
-    report.try_push_job_info(job_config, dict(status='running'))
     fake_ctx = supervisor.create_fake_context(job_config, block=True)
     machine_type = job_config["machine_type"]
     count = len(job_config['roles'])
@@ -435,14 +444,4 @@ def lock_machines(job_config):
             tries=-1,
             reimage=False,
         )
-    job_config = fake_ctx.config
-    return job_config
-
-
-def create_job_archive(job_name, job_archive_path, archive_dir):
-    log.info('Creating job\'s archive dir %s', job_archive_path)
-    safe_archive = safepath.munge(job_name)
-    run_archive = os.path.join(archive_dir, safe_archive)
-    if not os.path.exists(run_archive):
-        safepath.makedirs('/', run_archive)
-    safepath.makedirs('/', job_archive_path)
+    return fake_ctx.config

--- a/teuthology/dispatcher/supervisor.py
+++ b/teuthology/dispatcher/supervisor.py
@@ -63,6 +63,7 @@ def main(args):
         with exporter.JobTime().time(suite=suite):
             return run_job(
                 job_config,
+                args.job_config,
                 args.bin_path,
                 args.archive_dir,
                 args.verbose
@@ -70,13 +71,18 @@ def main(args):
     else:
         return run_job(
             job_config,
+            args.job_config,
             args.bin_path,
             args.archive_dir,
             args.verbose
         )
 
 
-def run_job(job_config, teuth_bin_path, archive_dir, verbose):
+def run_job(job_config: dict,
+            job_config_path: str,
+            teuth_bin_path: str,
+            archive_dir: str,
+            verbose: bool) -> int:
     safe_archive = safepath.munge(job_config['name'])
     if job_config.get('first_in_suite') or job_config.get('last_in_suite'):
         job_archive = os.path.join(archive_dir, safe_archive)
@@ -138,8 +144,7 @@ def run_job(job_config, teuth_bin_path, archive_dir, verbose):
     ])
     if job_config['description'] is not None:
         arg.extend(['--description', job_config['description']])
-    job_archive = os.path.join(job_config['archive_path'], 'orig.config.yaml')
-    arg.extend(['--', job_archive])
+    arg.extend(['--', job_config_path])
 
     log.debug("Running: %s" % ' '.join(arg))
     p = subprocess.Popen(

--- a/teuthology/dispatcher/test/test_supervisor.py
+++ b/teuthology/dispatcher/test/test_supervisor.py
@@ -34,7 +34,8 @@ class TestSuperviser(object):
         m_p.returncode = 0
         m_popen.return_value = m_p
         m_t_config.results_server = True
-        supervisor.run_job(config, "teuth/bin/path", "archive/dir", verbose=False)
+        config_path = "archive/path/initial.config.yaml"
+        supervisor.run_job(config, config_path, "teuth/bin/path", "archive/dir", verbose=False)
         m_run_watchdog.assert_called_with(m_p, config)
         expected_args = [
             'teuth/bin/path/teuthology',
@@ -45,7 +46,7 @@ class TestSuperviser(object):
             '--description',
             'the_description',
             '--',
-            "archive/path/orig.config.yaml",
+            config_path,
         ]
         m_popen.assert_called_with(args=expected_args, stderr=DEVNULL, stdout=DEVNULL)
 
@@ -80,7 +81,8 @@ class TestSuperviser(object):
         m_p.returncode = 1
         m_popen.return_value = m_p
         m_t_config.results_server = False
-        supervisor.run_job(config, "teuth/bin/path", "archive/dir", verbose=False)
+        config_path = "archive/path/initial.config.yaml"
+        supervisor.run_job(config, config_path, "teuth/bin/path", "archive/dir", verbose=False)
 
     @patch("teuthology.dispatcher.supervisor.report.try_push_job_info")
     @patch("time.sleep")


### PR DESCRIPTION
There is introduced targets in orig.config.yaml in the dispatcher code, however it should not be here so the original config should be still usable with teuthology (teuthology-run) with arbitrary targets yaml file, which is provided separately.