### PR TITLE
task/ansible: mark nodes down on hardware failures

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Content Index
    downburst_vms.rst
    INSTALL.rst
    LAB_SETUP.rst
+   node_health.rst
    exporter.rst
    commands/list.rst
    ChangeLog.rst

--- a/docs/node_health.rst
+++ b/docs/node_health.rst
@@ -1,0 +1,100 @@
+.. _node_health:
+
+===================
+Marking Nodes Down
+===================
+
+Every node in the lock server (paddles) has an ``up`` flag. A node that is
+marked down is never handed out to a job, so a broken machine stops eating
+scheduled jobs until someone looks at it. Nodes are marked down by hand with
+``teuthology-lock --update --status down <node>``, and automatically by
+``teuthology-supervisor`` in the two cases described below.
+
+All of this happens in the supervisor process, not in the job process. Tasks
+never talk to paddles about node status: a job should not depend on the lock
+server being reachable, and the supervisor is what owns the nodes for the
+duration of a job anyway.
+
+Repeated reimaging failures
+===========================
+
+If reimaging a node fails, the supervisor asks paddles for that node's last 10
+jobs. If all 10 of them failed to reimage, the node is marked down with the
+description ``reimage failed 10 times``. See
+``check_for_reimage_failures_and_mark_down()`` in
+``teuthology/dispatcher/supervisor.py``.
+
+Failures reported by ansible
+============================
+
+Some ansible failures tell us right away that the node itself is broken - a
+disk that is missing or dead, for example. Waiting for that node to fail ten
+more jobs is a waste, so the supervisor marks it down as soon as it sees one.
+
+Which failures count is up to the site config; nothing is marked down unless
+``disable_targets.ansible_failure_patterns`` says so.
+
+How it works
+------------
+
+#. The ``ansible`` task sets ``ANSIBLE_FAILURE_LOG`` when it runs
+   ``ansible-playbook``. ceph-cm-ansible's ``failure_log`` callback plugin
+   (``callback_plugins/failure_log.py``) writes every task failure to that
+   file as YAML.
+#. When the playbook fails, the task archives the log to
+   ``ansible_failures.yaml`` in the job's archive directory.
+#. After the job process exits, the supervisor reads that file back and passes
+   it, along with the patterns configured for the job's machine type, to
+   ``FailureAnalyzer.find_matching_failures()`` in
+   ``teuthology/task/ansible.py``.
+#. Any node whose failure message matches is marked down, as long as it is one
+   of the job's own targets. This is
+   ``check_for_ansible_failures_and_mark_down()`` in
+   ``teuthology/dispatcher/supervisor.py``.
+
+Nodes are always marked down before they're unlocked, so another job can't grab
+one in the meantime. The description is set afterwards, to ``ansible failure:
+<msg>``, so the reason shows up in ``teuthology-lock --list`` - it can't be set
+any earlier because ``unlock_targets()`` matches on it. A node that was left
+locked on purpose (``unlock_on_failure: false``) keeps its description so it
+can still be unlocked later.
+
+Expected format
+---------------
+
+The failure log is a YAML document keyed by hostname, with each value being the
+ansible result dict for the failed task. Only the ``msg`` field is examined,
+either on the record itself or on each entry of its ``results`` list::
+
+    trial007.front.sepia.ceph.com:
+      _ansible_no_log: false
+      changed: false
+      msg: 'Wanted 2 disks of ~1700 GB (rotational=False), but only matched 1: [''nvme1n1'']'
+
+The callback plugin records the result, not the name of the task that produced
+it, so matching is done on the message text. Whitespace in ``msg`` is collapsed
+first, because ansible wraps long messages across lines.
+
+Configuring the patterns
+------------------------
+
+``disable_targets.ansible_failure_patterns`` in :ref:`site_config` maps a
+machine type to a list of regular expressions, matched case-insensitively
+against the message. A machine type with no patterns never gets marked down
+this way. This is what we use in sepia::
+
+    disable_targets:
+      ansible_failure_patterns:
+        # "Ensure we found enough OSD disks" in ceph-cm-ansible's
+        # roles/testnode/tasks/configure_lvm.yml
+        trial: &missing_osd_devices
+          - 'Wanted \d+ disks? of .+ but only matched \d+'
+        gibba: *missing_osd_devices
+        smithi: *missing_osd_devices
+
+Use single quotes, or YAML will choke on the backslashes.
+
+Keep in mind that a pattern ties us to the exact wording of a task in
+ceph-cm-ansible: reword the task, and the pattern needs the same change. Only
+add patterns for failures that really do mean the node is broken - a node
+marked down stays down until someone brings it back up.

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -96,6 +96,16 @@ Here is a sample configuration with many of the options set and documented::
     # it is killed by the supervisor process.
     max_job_time: 259200
 
