### PR TITLE
suite: Avoid creating subprocesses for each job when scheduling

### DIFF
--- a/tests/suite/test_init.py
+++ b/tests/suite/test_init.py
@@ -225,7 +225,9 @@ Maybe you want 'gibba,smithi,mira' or similar"
             get_gitbuilder_hash=DEFAULT,
             git_ls_remote=lambda *args: '1234',
             package_version_for_hash=DEFAULT,
-        ) as m:
+        ) as m, patch('teuthology.beanstalk.connect') as m_connect, \
+                patch('teuthology.schedule.schedule_job'):
+            m_connect.return_value = Mock()
             m['package_version_for_hash'].return_value = 'fake-9.5'
             config.suite_verify_ceph_hash = False
             main([
@@ -253,7 +255,9 @@ Maybe you want 'gibba,smithi,mira' or similar"
             get_gitbuilder_hash=DEFAULT,
             git_ls_remote=lambda *args: '12345',
             package_version_for_hash=DEFAULT,
-        ) as m:
+        ) as m, patch('teuthology.beanstalk.connect') as m_connect, \
+                patch('teuthology.schedule.schedule_job'):
+            m_connect.return_value = Mock()
             m['package_version_for_hash'].return_value = 'fake-9.5'
             config.suite_verify_ceph_hash = True
             main([

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -3,21 +3,18 @@ from teuthology.misc import get_user
 
 
 class TestSchedule(object):
-    basic_args = {
-        '--verbose': False,
-        '--owner': 'OWNER',
-        '--description': 'DESC',
-        '--email': 'EMAIL',
-        '--first-in-suite': False,
-        '--last-in-suite': True,
-        '--name': 'NAME',
-        '--worker': 'tala',
-        '--timeout': '6',
-        '--priority': '99',
-        # TODO: make this work regardless of $PWD
-        #'<conf_file>': ['../../examples/3node_ceph.yaml',
-        #                '../../examples/3node_rgw.yaml'],
-        }
+    basic_kwargs = dict(
+        name='NAME',
+        description='DESC',
+        owner='OWNER',
+        worker='tala',
+        priority='99',
+        first_in_suite=False,
+        last_in_suite=True,
+        email='EMAIL',
+        verbose=False,
+        timeout='6',
+    )
 
     def test_basic(self):
         expected = {
@@ -34,12 +31,11 @@ class TestSchedule(object):
             'tube': 'tala',
         }
 
-        job_dict = build_config(self.basic_args)
+        job_dict = build_config({}, **self.basic_kwargs)
         assert job_dict == expected
 
     def test_owner(self):
-        args = self.basic_args
-        args['--owner'] = None
-        job_dict = build_config(self.basic_args)
+        kwargs = dict(self.basic_kwargs, owner=None)
+        job_dict = build_config({}, **kwargs)
         assert job_dict['owner'] == 'scheduled_%s' % get_user()
 

--- a/teuthology/beanstalk.py
+++ b/teuthology/beanstalk.py
@@ -18,7 +18,7 @@ def connect():
     if host is None or port is None:
         raise RuntimeError(
             'Beanstalk queue information not found in {conf_path}'.format(
-                conf_path=config.teuthology_yaml))
+                conf_path=config.yaml_path))
     return beanstalkc.Connection(host=host, port=port, parse_yaml=yaml.safe_load)
 
 

--- a/teuthology/schedule.py
+++ b/teuthology/schedule.py
@@ -31,7 +31,24 @@ def main(args):
     name = args['--name']
     if not name or name.isdigit():
         raise ValueError("Please use a more descriptive value for --name")
