### PR TITLE
packaging: use major version for Pulp `distro_version` label

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -922,6 +922,28 @@ class TestPulpProject(TestBuilderProject):
         assert 'branch=jewel' in labels
         assert 'sha1=sha1' not in labels
 
+    @pytest.mark.parametrize(
+        'os_type,os_version,codename,expected',
+        [
+            ('rocky', '9.7', None, 'distro_version=9'),
+            ('rocky', '10.1', None, 'distro_version=10'),
+            ('alma', '9.7', None, 'distro_version=9'),
+            ('centos', '8.1', None, 'distro_version=8'),
+            ('rhel', '7.0', None, 'distro_version=7'),
+            ('ubuntu', '20.04', 'focal', 'distro_version=focal'),
+        ],
+    )
+    def test_search_uses_major_distro_version(
+            self, os_type, os_version, codename, expected):
+        config = dict(os_type=os_type, os_version=os_version)
+        if codename:
+            config['codename'] = codename
+        gp = self.klass('ceph', config)
+        gp._search()
+        labels = self.m_get.call_args[1]['params']['pulp_label_select']
+        assert expected in labels
+        assert f'distro_version={os_version},' not in labels
+
     def test_get_package_version_found(self):
         resp = Mock()
         resp.ok = True

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -1164,7 +1164,12 @@ class PulpProject(GitbuilderProject):
         labels = f'project={self.project},'
         labels += f'flavors={self.flavor},'
         labels += f'distro={self.os_type},'
-        labels += f'distro_version={self.os_version},'
+        distro_version = self._get_distro(
+            distro=self.os_type,
+            version=self.os_version,
+            codename=self.codename,
+        ).split('/', 1)[1]
+        labels += f'distro_version={distro_version},'
 
         # Add the architecture to the search parameters.
         arch = 'noarch' if self.force_noarch else self.arch


### PR DESCRIPTION
`PulpProject._search()` was sending the full `os_version` in the `distro_version` Pulp label, while repo paths and Shaman use the major version. Derive `distro_version` from `_get_distro()` so RPM distros search by major release and deb distros still use codename.

Sample testrun - 
```
(teuthology) [vamahaja@folio03 teuthology]$ teuthology-suite -p 50 -m trial -d rocky -D 10.1 -l 1 --subset 1/23 -s smoke -c tentacle -S 81f1fcbeb4eb4dde9aee5367cac15684467a119c
2026-06-22 13:26:15,906.906 INFO:teuthology.suite:Using random seed=2964
2026-06-22 13:26:15,906.906 INFO:teuthology.suite.run:Checking for expiration (None)
2026-06-22 13:26:15,906.906 INFO:teuthology.suite.run:kernel sha1: distro
2026-06-22 13:26:16,411.411 INFO:teuthology.suite.run:ceph sha1 explicitly supplied
2026-06-22 13:26:16,411.411 INFO:teuthology.suite.run:ceph sha1: 81f1fcbeb4eb4dde9aee5367cac15684467a119c
2026-06-22 13:26:16,666.666 INFO:teuthology.suite.run:ceph branch: tentacle 2cc1b1302259e8f3cf00c5979068acd39cbd0048
2026-06-22 13:26:16,666.666 INFO:teuthology.repo_utils:enforce_repo_state dest_clone=/home/vamahaja/.teuthology/src/github.com_ceph_ceph dest_path=/home/vamahaja/.teuthology/src/github.com_ceph_ceph_2cc1b1302259e8f3cf00c5979068acd39cbd0048 repo_url=https://github.com/ceph/ceph.git branch=tentacle commit=2cc1b1302259e8f3cf00c5979068acd39cbd0048
2026-06-22 13:26:16,666.666 INFO:teuthology.repo_utils:Fetching into bare repo /home/vamahaja/.teuthology/src/github.com_ceph_ceph from https://github.com/ceph/ceph.git (branch: tentacle, commit: 2cc1b1302259e8f3cf00c5979068acd39cbd0048)
2026-06-22 13:26:16,670.670 INFO:teuthology.repo_utils:Setting up worktree at /home/vamahaja/.teuthology/src/github.com_ceph_ceph_2cc1b1302259e8f3cf00c5979068acd39cbd0048 from bare repo /home/vamahaja/.teuthology/src/github.com_ceph_ceph using ref 2cc1b1302259e8f3cf00c5979068acd39cbd0048
2026-06-22 13:26:16,685.685 INFO:teuthology.suite.run:teuthology branch: packaging-rocky-version e0d9ed7c8d9ea372e55028652251484d3c96b212
2026-06-22 13:26:16,700.700 INFO:teuthology.suite.build_matrix:Subset=1/23
2026-06-22 13:26:16,702.702 INFO:teuthology.suite.run:Suite smoke in /home/vamahaja/.teuthology/src/github.com_ceph_ceph_2cc1b1302259e8f3cf00c5979068acd39cbd0048/qa/suites/smoke generated 23 jobs (not yet filtered or merged)
2026-06-22 13:26:16,759.759 INFO:teuthology.packaging:Using pulp project: pulp
2026-06-22 13:26:16,759.759 INFO:teuthology.packaging:Using pulp project: pulp
2026-06-22 13:26:16,975.975 INFO:teuthology.suite.run:Stopped after 1 jobs due to --limit=1
Job scheduled with name vamahaja-2026-06-22_13:26:15-smoke-tentacle-distro-default-trial and ID 216
2026-06-22 13:26:19,034.034 INFO:teuthology.suite.run:Scheduling smoke/basic/{clusters/{fixed-3-cephfs} objectstore/bluestore-bitmap supported-random-distro$/{rpm_latest} tasks/{0-install test/kclient_workunit_suites_dbench}}
Job scheduled with name vamahaja-2026-06-22_13:26:15-smoke-tentacle-distro-default-trial and ID 217
2026-06-22 13:26:21,147.147 INFO:teuthology.suite.run:Suite smoke in /home/vamahaja/.teuthology/src/github.com_ceph_ceph_2cc1b1302259e8f3cf00c5979068acd39cbd0048/qa/suites/smoke scheduled 1 jobs.
2026-06-22 13:26:21,147.147 INFO:teuthology.suite.run:22/23 jobs were filtered out.
2026-06-22 13:26:21,147.147 INFO:teuthology.suite.run:Scheduled 1 jobs in total.
Job scheduled with name vamahaja-2026-06-22_13:26:15-smoke-tentacle-distro-default-trial and ID 218
2026-06-22 13:26:23,202.202 INFO:teuthology.suite.run:Test results viewable at http://172.21.5.153:9091/vamahaja-2026-06-22_13:26:15-smoke-tentacle-distro-default-trial/
```