### PR TITLE
teuthology/repo_utils: update shallow references

### DIFF
--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -233,7 +233,7 @@ def fetch_bare_repo(bare_dir, url, branch, commit=None):
             return
 
     log.debug("Commit not present or not specified; fetching from remote")
-    args = ['git', 'fetch', url]
+    args = ['git', 'fetch', '--update-shallow', url]
     if commit is not None:
         args.append(commit)
     else:


### PR DESCRIPTION
If the remote itself is shallow, otherwise the fetch will fail:

    batrick@menzoberranzan ~/trash/test$ git fetch https://git.ceph.com/ceph-cm-ansible.git main
    remote: Enumerating objects: 11626, done.
    remote: Counting objects: 100% (11626/11626), done.
    remote: Compressing objects: 100% (4150/4150), done.
    remote: Total 11626 (delta 7278), reused 10977 (delta 6899), pack-reused 0 (from 0)
    Receiving objects: 100% (11626/11626), 3.20 MiB | 40.43 MiB/s, done.
    Resolving deltas: 100% (7278/7278), done.
    warning: rejected refs/heads/main because shallow roots are not allowed to be updated

Fixes: https://tracker.ceph.com/issues/77076