### PR TITLE
selinux: allowlist bpf podman denials

### DIFF
--- a/teuthology/task/selinux.py
+++ b/teuthology/task/selinux.py
@@ -139,6 +139,7 @@ class SELinux(Task):
             'context=system_u:system_r:NetworkManager_dispatcher_t:s0',
             'context=system_u:system_r:getty_t:s0',
             'comm="iptables"',
+            'comm="systemd".*denied.*\{ prog_run \}.*tclass=bpf.*permissive=1',
         ]
         se_allowlist = self.config.get('allowlist', [])
         if se_allowlist:


### PR DESCRIPTION
Rocky Linux 10 logs SELinux AVCs for systemd BPF operations during container startup due to incomplete SELinux policy coverage. These AVCs occur in permissive mode, are reproducible without Ceph, and do not indicate functional failure. Tests should ignore this specific AVC class while continuing to fail on enforced denials.