### PR TITLE
lupa: update to 2.8 and use lua 5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "gevent>=24.10.1,<25",
     "httplib2",
     "humanfriendly",
-    "lupa",
+    "lupa>=2.8",
     "lxml",
     "netaddr",
     "oauthlib",

--- a/teuthology/suite/merge.py
+++ b/teuthology/suite/merge.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-import lupa
+import lupa.lua54 as lupa
 import os
 from types import MappingProxyType
 import yaml


### PR DESCRIPTION
Do not incidentally upgrade Lua to 5.5.