+    # Ansible failure messages that mean a node is broken, per machine type.
+    # The supervisor marks a node down when its ansible failure matches one of
+    # these. See :ref:`node_health`.
+    disable_targets:
+      ansible_failure_patterns:
+        trial: &missing_osd_devices
+          - 'Wanted \d+ disks? of .+ but only matched \d+'
+        gibba: *missing_osd_devices
+        smithi: *missing_osd_devices
+
     # The template from which the URL of the repository containing packages
     # is built.
     #

--- a/tests/dispatcher/test_ansible_failure_mark_machine_down.py
+++ b/tests/dispatcher/test_ansible_failure_mark_machine_down.py
@@ -1,0 +1,156 @@
+import os
+import yaml
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from teuthology.config import config
+from teuthology.dispatcher import supervisor
+
+
+MISSING_OSD_DEVICES = r'Wanted \d+ disks? of .+ but only matched \d+'
+
+DISK_FAILURE = {
+    'trial007.front.sepia.ceph.com': {
+        '_ansible_no_log': False,
+        'changed': False,
+        'msg': "Wanted 2 disks of ~1700 GB (rotational=False), but only"
+               " matched 1: ['nvme1n1']",
+    },
+}
+
+OTHER_FAILURE = {
+    'trial007.front.sepia.ceph.com': {
+        'changed': False,
+        'msg': 'Failure talking to yum: failure',
+    },
+}
+
+
+class TestCheckAnsibleFailureMarkDown(object):
+    def setup_method(self):
+        # don't depend on whatever lab_domain the site config has
+        self.orig_lab_domain = config.lab_domain
+        config.lab_domain = 'front.sepia.ceph.com'
+        self.the_function = supervisor.check_for_ansible_failures_and_mark_down
+        self.patcher = patch.object(
+            supervisor,
+            'teuth_config',
+            SimpleNamespace(disable_targets=dict(
+                ansible_failure_patterns=dict(trial=[MISSING_OSD_DEVICES]),
+            )),
+        )
+        self.patcher.start()
+
+    def teardown_method(self, method):
+        self.patcher.stop()
+        config.lab_domain = self.orig_lab_domain
+
+    def job_config(self, tmp_path, failure_log=None, targets=None):
+        if failure_log is not None:
+            path = os.path.join(str(tmp_path), supervisor.FAILURE_LOG_NAME)
+            with open(path, 'w') as f:
+                yaml.safe_dump(failure_log, f)
+        if targets is None:
+            targets = {
+                'ubuntu@trial007.front.sepia.ceph.com': 'ssh-ed25519',
+            }
+        return dict(
+            archive_path=str(tmp_path),
+            machine_type='trial',
+            targets=targets,
+        )
+
+    @patch('teuthology.lock.ops.update_lock')
+    def test_disk_failure(self, m_update_lock, tmp_path):
+        job_config = self.job_config(tmp_path, DISK_FAILURE)
+        assert self.the_function(job_config) == {
+            'trial007': DISK_FAILURE['trial007.front.sepia.ceph.com']['msg'],
+        }
+        m_update_lock.assert_called_once_with('trial007', status='down')
+
+    @patch('teuthology.lock.ops.update_lock')
+    def test_other_failure(self, m_update_lock, tmp_path):
+        job_config = self.job_config(tmp_path, OTHER_FAILURE)
+        self.the_function(job_config)
+        assert m_update_lock.called is False
+
+    @patch('teuthology.lock.ops.update_lock')
+    def test_no_failure_log(self, m_update_lock, tmp_path):
+        job_config = self.job_config(tmp_path)
+        self.the_function(job_config)
+        assert m_update_lock.called is False
+
+    @patch('teuthology.lock.ops.update_lock')
+    def test_host_is_not_a_target(self, m_update_lock, tmp_path):
+        job_config = self.job_config(
+            tmp_path,
+            DISK_FAILURE,
+            targets={'ubuntu@trial008.front.sepia.ceph.com': 'ssh-ed25519'},
+        )
+        self.the_function(job_config)
+        assert m_update_lock.called is False
+
+    @patch('teuthology.lock.ops.update_lock')
+    def test_no_patterns_for_machine_type(self, m_update_lock, tmp_path):
+        job_config = self.job_config(tmp_path, DISK_FAILURE)
+        job_config['machine_type'] = 'smithi'
+        self.the_function(job_config)
+        assert m_update_lock.called is False
+
+    @patch('teuthology.lock.ops.update_lock')
+    def test_not_configured(self, m_update_lock, tmp_path):
+        job_config = self.job_config(tmp_path, DISK_FAILURE)
+        with patch.object(
+            supervisor, 'teuth_config', SimpleNamespace(disable_targets=dict())
+        ):
+            self.the_function(job_config)
+        assert m_update_lock.called is False
+
+    @patch('teuthology.lock.ops.update_lock')
+    def test_unparseable_failure_log(self, m_update_lock, tmp_path):
+        job_config = self.job_config(tmp_path)
+        path = os.path.join(str(tmp_path), supervisor.FAILURE_LOG_NAME)
+        with open(path, 'w') as f:
+            f.write('{not: valid: yaml')
+        self.the_function(job_config)
+        assert m_update_lock.called is False
+
+
+class TestDescribeDisabledTargets(object):
+    def setup_method(self):
+        self.orig_lab_domain = config.lab_domain
+        config.lab_domain = 'front.sepia.ceph.com'
+        self.the_function = supervisor.describe_disabled_targets
+        self.failures = {'trial007': 'Wanted 2 disks, but only matched 1'}
+
+    def teardown_method(self, method):
+        config.lab_domain = self.orig_lab_domain
+
+    @patch('teuthology.lock.ops.update_lock')
+    @patch('teuthology.lock.query.get_statuses')
+    def test_unlocked(self, m_get_statuses, m_update_lock):
+        m_get_statuses.return_value = [
+            dict(name='trial007.front.sepia.ceph.com', locked=False),
+        ]
+        self.the_function(self.failures)
+        m_update_lock.assert_called_once_with(
+            'trial007',
+            description='ansible failure: Wanted 2 disks, but only matched 1',
+        )
+
+    @patch('teuthology.lock.ops.update_lock')
+    @patch('teuthology.lock.query.get_statuses')
+    def test_still_locked(self, m_get_statuses, m_update_lock):
+        m_get_statuses.return_value = [
+            dict(name='trial007.front.sepia.ceph.com', locked=True),
+        ]
+        self.the_function(self.failures)
+        assert m_update_lock.called is False
+
+    @patch('teuthology.lock.ops.update_lock')
+    @patch('teuthology.lock.query.get_statuses')
+    def test_no_failures(self, m_get_statuses, m_update_lock):
+        self.the_function(dict())
+        assert m_get_statuses.called is False
+        assert m_update_lock.called is False

