### PR TITLE
Add tracker suggestions to teuthology log

### DIFF
--- a/teuthology/run.py
+++ b/teuthology/run.py
@@ -272,6 +272,21 @@ def report_outcome(config, archive, summary):
     summary_dump = yaml.safe_dump(summary)
     log.info('Summary data:\n%s' % summary_dump)
 
+    if not passed:
+        try:
+            from teuthology.util.redmine_suggest import log_redmine_suggestions_on_failure
+            log_redmine_suggestions_on_failure(
+                log,
+                summary.get('failure_reason'),
+                config,
+                failure_reason_detail=summary.get('failure_reason_detail'),
+                teuthology_log_path=(
+                    os.path.join(archive, 'teuthology.log') if archive else None
+                ),
+            )
+        except Exception as e:
+            log.debug('Redmine tracker suggestions skipped: %s', e)
+
     if ('email-on-error' in config
             and not passed):
         config_dump = yaml.safe_dump(config)

--- a/teuthology/run_tasks.py
+++ b/teuthology/run_tasks.py
@@ -21,6 +21,32 @@ from teuthology.util import sentry
 log = logging.getLogger(__name__)
 
 
+def _first_nested_exception_message(exc, max_len=300):
+    """
+    Return the first nested exception message from '__cause__'/'__context__'.
+    """
+    if exc is None:
+        return None
+    seen = set()
+    outer_msg = str(exc).strip()
+    nested = exc.__cause__ or exc.__context__
+    while nested and id(nested) not in seen:
+        seen.add(id(nested))
+        msg = str(nested).strip()
+        if msg and msg != outer_msg:
+            return msg[:max_len]
+        nested = nested.__cause__ or nested.__context__
+    return None
+
+
+def _set_failure_reason_detail_if_missing(summary, exc):
+    if 'failure_reason_detail' in summary:
+        return
+    detail = _first_nested_exception_message(exc)
+    if detail:
+        summary['failure_reason_detail'] = detail
+
+
 def get_task(name):
     # todo: support of submodules
     if '.' in name:
@@ -120,6 +146,7 @@ def run_tasks(tasks, ctx):
                 set_status(ctx.summary, 'fail')
         if 'failure_reason' not in ctx.summary:
             ctx.summary['failure_reason'] = str(e)
+        _set_failure_reason_detail_if_missing(ctx.summary, e)
         log.exception('Saw exception from tasks.')
 
         ctx.summary['sentry_event'] = sentry.report_error(ctx.config, e, taskname)
@@ -166,6 +193,7 @@ def run_tasks(tasks, ctx):
                         set_status(ctx.summary, 'fail')
                     if 'failure_reason' not in ctx.summary:
                         ctx.summary['failure_reason'] = str(e)
+                    _set_failure_reason_detail_if_missing(ctx.summary, e)
                     log.exception('Manager failed: %s', taskname)
 
                     if exc_info == (None, None, None):

--- a/teuthology/test/test_run.py
+++ b/teuthology/test/test_run.py
@@ -129,10 +129,11 @@ class TestRun(object):
     @patch("teuthology.run.get_status")
     @patch("yaml.safe_dump")
     @patch("teuthology.report.try_push_job_info")
+    @patch("teuthology.util.redmine_suggest.log_redmine_suggestions_on_failure")
     @patch("teuthology.run.email_results")
     @patch("teuthology.run.open")
     @patch("sys.exit")
-    def test_report_outcome(self, m_sys_exit, m_open, m_email_results, m_try_push_job_info, m_safe_dump, m_get_status):
+    def test_report_outcome(self, m_sys_exit, m_open, m_email_results, m_log_redmine_suggestions_on_failure, m_try_push_job_info, m_safe_dump, m_get_status):
         m_get_status.return_value = "fail"
         summary = {"failure_reason": "reasons"}
         summary_dump = "failure_reason: reasons\n"
@@ -140,10 +141,43 @@ class TestRun(object):
         config_dump = "email-on-error: true\n"
         m_safe_dump.side_effect = [None, summary_dump, config_dump]
         run.report_outcome(config, "the/archive/path", summary)
+        assert m_log_redmine_suggestions_on_failure.called
         m_try_push_job_info.assert_called_with(config, summary)
         m_open.assert_called_with("the/archive/path/summary.yaml", "w")
         assert m_email_results.called
         assert m_open.called
