### PR TITLE
containers/teuthology-dev: Skip epel during ansible

### DIFF
--- a/containers/teuthology-dev/containerized_node.yaml
+++ b/containers/teuthology-dev/containerized_node.yaml
@@ -1,6 +1,6 @@
 overrides:
   ansible.cephlab:
-    skip_tags: "timezone,nagios,monitoring-scripts,ssh,hostname,pubkeys,zap,sudoers,kerberos,selinux,lvm,ntp-client,resolvconf,packages,cpan,nfs"
+    skip_tags: "timezone,nagios,monitoring-scripts,ssh,hostname,pubkeys,zap,sudoers,kerberos,selinux,lvm,ntp-client,resolvconf,packages,cpan,nfs,epel"
     vars:
       containerized_node: true
       start_rpcbind: false


### PR DESCRIPTION
This may have been broken by https://github.com/ceph/ceph-sepia-secrets/pull/1132