### PR TITLE
packaging: fix Pulp deb search and improve its error messages

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -930,7 +930,6 @@ class TestPulpProject(TestBuilderProject):
             ('alma', '9.7', None, 'distro_version=9'),
             ('centos', '8.1', None, 'distro_version=8'),
             ('rhel', '7.0', None, 'distro_version=7'),
-            ('ubuntu', '20.04', 'focal', 'distro_version=focal'),
         ],
     )
     def test_search_uses_major_distro_version(
@@ -943,6 +942,19 @@ class TestPulpProject(TestBuilderProject):
         labels = self.m_get.call_args[1]['params']['pulp_label_select']
         assert expected in labels
         assert f'distro_version={os_version},' not in labels
+
+    # deb distros search with the numeric version like shaman/chacra,
+    # never the codename, even when the job config supplies a codename.
+    @pytest.mark.parametrize(
+        'os_version',
+        ['20.04', 'focal'],
+    )
+    def test_search_uses_numeric_distro_version_for_deb(self, os_version):
+        gp = self.klass('ceph', dict(os_type='ubuntu', os_version=os_version))
+        gp._search()
+        labels = self.m_get.call_args[1]['params']['pulp_label_select']
+        assert 'distro_version=20.04,' in labels
+        assert 'focal' not in labels
 
     def test_get_package_version_found(self):
         resp = Mock()
@@ -990,7 +1002,7 @@ class TestPulpProject(TestBuilderProject):
         ('rocky', '10.1', None, 'rocky/10'),
         ('centos', '8.1', None, 'centos/8'),
         ('fedora', '20', None, 'fedora/20'),
-        ('ubuntu', '20.04', 'focal', 'ubuntu/focal'),
+        ('ubuntu', '20.04', 'focal', 'ubuntu/20.04'),
     ]
 
     @pytest.mark.parametrize(
@@ -1004,7 +1016,7 @@ class TestPulpProject(TestBuilderProject):
         ('rhel', None, None, 'centos/8'),
         ('centos', None, None, 'centos/9'),
         ('fedora', None, None, 'fedora/25'),
-        ('ubuntu', None, None, 'ubuntu/jammy'),
+        ('ubuntu', None, None, 'ubuntu/22.04'),
         ('alma', None, None, 'alma/9'),
         ('rocky', None, None, 'rocky/9'),
     ]
@@ -1015,7 +1027,7 @@ class TestPulpProject(TestBuilderProject):
         ('rocky', '10.1', None, 'rocky/10'),
         ('centos', '8.1', None, 'centos/8'),
         ('fedora', '20', None, 'fedora/20'),