+        assert m_sys_exit.called
+
+    @patch("teuthology.util.redmine_suggest.log_redmine_suggestions_on_failure")
+    @patch("teuthology.report.try_push_job_info")
+    @patch("teuthology.run.get_status")
+    @patch("yaml.safe_dump")
+    @patch("sys.exit")
+    def test_report_outcome_passes_failure_reason_detail(
+        self,
+        m_sys_exit,
+        m_safe_dump,
+        m_get_status,
+        m_try_push_job_info,
+        m_log_redmine_suggestions_on_failure,
+    ):
+        m_get_status.return_value = "fail"
+        m_safe_dump.return_value = ""
+        summary = {
+            "failure_reason": "reached maximum tries (50) after waiting for 300 seconds",
+            "failure_reason_detail": "Command failed on node with status 1",
+        }
+        cfg = {"redmine_base_url": "https://tracker.ceph.com"}
+        run.report_outcome(cfg, None, summary)
+
+        m_log_redmine_suggestions_on_failure.assert_called_once_with(
+            run.log,
+            summary["failure_reason"],
+            cfg,
+            failure_reason_detail=summary["failure_reason_detail"],
+            teuthology_log_path=None,
+        )
+        m_try_push_job_info.assert_called_with(cfg, summary)
         assert m_sys_exit.called
 
     @patch("teuthology.run.set_up_logging")

--- a/teuthology/test/test_run_tasks.py
+++ b/teuthology/test/test_run_tasks.py
@@ -1,0 +1,19 @@
+from teuthology import run_tasks
+
+
+def test_first_nested_exception_message_from_context():
+    try:
+        try:
+            raise RuntimeError("Command failed on node with status 1")
+        except RuntimeError:
+            raise ValueError("reached maximum tries (50) after waiting for 300 seconds")
+    except ValueError as exc:
+        detail = run_tasks._first_nested_exception_message(exc)
+    assert detail == "Command failed on node with status 1"
+
+
+def test_set_failure_reason_detail_if_missing_keeps_existing():
+    summary = {"failure_reason_detail": "already set"}
+    exc = RuntimeError("outer")
+    run_tasks._set_failure_reason_detail_if_missing(summary, exc)
+    assert summary["failure_reason_detail"] == "already set"

