### PR TITLE
internal: fix core-dumps/debug-info collection

### DIFF
--- a/teuthology/task/internal/__init__.py
+++ b/teuthology/task/internal/__init__.py
@@ -299,6 +299,27 @@ def check_conflict(ctx, config):
         raise RuntimeError('Stale jobs detected, aborting.')
 
 
+def get_dump_program(file_info: str) -> str:
+    """
+    Parse the output of the file(1) command on a core dump to extract the
+    program that produced it. Prefers execfn (the actual file passed to
+    execve) over the 'from' field (argv[0], which can be overridden).
+
+    Raises ValueError if neither field can be parsed.
+    """
+    execfn_match = re.findall(r"execfn:\s*'([^']+)'", file_info)
+    if execfn_match:
+        program = execfn_match[0]
+        log.info(f' dump_program (from execfn): {program}')
+        return program
+    from_match = re.findall("from '([^ ']+)", file_info)
+    if from_match:
+        program = from_match[0].split()[0]
+        log.info(f' dump_program: {program}')
+        return program
+    raise ValueError(f"cannot parse program name from file output: {file_info}")
+
+
 def fetch_binaries_for_coredumps(path, remote):
     """
     Pul ELFs (debug and stripped) for each coredump found
@@ -334,34 +355,57 @@ def fetch_binaries_for_coredumps(path, remote):
                     log.error(e)
                     continue
             try:
-                dump_command = re.findall("from '([^ ']+)", dump_out)[0]
-                dump_program = dump_command.split()[0]
-                log.info(f' dump_program: {dump_program}')
-            except Exception as e:
+                dump_program = get_dump_program(dump_out)
+            except ValueError as e:
                 log.info("core doesn't have the desired format, moving on ...")
                 log.error(e)
                 continue
 
             # Find path on remote server:
-            remote_path = remote.sh(['which', dump_program]).rstrip()
+            if os.path.isabs(dump_program):
+                remote_path = dump_program
+            else:
+                remote_path = remote.sh(['which', dump_program]).rstrip()
 
             # Pull remote program into coredump folder:
             local_path = os.path.join(coredump_path,
-                                      dump_program.lstrip(os.path.sep))
+                                      remote_path.lstrip(os.path.sep))
             local_dir = os.path.dirname(local_path)
             if not os.path.exists(local_dir):
                 os.makedirs(local_dir)
             remote._sftp_get_file(remote_path, local_path)
 
+            # Resolve symlinks (e.g. update-alternatives) so the
+            # debug path matches the debuginfo package contents.
+            try:
+                resolved_path = remote.sh(
+                    ['readlink', '-f', remote_path]).rstrip()
+                if resolved_path:
+                    remote_path = resolved_path
+            except Exception:
+                pass
+
             # Pull Debug symbols:
-            debug_path = os.path.join('/usr/lib/debug', remote_path)
+            debug_dir = os.path.dirname(os.path.join(
+                '/usr/lib/debug', remote_path.lstrip(os.path.sep)))
+            binary_name = os.path.basename(remote_path)
 
-            # RPM distro's append their non-stripped ELF's with .debug
-            # When deb based distro's do not.
             if remote.system_type == 'rpm':
-                debug_path = '{debug_path}.debug'.format(debug_path=debug_path)
+                # RPM debuginfo packages may include the version-release-arch
+                # in the filename, so use find to locate the debug file.
+                find_out = remote.sh([
+                    'find', debug_dir, '-maxdepth', '1',
+                    '-name', f'{binary_name}*.debug',
+                ]).rstrip()
+                if find_out:
+                    debug_path = find_out.splitlines()[0]
+                else:
+                    debug_path = os.path.join(debug_dir,
+                                              f'{binary_name}.debug')
+            else:
+                debug_path = os.path.join(debug_dir, binary_name)
 
-            remote.get_file(debug_path, coredump_path)
+            remote.get_file(debug_path, dest_dir=coredump_path)
 
 
 def gzip_if_too_large(compress_min_size, src, tarinfo, local_path):

--- a/teuthology/task/tests/test_fetch_coredumps.py
+++ b/teuthology/task/tests/test_fetch_coredumps.py
@@ -1,7 +1,8 @@
-from teuthology.task.internal import fetch_binaries_for_coredumps
+from teuthology.task.internal import fetch_binaries_for_coredumps, get_dump_program
 from unittest.mock import patch, Mock
 import gzip
 import os
+import pytest
 
 class TestFetchCoreDumps(object):
     class MockDecode(object):
@@ -30,6 +31,12 @@ class TestFetchCoreDumps(object):
             " x86-64, version 1 (SYSV), SVR4-style, from 'ceph_test_rados_api_io',"\
             " real uid: 1194, effective uid: 1194, real gid: 1194,"\
             " effective gid: 1194, execfn: '/usr/bin/ceph_test_rados_api_io', platform: 'x86_64'"
+        )
+        self.uncompressed_execfn_differs = self.MockPopen(
+            "ELF 64-bit LSB core file,"\
+            " x86-64, version 1 (SYSV), SVR4-style, from 'ceph-osd -f --cluster ceph',"\
+            " real uid: 1194, effective uid: 1194, real gid: 1194,"\
+            " effective gid: 1194, execfn: '/usr/bin/crimson-osd', platform: 'x86_64'"
         )
         self.uncompressed_incorrect = self.MockPopen("ASCII text")
         self.compressed_correct = self.MockPopen(
@@ -112,5 +119,44 @@ class TestFetchCoreDumps(object):
         self.the_function(None, self.m_remote)
         assert self.m_remote.get_file.called == False
 
+    # execfn differs from 'from' field (which may be spoofed)
+    @patch('teuthology.task.internal.subprocess.Popen')
+    @patch('teuthology.task.internal.os')
+    def test_execfn_preferred_over_from(self, m_os, m_subproc_popen):
+        m_subproc_popen.side_effect = [
+                self.uncompressed_execfn_differs,
+                Exception("We shouldn't be hitting this!")
+            ]
+        m_os.path.join.return_value = self.core_dump_path
+        m_os.path.sep = '/'
+        m_os.path.isabs.return_value = True
+        m_os.path.isdir.return_value = True
+        m_os.path.dirname.return_value = self.core_dump_path
+        m_os.path.exists.return_value = True
+        m_os.listdir.return_value = [self.core_dump_path]
+        self.the_function(None, self.m_remote)
+        assert self.m_remote._sftp_get_file.called
+
     def teardown(self):
         os.remove(self.core_dump_path)
+
+
+class TestGetDumpProgram(object):
+    def test_execfn_preferred_over_from(self):
+        file_info = (
+            "ELF 64-bit LSB core file, x86-64, version 1 (SYSV), SVR4-style,"
+            " from 'ceph-osd -f --cluster ceph',"
+            " execfn: '/usr/bin/crimson-osd', platform: 'x86_64'"
+        )
+        assert get_dump_program(file_info) == '/usr/bin/crimson-osd'
+
+    def test_from_field_when_no_execfn(self):
+        file_info = (
+            "ELF 64-bit LSB core file, x86-64, version 1 (SYSV), SVR4-style,"
+            " from 'radosgw --rgw-socket-path /tmp/sock'"
+        )
+        assert get_dump_program(file_info) == 'radosgw'
+
+    def test_raises_on_unparseable(self):
+        with pytest.raises(ValueError):
+            get_dump_program("ASCII text")


### PR DESCRIPTION
... especially for Crimson OSDs.

Specifically:
- use the value of execfn to identify the correct binary;
- correctly handle absolute paths when constructing the debug symbol path (stripping the leading separator before joining);
- find versioned debuginfo files instead of assuming an exact basename.