### PR TITLE
task/install/deb: fix apt key fetch hanging when http is blocked

### DIFF
--- a/teuthology/task/install/deb.py
+++ b/teuthology/task/install/deb.py
@@ -57,7 +57,7 @@ def _update_package_list_and_install(ctx, remote, debs, config):
         remote.run(
             args=[
                 'wget', '-q', '-O-',
-                'http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc',  # noqa
+                'https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc',  # noqa
                 run.Raw('|'),
                 'sudo', 'apt-key', 'add', '-',
             ],
@@ -198,7 +198,7 @@ def _upgrade_packages(ctx, config, remote, debs):
         remote.run(
             args=[
                 'wget', '-q', '-O-',
-                'http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc',  # noqa
+                'https://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc',  # noqa
                 run.Raw('|'),
                 'sudo', 'apt-key', 'add', '-',
             ],


### PR DESCRIPTION
### Problem

The install task fetches the Ceph autobuild GPG key over plain HTTP:

`wget http://git.ceph.com/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc | sudo apt-key add -`
git.ceph.com only serves over HTTPS. When the HTTP URL is used, wget either hangs until timeout or returns no data, causing apt-key add to fail with:

```
gpg: no valid OpenPGP data found
CommandFailedError: Command failed with status 2
```
This affects all Ubuntu/Debian jobs that run on nodes where the Ceph GPG key is not already cached in the keyring.

### Fix

Replace http:// with https:// at both occurrences in teuthology/task/install/deb.py — in _update_package_list_and_install and _upgrade_packages.