### PR TITLE
pyproject: set minimum python3.12 as requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
-            python: "3.10"
-          - os: ubuntu-22.04
-            python: "3.11"
           - os: ubuntu-24.04
             python: "3.12"
+          - os: ubuntu-26.04
+            python: "3.14"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
-            python: "3.10"
-          - os: ubuntu-22.04
-            python: "3.11"
+          - os: ubuntu-24.04
+            python: "3.12"
+          - os: ubuntu-24.04
+            python: "3.14"
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@
 version: 2
 formats: []
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.12"
 python:
   install:
     - method: pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = "Ceph test framework"
 readme = "README.rst"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "ansible-core==2.17.7",
     "apache-libcloud",
@@ -49,10 +49,9 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",


### PR DESCRIPTION
Maybe it's time to say goodbye to <python3.12 and to four years old distros?