--- a/tests/task/test_ansible.py
+++ b/tests/task/test_ansible.py
@@ -56,6 +56,76 @@ class TestFailureAnalyzer:
         obj = self.klass()
         assert obj.analyze_line(line) == result
 
+    @mark.parametrize(
+        'failure_log,result',
+        [
+            [
+                "",
+                {},
+            ],
+            [
+                yaml.safe_dump({
+                    "smithi001.front.sepia.ceph.com": {
+                        "changed": False,
+                        "msg": "Failure talking to yum: failure",
+                    },
+                }),
+                {},
+            ],
+            [
+                yaml.safe_dump({
+                    "trial007.front.sepia.ceph.com": {
+                        "_ansible_no_log": False,
+                        "changed": False,
+                        "msg": "Wanted 2 disks of ~1700 GB (rotational=False),"
+                               " but only matched 1: ['nvme1n1']",
+                    },
+                }),
+                {
+                    "trial007.front.sepia.ceph.com":
+                        "Wanted 2 disks of ~1700 GB (rotational=False), but"
+                        " only matched 1: ['nvme1n1']",
+                },
+            ],
+            [
+                # ansible wraps the message onto multiple lines
+                yaml.safe_dump({
+                    "trial007.front.sepia.ceph.com": {
+                        "msg": "Wanted 2 disks of ~1700 GB\n"
+                               "(rotational=False), but only matched\n"
+                               "1: ['nvme1n1']",
+                    },
+                }),
+                {
+                    "trial007.front.sepia.ceph.com":
+                        "Wanted 2 disks of ~1700 GB (rotational=False), but"
+                        " only matched 1: ['nvme1n1']",
+                },
+            ],
+            [
+                yaml.safe_dump({
+                    "trial007.front.sepia.ceph.com": {
+                        "results": [
+                            {"msg": "Failure talking to yum: failure"},
+                            {"msg": "Wanted 2 disks of ~1700 GB"
+                                    " (rotational=False), but only matched 0:"
+                                    " []"},
+                        ],
+                    },
+                }),
+                {
+                    "trial007.front.sepia.ceph.com":
+                        "Wanted 2 disks of ~1700 GB (rotational=False), but"
+                        " only matched 0: []",
+                },
+            ],
+        ]
+    )
+    def test_find_matching_failures(self, failure_log, result):
+        obj = self.klass()
+        patterns = [r"Wanted \d+ disks? of .+ but only matched \d+"]
+        assert obj.find_matching_failures(failure_log, patterns) == result
+
 
 class TestAnsibleTask(TestTask):
     klass = Ansible