-    job_config = build_config(args)
+    config_paths = args.get('<conf_file>', list())
+    conf_dict = merge_configs(config_paths)
+    job_config = build_config(
+        conf_dict,
+        name=args['--name'],
+        description=args['--description'],
+        owner=args['--owner'],
+        worker=args['--worker'],
+        priority=args['--priority'],
+        first_in_suite=args['--first-in-suite'],
+        last_in_suite=args['--last-in-suite'],
+        email=args['--email'],
+        verbose=args['--verbose'],
+        timeout=args.get('--timeout'),
+        seed=args.get('--seed'),
+        subset=args.get('--subset'),
+        no_nested_subset=args.get('--no-nested-subset'),
+    )
     backend = args['--queue-backend']
     if args['--dry-run']:
         print('---\n' + yaml.safe_dump(job_config))
@@ -44,60 +61,57 @@ def main(args):
                          "Try 'beanstalk' or '@path-to-a-file" % backend)
 
 
-def build_config(args):
+def build_config(conf_dict, name, description, owner, worker, priority,
+                 first_in_suite=False, last_in_suite=False, email=None,
+                 verbose=False, timeout=None, seed=None, subset=None,
+                 no_nested_subset=None):
     """
-    Given a dict of arguments, build a job config
+    Build a job config dict from a merged config dict and scheduling
+    parameters.
+
+    Settings in conf_dict override the explicit parameters so that YAML
+    config can, for example, change the machine_type.
     """
-    config_paths = args.get('<conf_file>', list())
-    conf_dict = merge_configs(config_paths)
-    # strip out targets; the worker will allocate new ones when we run
-    # the job with --lock.
+    conf_dict = dict(conf_dict)
     if 'targets' in conf_dict:
         del conf_dict['targets']
-    args['config'] = conf_dict
 
-    owner = args['--owner']
     if owner is None:
         owner = 'scheduled_{user}'.format(user=get_user())
 
     job_config = dict(
-        name=args['--name'],
-        first_in_suite=args['--first-in-suite'],
-        last_in_suite=args['--last-in-suite'],
-        email=args['--email'],
-        description=args['--description'],
+        name=name,
+        first_in_suite=first_in_suite,
+        last_in_suite=last_in_suite,
+        email=email,
+        description=description,
         owner=owner,
-        verbose=args['--verbose'],
-        machine_type=args['--worker'],
-        tube=args['--worker'],
-        priority=int(args['--priority']),
+        verbose=verbose,
+        machine_type=worker,
+        tube=worker,
+        priority=int(priority),
     )
-    # Update the dict we just created, and not the other way around, to let
-    # settings in the yaml override what's passed on the command line. This is
-    # primarily to accommodate jobs with multiple machine types.
     job_config.update(conf_dict)
-    for arg,conf in {'--timeout':'results_timeout',
-                     '--seed': 'seed',
-                     '--subset': 'subset',
-                     '--no-nested-subset': 'no_nested_subset'}.items():
-        val = args.get(arg, None)
+    for key, val in [('results_timeout', timeout), ('seed', seed),
+                     ('subset', subset), ('no_nested_subset', no_nested_subset)]:
         if val is not None:
-            job_config[conf] = val
-
+            job_config[key] = val
     return job_config
 
 
-def schedule_job(job_config, num=1, report_status=True):
+def schedule_job(job_config, num=1, report_status=True, connection=None):
     """
     Schedule a job.
 
     :param job_config: The complete job dict
     :param num:      The number of times to schedule the job
+    :param report_status: Whether to report job status to paddles
+    :param connection: Optional existing beanstalk connection to reuse
     """
     num = int(num)
     job = yaml.safe_dump(job_config)
     tube = job_config.pop('tube')