--- a/teuthology/util/redmine_suggest.py
+++ b/teuthology/util/redmine_suggest.py
@@ -1,0 +1,265 @@
+"""
+Suggest Redmine / tracker issue IDs when a job fails.
+
+Redmine search API — ``GET .../search.json?q=...&issues=1`` uses a normalized
+excerpt of failure text as full-text query and logs candidate issues.
+
+Enable from job YAML::
+
+    redmine_base_url: https://tracker.ceph.com
+    redmine_search_limit: 5
+"""
+
+import logging
+import os
+import re
+
+import requests
+
+from teuthology.scrape import TimeoutReason
+
+log = logging.getLogger(__name__)
+
+
+_GENERIC_TIMEOUT_PATTERNS = [
+    r"reached maximum tries \(\d+\) after waiting for \d+ seconds",
+    r"hit max job timeout",
+    r"authenticate timed out after \d+",
+    r"\boperation timed out\b",
+    r"\bconnection timed out\b",
+]
+
+
+def _normalize_base_url(url):
+    return url.rstrip("/")
+
+
+def normalize_failure_text_for_search(text):
+    """
+    Normalize failure text tokens so similar failures map to similar queries.
+    """
+    if not text:
+        return ""
+    out = " ".join(text.split())
+    out = re.sub(
+        r"\bon\s+(?:"
+        r"(?:\d{1,3}\.){3}\d{1,3}|"
+        r"[A-Za-z0-9._-]+"
+        r")(?=\s+with status\b)",
+        "",
+        out,
+        flags=re.IGNORECASE,
+    )
+    # remove noisy environment assignments from cli
+    out = re.sub(r"\b[A-Z_][A-Z0-9_]*=(?:\"[^\"]*\"|'[^']*'|\S+)", "", out)
+    # Replace host-like tokens so search is less tied to one run.
+    out = re.sub(r"\bip-\d+(?:-\d+){3}\b", "host", out)
+    out = re.sub(r"\bnode\d+\b", "host", out)
+    out = re.sub(r"\b(?:\d{1,3}\.){3}\d{1,3}\b", "host", out)
+    out = re.sub(r"\b[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)+\b", "host", out, flags=re.IGNORECASE)
+    # Keep command core by dropping leading sudo in cmd snippets
+    out = re.sub(r"(?<!\w)sudo\s+", "", out, flags=re.IGNORECASE)
+    out = re.sub(r"\s+", " ", out)
+    # Clean up truncated quote artifacts at query boundary
+    out = out.replace("''", "'")
+    return out.strip(" '\"|:")
+
+
+def failure_search_query(failure_reason, max_len=200):
+    """Build a Redmine ``q`` parameter from free-text failure output."""
+    if not failure_reason:
+        return ""
+    one_line = normalize_failure_text_for_search(failure_reason)
+    return one_line[:max_len]
+
+
+def combined_failure_text(
+    failure_reason,
+    failure_reason_detail=None,
+    log_failure_hint=None,
+):
+    """
+    Build matching/search text from summary fields.
+
+    `failure_reason_detail` (if present) is preferred because it often
+    contains the actionable inner exception while `failure_reason` can be
+    generic (like timeout wrapper).
+    """
+    reason = (failure_reason or "").strip()
+    detail = (failure_reason_detail or "").strip()
+    hint = (log_failure_hint or "").strip()
+    reason_is_timeout = is_generic_timeout_reason(reason)
+    timeout_data = extract_timeout_command_from_scrape(detail) or extract_timeout_command_from_scrape(reason)
+
+    parts = []
+    if timeout_data:
+        timeout, command = timeout_data
+        parts.append("timeout %s running %s" % (timeout, command))
+    if hint:
+        parts.append(hint)
+    if detail and detail != hint:
+        parts.append(detail)
+    if reason and not reason_is_timeout and reason != detail and reason != hint:
+        parts.append("caused by: %s" % reason if (hint or detail) else reason)
+    return " | ".join(parts)
+
+
+class _FailureReasonOnlyJob(object):
+    def __init__(self, failure_reason):
+        self._failure_reason = failure_reason
+
+    def get_failure_reason(self):
+        return self._failure_reason
+
+
+def extract_timeout_command_from_scrape(failure_reason):
+    if not failure_reason:
+        return None
+    return TimeoutReason.get_timeout(_FailureReasonOnlyJob(failure_reason))
+
+
+def is_generic_timeout_reason(text):
+    text = (text or "").strip().lower()
+    if not text:
+        return False
+    return any(re.search(pat, text) for pat in _GENERIC_TIMEOUT_PATTERNS)
+
+
+def extract_log_failure_hint(
+    teuthology_log_path, max_scan_bytes=20_000_000
+):
+    """
+    Extract a compact, high-signal failure hint from `teuthology.log`.
+
+    This is a best-effort fallback for runs where summary/exception text is too
+    generic. The parser scans from the end of the log for common test-failure
+    markers.
+    """
+    if not teuthology_log_path:
+        return None
+    try:
+        with open(teuthology_log_path, "rb") as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            start = max(0, size - max_scan_bytes)
+            f.seek(start)
+            text = f.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+    patterns = [
+        (r"\[\s*FAILED\s*\]\s+([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)\b", "failed test: %s"),
+        (r"(?m)^\s*FAILED\s+([^\s]+::[^\s]+)\s*$", "failed test: %s"),
+        (r"(?m)^\s*FAIL:\s+([A-Za-z0-9_./:-]+)\s*$", "failed test: %s"),
+    ]
+    for pattern, fmt in patterns:
+        matches = re.findall(pattern, text)
+        if matches:
+            return fmt % matches[-1]
+    return None
+
+
+def _issue_id_from_search_result(item):
+    url = item.get("url") or ""
+    m = re.search(r"/issues/(\d+)", url)
+    if m:
+        return int(m.group(1))
+    title = item.get("title") or ""
+    m = re.search(r"#(\d+)", title)
+    if m:
+        return int(m.group(1))
+    rid = item.get("id")
+    if isinstance(rid, int) and item.get("type", "").startswith("issue"):
+        return rid
+    return None
+
+
+def redmine_search_issue_ids(
+    base_url,
+    query,
+    limit=8,
+    timeout=20.0,
+):
+    """
+    Call Redmine ``/search.json`` and return (issue_id, title) pairs.
+
+    :returns: list of tuples; empty on error or empty query.
+    """
+    if not query.strip():
+        return []
+    url = _normalize_base_url(base_url) + "/search.json"
+    params = {"q": query, "issues": 1, "limit": max(1, min(limit, 100))}
+    try:
+        resp = requests.get(url, params=params, timeout=timeout)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        log.warning("Redmine search failed: %s", e)
+        return []
+    try:
+        payload = resp.json()
+    except ValueError:
+        log.warning("Redmine search returned non-JSON")
+        return []
+    results = payload.get("results") or []
+    out = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        type_s = str(item.get("type") or "")
+        if "issue" not in type_s.lower():
+            continue
+        iid = _issue_id_from_search_result(item)
+        if iid is None:
+            continue
+        title = str(item.get("title") or "").replace("\n", " ")[:120]
+        out.append((iid, title))
+    return out
+
+
+def log_redmine_suggestions_on_failure(
+    logger,
+    failure_reason,
+    cfg,
+    failure_reason_detail=None,
+    teuthology_log_path=None,
+):
+    """
+    Log possible tracker issue IDs after the summary block (teuthology.log).
+
+    `cfg` is the full job config mapping.
+    """
+    if not cfg or not isinstance(cfg, dict):
+        return
+    log_failure_hint = extract_log_failure_hint(teuthology_log_path)
+    reason = combined_failure_text(
+        failure_reason,
+        failure_reason_detail,
+        log_failure_hint=log_failure_hint,
+    )
+
+    base_url = (
+        cfg.get("redmine_base_url")
+        or "https://tracker.ceph.com"
+    )
+    search_limit = int(cfg.get("redmine_search_limit", 5))
+
+    if not base_url:
+        logger.debug("redmine-on-failure: no base_url; skipping Redmine search")
+        return
+
+    q = failure_search_query(reason)
+    hits = redmine_search_issue_ids(
+        str(base_url), q, limit=search_limit
+    )
+    if not hits:
+        return
+
+    parts = []
+    seen_ids = set()
+    for i, t in hits:
+        if i in seen_ids:
+            continue
+        seen_ids.add(i)
+        parts.append("#%d: %s" % (i, t))
+    if parts:
+        logger.info("Possible tracker issues (Redmine search): %s", " | ".join(parts))

