### PR TITLE
suite: ignore transient MON_DOWN and FS_DEGRADED in default log-ignorelist

### DIFF
--- a/teuthology/suite/placeholder.py
+++ b/teuthology/suite/placeholder.py
@@ -82,7 +82,10 @@ dict_templ = {
             },
             'flavor': Placeholder('flavor'),
             'log-ignorelist': [r'\(MDS_ALL_DOWN\)',
-                              r'\(MDS_UP_LESS_THAN_MAX\)'],
+                              r'\(MDS_UP_LESS_THAN_MAX\)',
+                              r'\(MON_DOWN\)',
+                              r'\(FS_DEGRADED\)'
+                            ],
             'sha1': Placeholder('ceph_hash'),
         },
         'ceph-deploy': {


### PR DESCRIPTION
## Summary

- Add `\(MON_DOWN\)` and `\(FS_DEGRADED\)` to the default `ceph.log-ignorelist` in `teuthology/suite/placeholder.py` (`dict_templ`).
- These join the existing `MDS_ALL_DOWN` and `MDS_UP_LESS_THAN_MAX` entries applied to every job scheduled via `teuthology-suite`.

Smoke jobs are failing at teardown when `tasks.ceph` greps `/var/log/ceph/ceph.log` for `[WRN]`, even though the workunits themselves passed:

- **MON_DOWN** — e.g. `rados_python` on trial reported `1/3 mons down, quorum a,c` while tests passed; the same job passed on rerun ([adinda Jun 4 rerun](https://pulpito.ceph.com/adinda-2026-06-04_13:13:18-smoke-main-distro-default-trial/)).
- **FS_DEGRADED** — expected during `ceph_test_libcephfs_reclaim` / `ReclaimResetAfterMDSFailover`, which intentionally restarts MDS; libcephfs gtests pass but cluster log still contains the warning (OpenStack smoke).

This matches how other suites already treat these warnings (e.g. cephfs `ignorelist_health.yaml`, rados/mon thrash jobs).