-    beanstalk = teuthology.beanstalk.connect()
+    beanstalk = connection or teuthology.beanstalk.connect()
     beanstalk.use(tube)
     while num > 0:
         jid = beanstalk.put(

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -17,7 +17,7 @@ from teuthology.config import config, JobConfig
 from teuthology.exceptions import (
     BranchMismatchError, BranchNotFoundError, CommitNotFoundError,
 )
-from teuthology.misc import deep_merge, get_results_url, update_key
+from teuthology.misc import deep_merge, get_results_url, merge_configs, update_key
 from teuthology.orchestra.opsys import OS
 from teuthology.repo_utils import build_git_url
 
@@ -539,32 +539,75 @@ class Run(object):
         return jobs_missing_packages, jobs_to_schedule
 
     def schedule_jobs(self, jobs_missing_packages, jobs_to_schedule, name):
-        for job in jobs_to_schedule:
-            log.info(
-                'Scheduling %s', job['desc']
-            )
+        from teuthology.schedule import (
+            schedule_job, dump_job_to_file, build_config,
+        )
 
-            log_prefix = ''
-            if job in jobs_missing_packages:
-                log_prefix = "Missing Packages: "
-                if not config.suite_allow_missing_packages:
-                    util.schedule_fail(
-                        "At least one job needs packages that don't exist "
-                        f"for hash {self.base_config.sha1}.",
-                        name,
-                        dry_run=self.args.dry_run,
-                    )
-            util.teuthology_schedule(
-                args=job['args'],
-                dry_run=self.args.dry_run,
-                verbose=self.args.verbose,
-                log_prefix=log_prefix,
-                stdin=job['stdin'],
-            )
-            throttle = self.args.throttle
-            if not self.args.dry_run and throttle:
-                log.info("pause between jobs : --throttle " + str(throttle))
-                time.sleep(int(throttle))
+        worker = util.get_worker(self.args.machine_type)
+        backend = self.args.queue_backend or 'beanstalk'
+
+        base_yaml_conf = merge_configs(self.base_yaml_paths)
+
+        connection = None
+        if not self.args.dry_run and backend == 'beanstalk':
+            import teuthology.beanstalk
+            connection = teuthology.beanstalk.connect()
+
+        try:
+            for job in jobs_to_schedule:
+                log.info(
+                    'Scheduling %s', job['desc']
+                )
+
+                log_prefix = ''
+                if job in jobs_missing_packages:
+                    log_prefix = "Missing Packages: "
+                    if not config.suite_allow_missing_packages:
+                        util.schedule_fail(
+                            "At least one job needs packages that don't exist "
+                            f"for hash {self.base_config.sha1}.",
+                            name,
+                            dry_run=self.args.dry_run,
+                        )
+
+                conf_dict = copy.deepcopy(job['yaml'])
+                if base_yaml_conf:
+                    deep_merge(conf_dict, copy.deepcopy(base_yaml_conf))
+
+                job_config = build_config(
+                    conf_dict=conf_dict,
+                    name=self.name,
+                    description=job['desc'],
+                    owner=self.args.owner,
+                    worker=worker,
+                    priority=(self.args.priority
+                              if self.args.priority is not None else 1000),
+                    verbose=bool(self.args.verbose),
+                )
+
+                if self.args.dry_run:
+                    log.debug('%s job config:\n%s',
+                              log_prefix, yaml.safe_dump(job_config))
+                    if self.args.verbose and self.args.verbose > 1:
+                        print('---\n' + yaml.safe_dump(job_config))
+                elif backend == 'beanstalk':
+                    schedule_job(job_config, self.args.num, True,
+                                connection=connection)
+                elif backend.startswith('@'):
+                    dump_job_to_file(backend.lstrip('@'), job_config,
+                                    self.args.num)
+                else:
+                    raise ValueError(
+                        "Provided schedule backend '%s' is not supported. "
+                        "Try 'beanstalk' or '@path-to-a-file'" % backend)
+
+                throttle = self.args.throttle
+                if not self.args.dry_run and throttle:
+                    log.info("pause between jobs : --throttle " + str(throttle))
+                    time.sleep(int(throttle))
+        finally:
+            if connection:
+                connection.close()
 
     def check_priority(self, jobs_to_schedule):
         priority = self.args.priority


### PR DESCRIPTION
This saves 1-2 seconds per job submission, which on large suites adds up quickly.