--- a/teuthology/util/test/test_redmine_suggest.py
+++ b/teuthology/util/test/test_redmine_suggest.py
@@ -1,0 +1,210 @@
+import logging
+
+from teuthology.util import redmine_suggest
+
+
+def test_failure_search_query():
+    assert redmine_suggest.failure_search_query("") == ""
+    long = "a " * 150
+    q = redmine_suggest.failure_search_query(long, max_len=20)
+    assert len(q) <= 20
+
+
+def test_normalize_failure_text_for_search_removes_host_noise():
+    text = (
+        "Command failed on ip-a-b-c-d with status 100: "
+        "'sudo DEBIAN_FRONTEND=noninteractive apt-get -y install linux-image-generic'"
+    )
+    out = redmine_suggest.normalize_failure_text_for_search(text)
+    assert "ip-a-b-c-d" not in out
+    assert "DEBIAN_FRONTEND=noninteractive" not in out
+    assert "sudo " not in out
+    assert "apt-get -y install linux-image-generic" in out
+
+
+def test_normalize_failure_text_for_search_handles_other_host_formats():
+    text = (
+        "Command failed on 10.20.30.40 with status 1: "
+        "'sudo curl https://node1.example.com/api/health'"
+    )
+    out = redmine_suggest.normalize_failure_text_for_search(text)
+    assert "10.20.30.40" not in out
+    assert "node1.example.com" not in out
+    assert "host/api/health" in out
+
+
+def test_normalize_failure_text_for_search_handles_plain_hostnames():
+    text = "Command failed on trial011 with status 1: 'sudo ceph -s'"
+    out = redmine_suggest.normalize_failure_text_for_search(text)
+    assert "trial011" not in out
+    assert "Command failed with status 1" in out
+
+
+def test_combined_failure_text_prefers_detail():
+    combined = redmine_suggest.combined_failure_text(
+        "reached maximum tries (50) after waiting for 300 seconds",
+        "Command failed on node with status 1: 'sudo ceph osd pool create rbd 8'",
+    )
+    assert combined.startswith("Command failed on node")
+    assert "caused by: reached maximum tries" not in combined
+
+
+def test_combined_failure_text_uses_reason_when_not_timeout():
+    combined = redmine_suggest.combined_failure_text(
+        "command exited with non-zero status",
+        "Command failed on node with status 1",
+    )
+    assert "caused by: command exited with non-zero status" in combined
+
+
+def test_combined_failure_text_adds_timeout_command_hint():
+    combined = redmine_suggest.combined_failure_text(
+        "status 124:  timeout 3h /home/ubuntu/cephtest/workunit.client.0/qa/workunits/rados/test.sh'",
+        "",
+    )
+    assert "timeout 3h running qa/workunits/rados/test.sh" in combined
+
+
+def test_is_generic_timeout_reason():
+    assert redmine_suggest.is_generic_timeout_reason(
+        "reached maximum tries (50) after waiting for 300 seconds"
+    )
+    assert redmine_suggest.is_generic_timeout_reason("hit max job timeout")
+    assert not redmine_suggest.is_generic_timeout_reason(
+        "Command failed on node with status 1"
+    )
+
+
+def test_extract_log_failure_hint_gtest(tmpdir):
+    p = tmpdir.join("teuthology.log")
+    p.write(
+        "\n".join(
+            [
+                "[ RUN      ] TestMigration.Stress2",
+                "[  FAILED  ] TestMigration.Stress2 (24944 ms)",
+            ]
+        )
+    )
+    hint = redmine_suggest.extract_log_failure_hint(str(p))
+    assert hint == "failed test: TestMigration.Stress2"
+
+
+def test_issue_id_from_search_result():
+    iid = redmine_suggest._issue_id_from_search_result(
+        {"url": "https://tracker.ceph.com/issues/12345", "title": "x", "type": "issue"}
+    )
+    assert iid == 12345
+    iid2 = redmine_suggest._issue_id_from_search_result(
+        {"title": "Issue #99 (Closed): hello", "type": "issue closed"}
+    )
+    assert iid2 == 99
+
+
+def test_redmine_search_issue_ids(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "results": [
+                    {
+                        "id": 1,
+                        "title": "Issue #1: T",
+                        "type": "issue",
+                        "url": "https://tracker.ceph.com/issues/1",
+                    },
+                    {
+                        "id": 2,
+                        "title": "Wiki",
+                        "type": "wiki-page",
+                        "url": "https://tracker.ceph.com/wiki/x",
+                    },
+                ]
+            }
+
+    def fake_get(url, params, timeout):
+        assert "search.json" in url
+        assert params.get("issues") == 1
+        return FakeResp()
+
+    monkeypatch.setattr(redmine_suggest.requests, "get", fake_get)
+    out = redmine_suggest.redmine_search_issue_ids(
+        "https://tracker.ceph.com", "query", limit=5
+    )
+    assert out == [(1, "Issue #1: T")]
+
+
+def test_log_redmine_suggestions_no_hits(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        redmine_suggest,
+        "redmine_search_issue_ids",
+        lambda base_url, query, limit=8: [],
+    )
+    redmine_suggest.log_redmine_suggestions_on_failure(
+        logging.getLogger("t"),
+        "some failure",
+        {},
+    )
+    assert not caplog.records
+
+
+def test_log_redmine_suggestions_uses_failure_reason_detail(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        redmine_suggest,
+        "redmine_search_issue_ids",
+        lambda base_url, query, limit=8: [(77, "Issue 77")],
+    )
+    redmine_suggest.log_redmine_suggestions_on_failure(
+        logging.getLogger("t"),
+        "reached maximum tries (50) after waiting for 300 seconds",
+        {"redmine_base_url": "https://tracker.ceph.com"},
+        failure_reason_detail=(
+            "Command failed on node with status 1: "
+            "'sudo ceph --cluster ceph osd pool create rbd 8'"
+        ),
+    )
+    assert any("#77" in r.message for r in caplog.records)
+
+
+def test_log_redmine_suggestions_uses_log_failure_hint(caplog, tmpdir, monkeypatch):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        redmine_suggest,
+        "redmine_search_issue_ids",
+        lambda base_url, query, limit=8: [(88, "Issue 88")],
+    )
+    teuthology_log = tmpdir.join("teuthology.log")
+    teuthology_log.write(
+        "\n".join(
+            [
+                "[ RUN      ] TestMigration.Stress2",
+                "[  FAILED  ] TestMigration.Stress2 (24944 ms)",
+                "1 FAILED TEST",
+            ]
+        )
+    )
+    redmine_suggest.log_redmine_suggestions_on_failure(
+        logging.getLogger("t"),
+        "reached maximum tries (50) after waiting for 300 seconds",
+        {"redmine_base_url": "https://tracker.ceph.com"},
+        teuthology_log_path=str(teuthology_log),
+    )
+    assert any("#88" in r.message for r in caplog.records)
+
+
+def test_log_redmine_suggestions_searches_without_api_key(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        redmine_suggest,
+        "redmine_search_issue_ids",
+        lambda base_url, query, limit=8: [(99, "Issue without key")],
+    )
+    redmine_suggest.log_redmine_suggestions_on_failure(
+        logging.getLogger("t"),
+        "some failure",
+        {"redmine_base_url": "https://tracker.ceph.com"},
+    )
+    assert any("#99" in r.message for r in caplog.records)


### PR DESCRIPTION
Log possible Redmine matches on job failure using normalized failure text, optional nested exception detail, and hints from teuthology.log