-        ('ubuntu', '20.04', None, 'ubuntu/focal'),
+        ('ubuntu', '20.04', None, 'ubuntu/20.04'),
     ]
 
     @pytest.mark.parametrize(

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -1125,6 +1125,33 @@ class PulpProject(GitbuilderProject):
         return urljoin(self.pulp_server_url, path)
 
     @property
+    def _search_labels(self):
+        """Build the pulp_label_select filter used to find our distribution"""
+        labels = f'project={self.project},'
+        labels += f'flavors={self.flavor},'
+        labels += f'distro={self.os_type},'
+        distro_version = self._get_distro(
+            distro=self.os_type,
+            version=self.os_version,
+            codename=self.codename,
+        ).split('/', 1)[1]
+        labels += f'distro_version={distro_version},'
+
+        # Add the architecture to the search parameters.
+        arch = 'noarch' if self.force_noarch else self.arch
+        labels += f'arch={arch},'
+
+        # Add the reference to the search parameters.
+        ref_name, ref_val = list(self._choose_reference().items())[0]
+        labels += f'{ref_name}={ref_val}'
+        return labels
+
+    @property
+    def _search_query(self):
+        """The full search url, including the label filter"""
+        return f'{self._search_uri}?pulp_label_select={self._search_labels}'
+
+    @property
     def _result(self):
         """Get the results from the pulp api"""
         if getattr(self, '_result_obj', None) is None:
@@ -1133,11 +1160,11 @@ class PulpProject(GitbuilderProject):
 
             # Check if there is exactly one result.
             if not len(self._result_obj):
-                log.error(f'No results found for {self._search_uri}')
-                raise VersionNotFoundError(f'No results found for {self._search_uri}')
+                log.error(f'No results found for {self._search_query}')
+                raise VersionNotFoundError(f'No results found for {self._search_query}')
             elif len(self._result_obj) > 1:
-                log.error(f'Multiple results found for {self._search_uri}')
-                raise VersionNotFoundError(f'Multiple results found for {self._search_uri}')
+                log.error(f'Multiple results found for {self._search_query}')
+                raise VersionNotFoundError(f'Multiple results found for {self._search_query}')
 
         return self._result_obj[0]
 
@@ -1160,24 +1187,7 @@ class PulpProject(GitbuilderProject):
 
     def _search(self):
         """Search for the package in the pulp api"""
-        # Build the search parameters.
-        labels = f'project={self.project},'
-        labels += f'flavors={self.flavor},'
-        labels += f'distro={self.os_type},'
-        distro_version = self._get_distro(
-            distro=self.os_type,
-            version=self.os_version,
-            codename=self.codename,
-        ).split('/', 1)[1]
-        labels += f'distro_version={distro_version},'
-
-        # Add the architecture to the search parameters.
-        arch = 'noarch' if self.force_noarch else self.arch
-        labels += f'arch={arch},'
-
-        # Add the reference to the search parameters.
-        ref_name, ref_val = list(self._choose_reference().items())[0]
-        labels += f'{ref_name}={ref_val}'
+        labels = self._search_labels
         resp = requests.get(
             self._search_uri,
             params={'pulp_label_select': labels},

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -1201,13 +1201,13 @@ class PulpProject(GitbuilderProject):
 
     @classmethod
     def _get_distro(cls, distro=None, version=None, codename=None):
+        # Like shaman/chacra, deb-based distros use the numeric version
+        # (e.g. ubuntu/22.04), not the codename.
         if distro in ('centos', 'rhel'):
             distro = 'centos'
             version = cls._parse_version(version)
         if distro in ('alma', 'rocky'):
             version = cls._parse_version(version)
-        if distro in ('ubuntu', 'debian'):
-            version = codename or version
         return f'{distro}/{version}'
 
     def _get_package_sha1(self):

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -621,6 +621,26 @@ class GitbuilderProject(object):
         return version.split(".")[0]
 
     @classmethod
+    def _get_distro_numeric(cls, distro=None, version=None, codename=None):
+        """
+        The distro/version string used when searching shaman or pulp,
+        e.g. ubuntu/22.04 or centos/9.
+
+        Unlike gitbuilder/chacra URLs (see _get_distro), searches always
+        use the numeric version, never the codename.
+
+        :param distro:   The distro as a string
+        :param version:  The version as a string
+        :param codename: Unused; accepted so both methods share a signature
+        """
+        if distro in ('centos', 'rhel'):
+            distro = 'centos'
+            version = cls._parse_version(version)
+        if distro in ('alma', 'rocky'):
+            version = cls._parse_version(version)
+        return f'{distro}/{version}'
+
+    @classmethod
     def _get_distro(cls, distro=None, version=None, codename=None):
         """
         Given a distro and a version, returned the combined string
@@ -981,14 +1001,7 @@ class ShamanProject(GitbuilderProject):
         if len(self._result.json()) == 0:
             raise VersionNotFoundError(self._result.url)
 
-    @classmethod
-    def _get_distro(cls, distro=None, version=None, codename=None):
-        if distro in ('centos', 'rhel'):
-            distro = 'centos'
-            version = cls._parse_version(version)
-        if distro in ('alma', 'rocky'):
-            version = cls._parse_version(version)
-        return "%s/%s" % (distro, version)
+    _get_distro = GitbuilderProject._get_distro_numeric
 
     def _get_package_sha1(self):
         # This doesn't raise because GitbuilderProject._get_package_sha1()
@@ -1199,16 +1212,9 @@ class PulpProject(GitbuilderProject):
 
         return resp.json()
 
-    @classmethod
-    def _get_distro(cls, distro=None, version=None, codename=None):
-        # Like shaman/chacra, deb-based distros use the numeric version
-        # (e.g. ubuntu/22.04), not the codename.
-        if distro in ('centos', 'rhel'):
-            distro = 'centos'
-            version = cls._parse_version(version)
-        if distro in ('alma', 'rocky'):
-            version = cls._parse_version(version)
-        return f'{distro}/{version}'
+    # Pulp labels follow the shaman convention: numeric distro versions,
+    # set by ceph-build's pulp_upload.sh.
+    _get_distro = GitbuilderProject._get_distro_numeric
 
     def _get_package_sha1(self):
         """Get the package sha1 from the pulp api"""


### PR DESCRIPTION
Two fixes for `PulpProject`, motivated by every deb job failing `check_packages` with:

```
teuthology.exceptions.VersionNotFoundError: Failed to fetch package version from No results found for https://pulp.front.sepia.ceph.com/pulp/api/v3/distributions/deb/apt
```

(e.g. `yuriw-2026-08-10_23:39:44-smoke-wip-yuriw-cve-dryrun_tentacle-distro-default-trial/453537`)

**1. Search with the numeric distro_version for deb distros.** `PulpProject._get_distro` preferred the codename for ubuntu/debian (`distro_version=jammy`), but shaman/chacra and ceph-build's `pulp_upload.sh` all use the numeric version (`22.04`), so the `pulp_label_select` search matched no distributions. Drop the codename preference so the search uses `os_version` like `ShamanProject` does; `os_version` is always normalized to numeric form by `OS.version_codename` even when the job config supplies a codename.

**2. Report the full query in search errors.** The no-results/multiple-results errors only printed the API endpoint, which made the mismatch above needlessly hard to diagnose. Extract the `pulp_label_select` construction into a `_search_labels` property (so the logged query and the actual request can't drift apart) and report the full query:

```
No results found for https://pulp.front.sepia.ceph.com/pulp/api/v3/distributions/deb/apt?pulp_label_select=project=ceph,flavors=default,distro=ubuntu,distro_version=22.04,arch=x86_64,branch=wip-yuriw-cve-dryrun_tentacle
```

`tests/test_packaging.py`: 183 passed, 59 skipped. The existing distributions for in-flight branches already carry `distro_version=22.04`, so no relabeling or rebuild is needed once this lands.