### PR TITLE
repo_utils: reset existing worktrees to the fetched ref

### DIFF
--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -200,6 +200,35 @@ class TestRepoUtils(object):
         with raises(ValueError):
             repo_utils.enforce_repo_state(self.repo_url, self.dest_path, 'a b', self.commit)
 
+    def test_enforce_worktree_picks_up_new_commits(self):
+        bare_path = self.temp_path + '/bare_clone'
+        try:
+            repo_utils.enforce_repo_state(self.repo_url, self.dest_path, 'main',
+                                          dest_clone=bare_path)
+            assert os.path.exists(self.dest_path)
+
+            subprocess.check_call(
+                ('git', 'commit', '--allow-empty', '--allow-empty-message',
+                 '--no-edit'),
+                cwd=self.src_path,
+                stdout=subprocess.DEVNULL,
+            )
+            expected = subprocess.check_output(
+                ('git', 'rev-parse', 'HEAD'),
+                cwd=self.src_path,
+            ).decode().strip()
+
+            repo_utils.enforce_repo_state(self.repo_url, self.dest_path, 'main',
+                                          dest_clone=bare_path)
+            actual = subprocess.check_output(
+                ('git', 'rev-parse', 'HEAD'),
+                cwd=self.dest_path,
+            ).decode().strip()
+            assert actual == expected
+        finally:
+            shutil.rmtree(bare_path, ignore_errors=True)
+            shutil.rmtree(bare_path + '.lock', ignore_errors=True)
+
     def test_simultaneous_access(self):
         count = 5
         with parallel.parallel() as p:

--- a/teuthology/repo_utils.py
+++ b/teuthology/repo_utils.py
@@ -191,13 +191,15 @@ def create_worktree(bare_dir, workspace_dir, ref='FETCH_HEAD'):
     log.info("Setting up worktree at %s from bare repo %s using ref %s", workspace_dir, bare_dir, ref)
 
     if os.path.exists(workspace_dir):
-        log.debug("Workspace directory %s already exists, verifying", workspace_dir)
-        args = [
-            'git',
-            'log',
-            '-1',
-        ]
-        run_subprocess(args, cwd=workspace_dir)
+        # FETCH_HEAD is per-worktree, so resolve it in the bare repo, where the
+        # fetch happened.
+        sha = run_subprocess(
+            ['git', 'rev-parse', ref],
+            cwd=bare_dir,
+        ).stdout.strip()
+        log.debug("Workspace directory %s already exists, resetting it to %s",
+                  workspace_dir, sha)
+        run_subprocess(['git', 'reset', '--hard', sha], cwd=workspace_dir)
         return
 
     log.debug("Adding new worktree at %s", workspace_dir)


### PR DESCRIPTION
`create_worktree()` only runs `git log -1` and returns when the workspace directory already exists, so a worktree stays pinned to whatever commit it had when it was first created.  The bare clone keeps fetching fine and `.fetched_and_reset` keeps getting touched every job, so it all looks healthy while the checkout never moves.

Found this after a testnode failed against a public Rocky mirror even though we'd merged a change to prefer our internal mirror.  On soko04 the ceph-cm-ansible worktree was stuck at a June 11 commit (dir created June 12, never updated since) while the bare repo's FETCH_HEAD was current.  Every other worktree is stale too, ceph-ci since Feb 2025.  So jobs have been running old ansible regardless of what's merged.

Reset the workspace to the fetched ref instead.  FETCH_HEAD is per-worktree, so it has to be resolved in the bare repo where the fetch happened, otherwise the reset fails with "unknown revision".

Regression test included; it fails before the change and passes after.

Introduced in b57d834.