--- a/teuthology/config.py
+++ b/teuthology/config.py
@@ -162,6 +162,9 @@ class TeuthologyConfig(YamlConfig):
         'gitbuilder_host': 'gitbuilder.ceph.com',
         'githelper_base_url': 'https://githelper.ceph.com',
         'check_package_signatures': True,
+        'disable_targets': {
+            'ansible_failure_patterns': {},
+        },
         'job_threshold': 500,
         'lab_domain': 'front.sepia.ceph.com',
         'lock_server': 'https://paddles.front.sepia.ceph.com/',

--- a/teuthology/dispatcher/supervisor.py
+++ b/teuthology/dispatcher/supervisor.py
@@ -16,6 +16,7 @@ from teuthology.misc import get_user, archive_logs, compress_logs
 from teuthology.config import FakeNamespace
 from teuthology.lock import ops as lock_ops
 from teuthology.task import internal
+from teuthology.task.ansible import FailureAnalyzer, FAILURE_LOG_NAME
 from teuthology.misc import decanonicalize_hostname as shortname
 from teuthology.lock import query
 from teuthology.util import sentry
@@ -181,7 +182,11 @@ def run_job(job_config: dict,
     else:
         log.info('Success!')
     if 'targets' in job_config:
+        # Always mark nodes down before unlocking them. Otherwise another job
+        # can grab a broken node before we get to it.
+        failures = check_for_ansible_failures_and_mark_down(job_config)
         unlock_targets(job_config)
+        describe_disabled_targets(failures)
     return p.returncode
 
 def failure_is_reimage(failure_reason):
@@ -225,6 +230,96 @@ def check_for_reimage_failures_and_mark_down(targets, count=10):
         log.error(
             'Reimage failed {0} times ... marking machine down'.format(count)
         )
+
+
+def check_for_ansible_failures_and_mark_down(job_config):
+    """
+    Mark nodes down as soon as ansible reports a failure we know means the
+    node is broken, instead of waiting for it to fail a streak of jobs first.
+
+    The patterns to look for come from disable_targets.ansible_failure_patterns
+    in the site config, keyed by machine type. The job process itself doesn't
+    do any of this: it only archives the ansible failure log, which we read
+    back here, so a running job never has to talk to paddles. See
+    docs/node_health.rst.
+
+    :param job_config: dict, job config data
+    :returns:          dict, mapping machine name to the failure message, for
+                       the nodes that were marked down
+    """
+    marked_down = dict()
+    patterns = (teuth_config.disable_targets or dict()).get(
+        'ansible_failure_patterns', dict()
+    ).get(job_config.get('machine_type'))
+    if not patterns:
+        return marked_down
+    failure_log = os.path.join(job_config['archive_path'], FAILURE_LOG_NAME)
+    if not os.path.exists(failure_log):
+        return marked_down
+    try:
+        with open(failure_log) as f:
+            failures = FailureAnalyzer().find_matching_failures(
+                f.read(), patterns
+            )
+    except Exception:
+        log.exception("Failed to check %s for failures", failure_log)
+        return marked_down
+    targets = set(shortname(t) for t in job_config.get('targets', dict()))
+    for hostname, msg in sorted(failures.items()):
+        machine_name = shortname(hostname)
+        if machine_name not in targets:
+            log.warning(
+                "Not marking %s down; it is not a target of this job",
+                machine_name,
+            )
+            continue
+        log.error("Marking %s down: %s", machine_name, msg)
+        # Only the status is updated here. The job still holds the lock, and
+        # unlock_targets() refuses to unlock a node whose description no longer
+        # matches the job's archive path, so the reason is recorded later by
+        # describe_disabled_targets().
+        try:
+            lock_ops.update_lock(machine_name, status='down')
+            marked_down[machine_name] = msg
+        except Exception:
+            log.exception("Failed to mark %s down", machine_name)
+    return marked_down
+
+
+def describe_disabled_targets(failures):
+    """
+    Record why a node was marked down, so it's visible in
+    'teuthology-lock --list' and not just in this log.
+
+    This has to happen after the nodes have been unlocked; see
+    check_for_ansible_failures_and_mark_down().
+
+    :param failures: dict, mapping machine name to the failure message
+    """
+    if not failures:
+        return
+    still_locked = set(
+        shortname(status['name']) for status in query.get_statuses(failures)
+        if status['locked']
+    )
+    for machine_name, msg in sorted(failures.items()):
+        if machine_name in still_locked:
+            # unlock_on_failure was probably set. Leave the description alone
+            # so the node can still be unlocked later.
+            log.warning(
+                "Not updating the description for %s; it is still locked",
+                machine_name,
+            )
+            continue
+        try:
+            lock_ops.update_lock(
+                machine_name,
+                description='ansible failure: {0}'.format(msg),
+            )
+        except Exception:
+            log.exception(
+                "Failed to update the description for %s", machine_name
+            )
 
 
 def reimage(job_config):

--- a/teuthology/task/ansible.py
+++ b/teuthology/task/ansible.py
@@ -19,6 +19,10 @@ from teuthology.util.loggerfile import LoggerFile
 
 log = logging.getLogger(__name__)
 
+# The name the ansible failure log is archived under. The supervisor reads it
+# back to decide whether to mark a node down; see docs/node_health.rst.
+FAILURE_LOG_NAME = "ansible_failures.yaml"
+
 
 class FailureAnalyzer:
     def analyze(self, failure_log):
@@ -31,6 +35,38 @@ class FailureAnalyzer:
                 continue
             lines = lines.union(self.analyze_host_record(host_obj))
         return sorted(lines)
+
+    def find_matching_failures(self, failure_log, patterns):
+        """
+        Find hosts whose failure messages match any of the given patterns.
+
+        :param failure_log: The contents of an ansible failure log
+        :param patterns:    A list of regular expressions to match against
+        :returns:           A dict mapping hostname to the message that matched
+        """
+        failure_obj = yaml.safe_load(failure_log)
+        failures = dict()
+        if not isinstance(failure_obj, dict):
+            return failures
+        for hostname, host_obj in failure_obj.items():
+            if not isinstance(host_obj, dict):
+                continue
+            for result in host_obj.get("results", [host_obj]):
+                if not isinstance(result, dict):
+                    continue
+                msg = result.get("msg")
+                if not isinstance(msg, str):
+                    continue
+                # ansible wraps long messages, so collapse whitespace before
+                # matching
+                msg = " ".join(msg.split())
+                for pattern in patterns:
+                    if re.search(pattern, msg, flags=re.IGNORECASE):
+                        failures[hostname] = msg
+                        break
+                if hostname in failures:
+                    break
+        return failures
 
     def analyze_host_record(self, record):
         lines = set()
@@ -392,7 +428,7 @@ class Ansible(Task):
 
     def _archive_failures(self):
         if self.ctx.archive:
-            archive_path = "{0}/ansible_failures.yaml".format(self.ctx.archive)
+            archive_path = os.path.join(self.ctx.archive, FAILURE_LOG_NAME)
             log.info("Archiving ansible failure log at: {0}".format(
                 archive_path,
             ))


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/75669
Related: https://tracker.ceph.com/issues/75208

## What

We already mark a node down after it fails to reimage 10 times in a row. When ceph-cm-ansible's `Ensure we found enough OSD disks` task fails, though, we know right away that the node is missing a disk — and every job that lands on it until someone notices will fail the same way.

This scans the ansible failure log for messages that mean the hardware itself is broken and marks the affected nodes down immediately.

- `FailureAnalyzer.find_hardware_failures()` parses the failure log (keyed by hostname) and returns `{hostname: msg}` for failures matching a known hardware-failure pattern. The one pattern for now is `Wanted N disks of ... but only matched M`. Whitespace is collapsed before matching because ansible wraps that message across lines.
- `Ansible._handle_failure()` feeds the hits to a new `_mark_hardware_failures_down()` hook — a no-op in the base class, implemented in `CephLab` as `lock_ops.update_lock(hostname, status='down')`. This mirrors the existing `_set_status()` split. It's wrapped in its own try/except so a lock server problem can't disturb the existing failure-reporting path.

## Notes for reviewers

Two deliberate choices:

**The lock description is left untouched.** The dispatcher's 10-strikes path sets `description='reimage failed 10 times'`, but it runs *after* unlocking. Here the job still holds the lock, and `unlock_targets()` refuses to unlock a node whose description no longer matches `archive_path` — so setting it would leave the dead node locked forever. Only `up` is flipped; the reason goes to the log.

**We match on the message, not the task name.** ceph-cm-ansible's `callback_plugins/failure_log.py` only records the result dict (`msg`, `changed`, ...), never the task name. Verified against a real [ansible_failures.yaml](https://qa-proxy.ceph.com/teuthology/nmordech-2026-03-22_08:25:58-rados-wip-rocky10-branch-of-the-day-2026-03-22-1774160434-tentacle-distro-default-trial/116107/ansible_failures.yaml) from the tracker and against `roles/testnode/tasks/configure_lvm.yml`. Keying off the task name instead would require a callback plugin change in ceph-cm-ansible first.

## Testing

8 new cases in `tests/task/test_ansible.py`: analyzer coverage (the verbatim message from job 116107, a line-wrapped variant, a `results` list, a non-matching failure, an empty log) plus end-to-end checks that `CephLab` marks the node down, `Ansible` does not, and a non-hardware failure does not.

`tests/task/test_ansible.py`: 105 passed, 6 skipped. Full suite: 1222 passed, 3 failed — the 3 are in `tests/orchestra/test_connection.py` and fail identically on a clean checkout of main.