### PR TITLE
teuthology/task/kernel: use sudo to examine grub.cfg

### DIFF
--- a/teuthology/task/kernel.py
+++ b/teuthology/task/kernel.py
@@ -550,6 +550,7 @@ def install_and_reboot(ctx, need_install, config):
         # complex this will totally break.
 
         kernel_entries = role_remote.sh([
+                'sudo',
                 'grep', '-E',
                 '(submenu|menuentry.*' + kernel_title + ').*{',
                 '/boot/grub/grub.cfg'


### PR DESCRIPTION
Ubuntu 24.04 apparently protects this:

    2026-05-24T09:00:23.747 DEBUG:teuthology.orchestra.run:got remote process result: 2
    2026-05-24T09:00:23.747 INFO:teuthology.orchestra.run.trial136.stderr:grep: /boot/grub/grub.cfg: Permission denied