### PR TITLE
teuthology-node-cleanup: further tweak output, and add systemd timer files

### DIFF
--- a/scripts/node_cleanup.py
+++ b/scripts/node_cleanup.py
@@ -15,10 +15,12 @@ def main():
         teuthology.log.setLevel(logging.DEBUG)
     else:
         teuthology.log.setLevel(100)
+    # regardless of verbosity we do not want to log console stuff
+    logging.getLogger("teuthology.orchestra.console").setLevel(logging.WARNING)
     logger = logging.getLogger()
     for handler in logger.handlers:
         handler.setFormatter(
-            logging.Formatter('%(message)s')
+            logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
         )
     try:
         stale = query.find_stale_locks(
@@ -28,8 +30,8 @@ def main():
     except Exception:
         log.exception(f"Error while check for stale locks held by {args.owner}")
         return
+    log.debug(f"Stale nodes: {len(stale)}")
     if not stale:
-        log.debug("No stale nodes found.")
         return
     by_owner = {}
     for node in stale:
@@ -50,7 +52,7 @@ def main():
     else:
         for owner, nodes in by_owner.items():
             ops.unlock_safe([node["name"] for node in nodes], owner)
-    log.info(f"unlocked {len(stale)} nodes")
+    log.info(f"Unlocked {len(stale)} nodes")
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(

--- a/systemd/teuthology-node-cleanup@.service
+++ b/systemd/teuthology-node-cleanup@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Teuthology Node Cleanup
+
+[Service]
+Type=simple
+User=teuthworker
+Environment=REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ExecSearchPath=/home/teuthworker/src/teuthology_main/.venv/bin
+ExecStart=uv run teuthology-node-cleanup --machine-type %i

--- a/systemd/teuthology-node-cleanup@.timer
+++ b/systemd/teuthology-node-cleanup@.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run Teuthology Node Cleanup
+
+[Timer]
+OnUnitActiveSec=15m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
this tool runs regularly in Sepia; I've done it with cron in the past but the systemd way is easier to represent in this repo, and lets us query the journal for its output separately