### PR TITLE
WARN on and ignore Pulp-hosted shaman results when package_source: shaman AND sha1s of package repos lacking a container image

### DIFF
--- a/docs/detailed_test_config.rst
+++ b/docs/detailed_test_config.rst
@@ -316,3 +316,19 @@ pulp:
   username: pulp-username
   password: pulp-password
   force_noarch: True
+
+``package_source`` may also be set in an extra job yaml passed to
+``teuthology-suite``. It then applies both to the scheduled jobs and to the
+package checks ``teuthology-suite`` performs itself (for example when
+backtracking with ``--newest``), provided the scheduling host has the Pulp
+credentials configured.
+
+Some builds (currently security builds) are published only to the lab-internal
+Pulp and Quay instances. We still register them in Shaman, but their
+``chacra_url`` points to the Pulp repo URL. When using
+``package_source: shaman``, we ignore those repos. If a given sha1 has both a
+chacra *and* a Pulp repo, the chacra build is used. If it only has a Pulp
+build, it is treated as not found; ``--newest`` then logs a warning and moves
+on to the next sha1 unless the run selects ``package_source: pulp`` and the
+internal quay cephadm image (``defaults.cephadm.containers.image:
+quay-int.front.sepia.ceph.com/ceph-ci/ceph``).

--- a/docs/detailed_test_config.rst
+++ b/docs/detailed_test_config.rst
@@ -332,3 +332,11 @@ build, it is treated as not found; ``--newest`` then logs a warning and moves
 on to the next sha1 unless the run selects ``package_source: pulp`` and the
 internal quay cephadm image (``defaults.cephadm.containers.image:
 quay-int.front.sepia.ceph.com/ceph-ci/ceph``).
+
+Similarly, release builds have packages but no CI container. If a job uses
+the ``cephadm`` task, ``teuthology-suite`` asks the registry of the configured
+cephadm image (``defaults.cephadm.containers.image`` in the site config, or
+``defaults``/``overrides`` in the job yaml) whether ``<image>:<sha1>`` exists.
+If it does not, a warning is logged; with ``--newest`` the sha1 is skipped and
+the next one is tried. If the registry cannot be queried, scheduling proceeds
+as if the container existed.

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -43,7 +43,14 @@ Standard arguments:
                               Search for the newest revision built on all
                               required distro/versions, starting from
                               either --ceph or --sha1, backtracking
-                              up to <newest> commits [default: 0]
+                              up to <newest> commits [default: 0].
+                              Packages are looked up using the
+                              package_source from <config_yaml> if set.
+                              A sha1 whose packages exist only on the
+                              lab-internal Pulp (e.g. a security build)
+                              is skipped with a warning unless the run
+                              selects package_source: pulp and the
+                              quay-int cephadm image.
   -k <kernel>, --kernel <kernel>
                               The kernel branch to run against,
                               use 'none' to bypass kernel task.

--- a/scripts/suite.py
+++ b/scripts/suite.py
@@ -50,7 +50,11 @@ Standard arguments:
                               lab-internal Pulp (e.g. a security build)
                               is skipped with a warning unless the run
                               selects package_source: pulp and the
-                              quay-int cephadm image.
+                              quay-int cephadm image. If any job uses
+                              cephadm, a sha1 with packages but no
+                              container in the configured cephadm image
+                              registry (e.g. a release build) is skipped
+                              with a warning too.
   -k <kernel>, --kernel <kernel>
                               The kernel branch to run against,
                               use 'none' to bypass kernel task.

--- a/tests/suite/test_run_.py
+++ b/tests/suite/test_run_.py
@@ -842,3 +842,226 @@ class TestInternalSources(object):
                   if r.levelno == logging.ERROR and 'lab-internal Pulp' in r.getMessage()]
         assert len(errors) == 1
         assert "'ceph_sha1'" in errors[0]
+
+
+class TestContainerCheck(object):
+    """
+    --newest: a sha1 with packages but no cephadm container (e.g. a release
+    build, CI_CONTAINER=false) is skipped with a warning.
+    """
+    klass = run.Run
+
+    def setup_method(self):
+        self.args_dict = dict(
+            suite='suite',
+            suite_relpath='',
+            suite_dir='suite_dir',
+            suite_branch='main',
+            suite_repo='ceph',
+            ceph_repo='ceph',
+            ceph_branch='tentacle',
+            ceph_sha1='ceph_sha1',
+            teuthology_branch='main',
+            kernel_branch=None,
+            flavor='default',
+            distro='ubuntu',
+            distro_version='14.04',
+            machine_type='machine_type',
+            base_yaml_paths=list(),
+            newest=10,
+        )
+        self.args = YamlConfig.from_dict(self.args_dict)
+        self.orig_defaults = config.get('defaults')
+        config.defaults = dict(cephadm=dict(containers=dict(
+            image='quay.ceph.io/ceph-ci/ceph')))
+        self.p_hash_only_in_pulp = patch(
+            'teuthology.suite.util.hash_only_in_pulp', return_value=False)
+        self.p_hash_only_in_pulp.start()
+
+    def teardown_method(self):
+        config.defaults = self.orig_defaults
+        self.p_hash_only_in_pulp.stop()
+
+    @contextlib.contextmanager
+    def make_run(self):
+        with patch('teuthology.suite.util.fetch_repos'), \
+             patch('teuthology.suite.util.git_ls_remote',
+                   return_value='a_sha1'), \
+             patch('teuthology.suite.util.git_validate_sha1',
+                   return_value=self.args.ceph_sha1):
+            yield self.klass(self.args)
+
+    @pytest.mark.parametrize(
+        ['tasks', 'expected'],
+        [
+            (None, False),
+            ([], False),
+            ([{'install': None}, {'ceph': None}], False),
+            ([{'install': None}, {'cephadm': {'roleless': True}}], True),
+            ([{'cephadm.shell': {'host.a': ['ls']}}], True),
+            ([{'sequential': [{'install': None}, {'cephadm': None}]}], True),
+            ([{'parallel': [{'sequential': [{'cephadm': None}]}]}], True),
+            (['not-a-dict', {'ceph': None}], False),
+        ]
+    )
+    def test_uses_cephadm(self, tasks, expected):
+        assert run.Run.uses_cephadm(tasks) is expected
+
+    def test_container_ref(self):
+        with self.make_run() as runobj:
+            assert runobj.cephadm_container_ref('abc') == \
+                'quay.ceph.io/ceph-ci/ceph:abc'
+            assert runobj.cephadm_container_ref('abc', 'crimson-debug') == \
+                'quay.ceph.io/ceph-ci/ceph:abc-crimson-debug'
+            # a pinned tag or digest means the sha1 is irrelevant
+            config.defaults['cephadm']['containers']['image'] = \
+                'quay.ceph.io/ceph-ci/ceph:latest'
+            assert runobj.cephadm_container_ref('abc') is None
+            config.defaults['cephadm']['containers']['image'] = \
+                'quay.ceph.io/ceph-ci/ceph@sha256:0123'
+            assert runobj.cephadm_container_ref('abc') is None
+            # no image configured anywhere: nothing to check
+            config.defaults = dict()
+            assert runobj.cephadm_container_ref('abc') is None
+            assert runobj.container_missing('abc') is False
+
+    @pytest.mark.parametrize(
+        ['exists', 'missing'],
+        [(True, False), (False, True), (None, False)]
+    )
+    def test_container_missing(self, exists, missing):
+        with self.make_run() as runobj, \
+             patch('teuthology.suite.util.container_image_exists',
+                   return_value=exists) as m_exists:
+            assert runobj.container_missing('abc') is missing
+            m_exists.assert_called_once_with('quay.ceph.io/ceph-ci/ceph', 'abc')
+
+    def test_warning_text(self, caplog):
+        with self.make_run() as runobj:
+            with caplog.at_level(logging.WARNING, logger='teuthology.suite.run'):
+                runobj.warn_missing_container('abc', newest=True)
+                runobj.warn_missing_container('abc', newest=False)
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING]
+        assert warnings[0] == (
+            "ceph sha1 abc has packages but no container at "
+            "quay.ceph.io/ceph-ci/ceph:abc. Pending release build, or failed "
+            "container build of a passed package build? Moving on to the next "
+            "sha1 of tentacle")
+        assert warnings[1].startswith(
+            "ceph sha1 abc has packages but no container at "
+            "quay.ceph.io/ceph-ci/ceph:abc. Pending release build, or failed "
+            "container build of a passed package build?")
+        assert 'Moving on' not in warnings[1]
+
+    def _schedule(self, caplog, m_config_merge, jobs):
+        m_config_merge.return_value = jobs
+        with self.make_run() as runobj:
+            runobj.base_args = list()
+            with caplog.at_level(logging.WARNING, logger='teuthology.suite.run'):
+                count = runobj.schedule_suite()
+        return runobj, count
+
+    @patch('teuthology.suite.util.find_git_parents')
+    @patch('teuthology.suite.run.Run.schedule_jobs')
+    @patch('teuthology.suite.run.Run.write_rerun_memo')
+    @patch('teuthology.suite.util.get_install_task_flavor')
+    @patch('teuthology.suite.run.config_merge')
+    @patch('teuthology.suite.run.build_matrix')
+    @patch('teuthology.suite.util.container_image_exists')
+    @patch('teuthology.suite.util.package_version_for_hash')
+    @patch('teuthology.suite.util.get_arch')
+    def test_newest_skips_sha1_without_container(
+        self,
+        m_get_arch,
+        m_package_version_for_hash,
+        m_container_image_exists,
+        m_build_matrix,
+        m_config_merge,
+        m_get_install_task_flavor,
+        m_write_rerun_memo,
+        m_schedule_jobs,
+        m_find_git_parents,
+        caplog,
+    ):
+        """
+        End to end: first sha1 has packages but no container -> warning ->
+        parent sha1 has both -> used. Non-cephadm jobs never trigger the
+        registry lookup.
+        """
+        m_get_arch.return_value = 'x86_64'
+        m_get_install_task_flavor.return_value = 'default'
+        m_package_version_for_hash.return_value = 'ceph_version'
+        # (the real function is lru_cached; the mock is asked per job)
+        m_container_image_exists.side_effect = lambda image, tag: {
+            'ceph_sha1': False, 'ceph_sha1_p1': True}[tag]
+        m_find_git_parents.return_value = ['ceph_sha1_p1']
+        jobs = [
+            ('plain', ['a.yml'], {'tasks': [{'install': None}, {'ceph': None}]}),
+            ('cephadm', ['b.yml'], {'tasks': [{'cephadm': None}]}),
+            ('cephadm2', ['c.yml'], {'tasks': [{'cephadm': None}]}),
+        ]
+        m_build_matrix.return_value = [(d, f) for d, f, _ in jobs]
+
+        runobj, count = self._schedule(caplog, m_config_merge, jobs)
+        assert count == 3
+        assert runobj.base_config.sha1 == 'ceph_sha1_p1'
+        # only cephadm jobs ask the registry: 1 for the first sha1 (then we
+        # bail out), 2 for the parent
+        assert m_container_image_exists.call_args_list == [
+            call('quay.ceph.io/ceph-ci/ceph', 'ceph_sha1'),
+            call('quay.ceph.io/ceph-ci/ceph', 'ceph_sha1_p1'),
+            call('quay.ceph.io/ceph-ci/ceph', 'ceph_sha1_p1'),
+        ]
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING and 'no container' in r.getMessage()]
+        assert warnings == [
+            "ceph sha1 ceph_sha1 has packages but no container at "
+            "quay.ceph.io/ceph-ci/ceph:ceph_sha1. Pending release build, or "
+            "failed container build of a passed package build? Moving on to "
+            "the next sha1 of tentacle",
+        ]
+
+    @patch('teuthology.suite.run.Run.schedule_jobs')
+    @patch('teuthology.suite.run.Run.write_rerun_memo')
+    @patch('teuthology.suite.util.get_install_task_flavor')
+    @patch('teuthology.suite.run.config_merge')
+    @patch('teuthology.suite.run.build_matrix')
+    @patch('teuthology.suite.util.container_image_exists')
+    @patch('teuthology.suite.util.package_version_for_hash')
+    @patch('teuthology.suite.util.get_arch')
+    def test_no_newest_warns_but_schedules(
+        self,
+        m_get_arch,
+        m_package_version_for_hash,
+        m_container_image_exists,
+        m_build_matrix,
+        m_config_merge,
+        m_get_install_task_flavor,
+        m_write_rerun_memo,
+        m_schedule_jobs,
+        caplog,
+    ):
+        self.args.newest = 0
+        m_get_arch.return_value = 'x86_64'
+        m_get_install_task_flavor.return_value = 'default'
+        m_package_version_for_hash.return_value = 'ceph_version'
+        m_container_image_exists.return_value = False
+        jobs = [
+            ('cephadm', ['b.yml'], {'tasks': [{'cephadm': None}]}),
+            ('cephadm2', ['c.yml'], {'tasks': [{'cephadm': None}]}),
+        ]
+        m_build_matrix.return_value = [(d, f) for d, f, _ in jobs]
+
+        runobj, count = self._schedule(caplog, m_config_merge, jobs)
+        assert count == 2
+        assert runobj.base_config.sha1 == 'ceph_sha1'
+        # nothing marked missing: schedule_jobs must not fail the run
+        missing, to_schedule = m_schedule_jobs.call_args.args[:2]
+        assert missing == []
+        assert len(to_schedule) == 2
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING and 'no container' in r.getMessage()]
+        # warned once, not once per job
+        assert len(warnings) == 1
+        assert 'cephadm jobs will fail to pull it' in warnings[0]

--- a/tests/suite/test_run_.py
+++ b/tests/suite/test_run_.py
@@ -260,6 +260,15 @@ class TestScheduleSuite(object):
             base_yaml_paths=list(),
         )
         self.args = YamlConfig.from_dict(self.args_dict)
+        # package_version_for_hash is mocked in these tests, so the cached
+        # builder project is never populated; keep hash_only_in_pulp() from
+        # going to the network to fill it.
+        self.p_hash_only_in_pulp = patch(
+            'teuthology.suite.util.hash_only_in_pulp', return_value=False)
+        self.p_hash_only_in_pulp.start()
+
+    def teardown_method(self):
+        self.p_hash_only_in_pulp.stop()
 
     @patch('teuthology.suite.run.Run.schedule_jobs')
     @patch('teuthology.suite.run.Run.write_rerun_memo')
@@ -640,3 +649,196 @@ class TestScheduleSuite(object):
                 job_yaml = yaml.safe_load(job['stdin'])
                 assert job_yaml.get('sha1') == working_sha1
                 assert job_yaml.get('suite_sha1') == sha1_side_effect[1]
+
+
+class TestInternalSources(object):
+    """
+    --newest: warn when a sha1 is skipped and the run does not select the
+    lab-internal pulp / quay-int, where e.g. security builds are published
+    exclusively.
+    """
+    klass = run.Run
+
+    def setup_method(self):
+        self.args_dict = dict(
+            suite='suite',
+            suite_relpath='',
+            suite_dir='suite_dir',
+            suite_branch='main',
+            suite_repo='ceph',
+            ceph_repo='ceph',
+            ceph_branch='main',
+            ceph_sha1='ceph_sha1',
+            teuthology_branch='main',
+            kernel_branch=None,
+            flavor='flavor',
+            distro='ubuntu',
+            distro_version='14.04',
+            machine_type='machine_type',
+            base_yaml_paths=list(),
+            newest=10,
+        )
+        self.args = YamlConfig.from_dict(self.args_dict)
+        self.orig_package_source = config.package_source
+        self.orig_pulp = config.get('pulp')
+        self.orig_defaults = config.get('defaults')
+        config.package_source = 'shaman'
+        config.pulp = dict()
+        config.defaults = dict()
+
+    def teardown_method(self):
+        config.package_source = self.orig_package_source
+        config.pulp = self.orig_pulp
+        config.defaults = self.orig_defaults
+
+    def write_yaml(self, tmp_path, contents):
+        path = tmp_path / 'extra.yaml'
+        path.write_text(yaml.safe_dump(contents))
+        self.args.base_yaml_paths = [str(path)]
+
+    @contextlib.contextmanager
+    def make_run(self):
+        with patch('teuthology.suite.util.fetch_repos'), \
+             patch('teuthology.suite.util.git_ls_remote',
+                   return_value='a_sha1'), \
+             patch('teuthology.suite.util.git_validate_sha1',
+                   return_value=self.args.ceph_sha1):
+            yield self.klass(self.args)
+
+    def test_missing_both(self):
+        with self.make_run() as runobj:
+            missing = runobj.missing_internal_sources()
+        assert missing == [
+            'package_source: pulp',
+            'defaults.cephadm.containers.image: '
+            'quay-int.front.sepia.ceph.com/ceph-ci/ceph',
+        ]
+
+    def test_selected_both_in_job_yaml(self, tmp_path):
+        self.write_yaml(tmp_path, dict(
+            package_source='pulp',
+            pulp=dict(username='u', password='p'),
+            defaults=dict(cephadm=dict(containers=dict(
+                image='quay-int.front.sepia.ceph.com/ceph-ci/ceph'))),
+        ))
+        with self.make_run() as runobj:
+            assert runobj.missing_internal_sources() == []
+            # job-level package_source is honored for schedule-time checks
+            assert config.package_source == 'pulp'
+
+    def test_selected_image_via_overrides_and_site_pulp(self, tmp_path):
+        config.package_source = 'pulp'
+        self.write_yaml(tmp_path, dict(
+            overrides=dict(cephadm=dict(containers=dict(
+                image='quay-int.front.sepia.ceph.com/ceph-ci/ceph:sometag'))),
+        ))
+        with self.make_run() as runobj:
+            assert runobj.missing_internal_sources() == []
+
+    def test_selected_pulp_only(self, tmp_path):
+        self.write_yaml(tmp_path, dict(
+            package_source='pulp',
+            pulp=dict(username='u', password='p'),
+            defaults=dict(cephadm=dict(containers=dict(
+                image='quay.io/ceph-ci/ceph'))),
+        ))
+        with self.make_run() as runobj:
+            assert runobj.missing_internal_sources() == [
+                'defaults.cephadm.containers.image: '
+                'quay-int.front.sepia.ceph.com/ceph-ci/ceph',
+            ]
+
+    def test_pulp_without_credentials_not_applied(self, tmp_path):
+        self.write_yaml(tmp_path, dict(package_source='pulp'))
+        with self.make_run() as runobj:
+            # No creds on this "host": keep checking shaman while scheduling
+            assert config.package_source == 'shaman'
+            # ...but the run itself does select pulp, so don't nag about it
+            assert 'package_source: pulp' not in runobj.missing_internal_sources()
+
+    def test_warns_when_pulp_only_and_not_selected(self, caplog):
+        with self.make_run() as runobj:
+            with caplog.at_level(logging.WARNING, logger='teuthology.suite.run'):
+                runobj.warn_pulp_only_sha1('sha_a')
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert 'sha_a' in warnings[0]
+        assert 'only built to the lab-internal Pulp/Quay' in warnings[0]
+        assert 'package_source: pulp' in warnings[0]
+        assert 'quay-int.front.sepia.ceph.com/ceph-ci/ceph' in warnings[0]
+        assert 'Moving on to the next sha1' in warnings[0]
+
+    def test_warns_when_pulp_only_and_selected(self, tmp_path, caplog):
+        # Both selected but (in this test) no pulp creds on the scheduling
+        # host, so the check fell back to shaman and found the sha1 pulp-only.
+        self.write_yaml(tmp_path, dict(
+            package_source='pulp',
+            defaults=dict(cephadm=dict(containers=dict(
+                image='quay-int.front.sepia.ceph.com/ceph-ci/ceph'))),
+        ))
+        with self.make_run() as runobj:
+            with caplog.at_level(logging.WARNING, logger='teuthology.suite.run'):
+                runobj.warn_pulp_only_sha1('sha_a')
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING and '--newest' in r.getMessage()]
+        assert len(warnings) == 1
+        assert 'could not be verified' in warnings[0]
+        assert 'does not select' not in warnings[0]
+
+    @patch('teuthology.suite.util.find_git_parents')
+    @patch('teuthology.suite.run.Run.schedule_jobs')
+    @patch('teuthology.suite.run.Run.write_rerun_memo')
+    @patch('teuthology.suite.util.get_install_task_flavor')
+    @patch('teuthology.suite.run.config_merge')
+    @patch('teuthology.suite.run.build_matrix')
+    @patch('teuthology.suite.util.hash_only_in_pulp')
+    @patch('teuthology.suite.util.package_version_for_hash')
+    @patch('teuthology.suite.util.get_arch')
+    def test_newest_skips_pulp_only_sha1_with_warning(
+        self,
+        m_get_arch,
+        m_package_version_for_hash,
+        m_hash_only_in_pulp,
+        m_build_matrix,
+        m_config_merge,
+        m_get_install_task_flavor,
+        m_write_rerun_memo,
+        m_schedule_jobs,
+        m_find_git_parents,
+        caplog,
+    ):
+        """
+        End to end: first sha1 is only in pulp -> warning about missing
+        pulp/quay-int -> second sha1 is simply not built (no warning) ->
+        third sha1 is used.
+        """
+        m_get_arch.return_value = 'x86_64'
+        build_matrix_output = [('desc', ['frag.yml'])]
+        m_build_matrix.return_value = build_matrix_output
+        m_config_merge.return_value = [(a, b, {}) for a, b in build_matrix_output]
+        m_get_install_task_flavor.return_value = 'default'
+        m_package_version_for_hash.side_effect = [None, None, 'ceph_version']
+        m_hash_only_in_pulp.side_effect = [True, False]
+        m_find_git_parents.return_value = ['ceph_sha1_p1', 'ceph_sha1_p2']
+
+        with self.make_run() as runobj:
+            runobj.base_args = list()
+            with caplog.at_level(logging.WARNING, logger='teuthology.suite.run'):
+                count = runobj.schedule_suite()
+        assert count == 1
+        assert runobj.base_config.sha1 == 'ceph_sha1_p2'
+        m_hash_only_in_pulp.assert_has_calls([
+            call('ceph_sha1', 'default', 'ubuntu', '14.04', 'machine_type'),
+            call('ceph_sha1_p1', 'default', 'ubuntu', '14.04', 'machine_type'),
+        ])
+        warnings = [r.getMessage() for r in caplog.records
+                    if r.levelno == logging.WARNING and '--newest' in r.getMessage()]
+        assert len(warnings) == 1
+        assert 'ceph_sha1 ' in warnings[0]
+        assert 'package_source: pulp' in warnings[0]
+        # the pulp-only job was flagged in the schedule-time error log too
+        errors = [r.getMessage() for r in caplog.records
+                  if r.levelno == logging.ERROR and 'lab-internal Pulp' in r.getMessage()]
+        assert len(errors) == 1
+        assert "'ceph_sha1'" in errors[0]

--- a/tests/suite/test_util.py
+++ b/tests/suite/test_util.py
@@ -265,3 +265,87 @@ class TestDistroDefaults(object):
         expected = ('x86_64', 'centos/9',
                     OS(name='centos', version='9.stream', codename='stream'))
         assert util.get_distro_defaults('rhel', 'magna') == expected
+
+
+class TestContainerImageExists(object):
+    def setup_method(self):
+        util.container_image_exists.cache_clear()
+
+    @pytest.mark.parametrize(
+        ['image', 'expected'],
+        [
+            ('quay.ceph.io/ceph-ci/ceph', ('quay.ceph.io', 'ceph-ci/ceph')),
+            ('quay-int.front.sepia.ceph.com/ceph-ci/ceph',
+             ('quay-int.front.sepia.ceph.com', 'ceph-ci/ceph')),
+            ('localhost:5000/ceph/ceph', ('localhost:5000', 'ceph/ceph')),
+            ('ceph/ceph', ('registry-1.docker.io', 'ceph/ceph')),
+            ('ceph', ('registry-1.docker.io', 'library/ceph')),
+        ]
+    )
+    def test_split_container_image(self, image, expected):
+        assert util._split_container_image(image) == expected
+
+    def _resp(self, status, headers=None):
+        resp = Mock()
+        resp.status_code = status
+        resp.headers = headers or {}
+        return resp
+
+    @patch('teuthology.suite.util.requests.head')
+    def test_exists(self, m_head):
+        m_head.return_value = self._resp(200)
+        assert util.container_image_exists('quay.ceph.io/ceph-ci/ceph', 'abc') is True
+        url = m_head.call_args.args[0]
+        assert url == 'https://quay.ceph.io/v2/ceph-ci/ceph/manifests/abc'
+        accept = m_head.call_args.kwargs['headers']['Accept']
+        assert 'application/vnd.oci.image.index.v1+json' in accept
+
+    @patch('teuthology.suite.util.requests.head')
+    def test_missing(self, m_head):
+        m_head.return_value = self._resp(404)
+        assert util.container_image_exists('quay.ceph.io/ceph-ci/ceph', 'abc') is False
+
+    @patch('teuthology.suite.util.requests.head')
+    def test_unknown_status(self, m_head):
+        m_head.return_value = self._resp(500)
+        assert util.container_image_exists('quay.ceph.io/ceph-ci/ceph', 'abc') is None
+
+    @patch('teuthology.suite.util.requests.head')
+    def test_network_error(self, m_head):
+        m_head.side_effect = util.requests.ConnectionError('nope')
+        assert util.container_image_exists('quay.ceph.io/ceph-ci/ceph', 'abc') is None
+
+    @patch('teuthology.suite.util.requests.get')
+    @patch('teuthology.suite.util.requests.head')
+    def test_bearer_token(self, m_head, m_get):
+        challenge = ('Bearer realm="https://auth.example.com/token",'
+                     'service="registry.example.com",'
+                     'scope="repository:ceph/ceph:pull"')
+        m_head.side_effect = [
+            self._resp(401, {'WWW-Authenticate': challenge}),
+            self._resp(200),
+        ]
+        token_resp = Mock()
+        token_resp.json.return_value = {'token': 'T0K3N'}
+        m_get.return_value = token_resp
+        assert util.container_image_exists('registry.example.com/ceph/ceph', 'abc') is True
+        m_get.assert_called_once_with(
+            'https://auth.example.com/token',
+            params={'service': 'registry.example.com',
+                    'scope': 'repository:ceph/ceph:pull'},
+            timeout=30,
+        )
+        second = m_head.call_args_list[1]
+        assert second.kwargs['headers']['Authorization'] == 'Bearer T0K3N'
+
+    @patch('teuthology.suite.util.requests.head')
+    def test_unauthorized_without_bearer(self, m_head):
+        m_head.return_value = self._resp(401, {'WWW-Authenticate': 'Basic realm="x"'})
+        assert util.container_image_exists('registry.example.com/ceph/ceph', 'abc') is None
+
+    @patch('teuthology.suite.util.requests.head')
+    def test_cached(self, m_head):
+        m_head.return_value = self._resp(404)
+        util.container_image_exists('quay.ceph.io/ceph-ci/ceph', 'abc')
+        util.container_image_exists('quay.ceph.io/ceph-ci/ceph', 'abc')
+        assert m_head.call_count == 1

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -731,6 +731,89 @@ class TestShamanProject(TestBuilderProject):
         }
     ]
 
+    # A sha1 that was built both by the cve-pipeline (repos on Pulp; newest,
+    # so shaman lists it first) and by the regular pipeline (repos on chacra).
+    SHAMAN_SEARCH_RESPONSE_PULP_AND_CHACRA = [
+        {
+            "url": "https://pulp.front.sepia.ceph.com/pulp/content/repos/ceph/wip-cve-dryrun_tentacle/66f67bca/rocky/10/flavors/default/",
+            "chacra_url": "https://pulp.front.sepia.ceph.com/pulp/api/v3/repositories/rpm/rpm/019fedb6-4793-72bd-895b-d0aa8effb7ad/",
+            "ref": "wip-cve-dryrun_tentacle",
+            "sha1": "66f67bca",
+            "distro": "rocky",
+            "distro_version": "10",
+            "status": "ready",
+            "flavor": "default",
+            "project": "ceph",
+            "archs": ["x86_64", "source"],
+            "extra": {
+                "version": "20.2.3-1-g66f67bca",
+                "package_manager_version": "20.2.3-1.g66f67bca",
+                "job_name": "cve-pipeline",
+            },
+        },
+        {
+            "url": "https://3.chacra.ceph.com/r/ceph/tentacle/66f67bca/rocky/10/flavors/default/",
+            "chacra_url": "https://3.chacra.ceph.com/repos/ceph/tentacle/66f67bca/rocky/10/flavors/default/",
+            "ref": "tentacle",
+            "sha1": "66f67bca",
+            "distro": "rocky",
+            "distro_version": "10",
+            "status": "ready",
+            "flavor": "default",
+            "project": "ceph",
+            "archs": ["x86_64", "source"],
+            "extra": {
+                "version": "20.2.3-1-g66f67bca",
+                "package_manager_version": "20.2.3-1.g66f67bca",
+                "job_name": "ceph-dev-pipeline",
+            },
+        },
+    ]
+
+    def _builder_with_search_response(self, response):
+        config = dict(
+            os_type="rocky",
+            os_version="10.1",
+            sha1='66f67bca',
+            arch='x86_64',
+            flavor='default',
+        )
+        builder = self.klass("ceph", config)
+        search_resp = Mock()
+        search_resp.ok = True
+        search_resp.url = 'https://shaman.ceph.com/api/search/?...'
+        search_resp.json.return_value = response
+        self.m_get.return_value = search_resp
+        return builder
+
+    def test_pulp_hosted_results_are_skipped(self):
+        builder = self._builder_with_search_response(
+            self.SHAMAN_SEARCH_RESPONSE_PULP_AND_CHACRA)
+        # the chacra-hosted entry is used even though it is listed second
+        assert builder.repo_url == \
+            "https://3.chacra.ceph.com/repos/ceph/tentacle/66f67bca/rocky/10/flavors/default/repo"
+        assert builder.base_url == \
+            "https://3.chacra.ceph.com/r/ceph/tentacle/66f67bca/rocky/10/flavors/default/"
+        assert builder.version == "20.2.3-1.g66f67bca"
+        assert builder.sha1 == "66f67bca"
+        assert not builder.pulp_only
+
+    def test_pulp_only_results(self):
+        builder = self._builder_with_search_response(
+            self.SHAMAN_SEARCH_RESPONSE_PULP_AND_CHACRA[:1])
+        assert builder.pulp_only
+        assert not builder.build_complete
+        with pytest.raises(packaging.VersionNotFoundError):
+            builder.repo_url
+        with pytest.raises(packaging.VersionNotFoundError):
+            builder.version
+
+    def test_no_results_not_pulp_only(self):
+        builder = self._builder_with_search_response([])
+        assert not builder.pulp_only
+        with pytest.raises(packaging.VersionNotFoundError):
+            builder.version
+
     def test_build_complete_success(self):
         config = dict(
             os_type="centos",

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -919,13 +919,69 @@ class ShamanProject(GitbuilderProject):
 
     def _get_base_url(self):
         self.assert_result()
-        return self._result.json()[0]['url']
+        return self._results[0]['url']
 
     @property
     def _result(self):
         if getattr(self, '_result_obj', None) is None:
             self._result_obj = self._search()
         return self._result_obj
+
+    @staticmethod
+    def _is_pulp_hosted(result):
+        """
+        Shaman also indexes builds whose repos live on a Pulp instance rather
+        than on chacra (e.g. security builds from the cve-pipeline). Those
+        entries carry Pulp URLs in ``url``/``chacra_url``.
+        """
+        return any(
+            '/pulp/' in (result.get(key) or '')
+            for key in ('url', 'chacra_url')
+        )
+
+    @property
+    def _results(self):
+        """
+        The search results this class can actually consume, newest first.
+
+        Pulp-hosted entries are skipped: they have no ``<chacra_url>/repo``
+        to fetch, so a shaman-sourced install of one of them fails with a
+        404 partway through. Anyone wanting those builds must use
+        ``package_source: pulp``.
+        """
+        if getattr(self, '_results_obj', None) is None:
+            usable, pulp_hosted = [], []
+            for result in self._result.json():
+                if self._is_pulp_hosted(result):
+                    pulp_hosted.append(result)
+                else:
+                    usable.append(result)
+            if pulp_hosted:
+                refs = sorted({r.get('ref') for r in pulp_hosted})
+                log.info(
+                    "Ignoring %d shaman result(s) for %s hosted on Pulp "
+                    "(ref %s); not usable with package_source: shaman",
+                    len(pulp_hosted), self._result.url, ', '.join(refs),
+                )
+            self._results_obj = usable
+            self._pulp_hosted_results = pulp_hosted
+        return self._results_obj
+
+    @property
+    def pulp_only(self):
+        """
+        True if shaman knows this build only from repos hosted on Pulp, i.e.
+        it exists but cannot be installed with package_source: shaman.
+
+        NOTE: this detection relies on ceph-build's cve-pipeline continuing to
+        register its Pulp-hosted builds in shaman with Pulp URLs in the
+        ``chacra_url`` (and ``url``) fields of the search results, as it does
+        today. If that ever stops, Pulp-only sha1s will simply look "not
+        found" here: no false positives, but teuthology-suite loses the hint
+        that the sha1 exists on Pulp and --newest will backtrack past it
+        without the explanatory warning.
+        """
+        return bool(not self._results and self._pulp_hosted_results)
 
     def _search(self):
         uri = self._search_uri
@@ -998,7 +1054,7 @@ class ShamanProject(GitbuilderProject):
         return result
 
     def assert_result(self):
-        if len(self._result.json()) == 0:
+        if not self._results:
             raise VersionNotFoundError(self._result.url)
 
     _get_distro = GitbuilderProject._get_distro_numeric
@@ -1006,25 +1062,25 @@ class ShamanProject(GitbuilderProject):
     def _get_package_sha1(self):
         # This doesn't raise because GitbuilderProject._get_package_sha1()
         # doesn't either.
-        if not len(self._result.json()):
+        if not self._results:
             log.error("sha1 not found: %s", self._result.url)
         else:
-            return self._result.json()[0]['sha1']
+            return self._results[0]['sha1']
 
     def _get_package_version(self):
         self.assert_result()
-        return self._result.json()[0]['extra']['package_manager_version']
+        return self._results[0]['extra']['package_manager_version']
 
     @property
     def scm_version(self):
         self.assert_result()
-        return self._result.json()[0]['extra']['version']
+        return self._results[0]['extra']['version']
 
     @property
     def repo_url(self):
         self.assert_result()
         return urljoin(
-            self._result.json()[0]['chacra_url'],
+            self._results[0]['chacra_url'],
             'repo',
         )
 
@@ -1040,7 +1096,7 @@ class ShamanProject(GitbuilderProject):
         # self._result has status, project, flavor, distros, arch, and sha1
         # restrictions, so the only reason for multiples should be "multiple
         # builds of the same sha1 etc."; the first entry is the newest
-        search_result = self._result.json()[0]
+        search_result = self._results[0]
 
         # now look for the build complete status
         path = '/'.join(

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -168,6 +168,62 @@ class Run(object):
                 sha1,
             )
 
+    @classmethod
+    def uses_cephadm(cls, tasks):
+        """
+        Whether a job's task list deploys a cluster with cephadm (looking
+        into sequential/parallel groups too). Only those jobs need the
+        ceph-ci container for the sha1 under test.
+        """
+        for task in tasks or []:
+            if not isinstance(task, dict):
+                continue
+            for name, conf in task.items():
+                if name == 'cephadm' or name.startswith('cephadm.'):
+                    return True
+                if name in ('sequential', 'parallel') and \
+                        cls.uses_cephadm(conf):
+                    return True
+        return False
+
+    def cephadm_container_ref(self, sha1, flavor='default'):
+        """
+        The image:tag the cephadm task will pull for this sha1, following
+        qa/tasks/cephadm.py: <image>:<sha1>, with crimson flavors appended.
+        Returns None if no image is configured, or if the configured image
+        already pins a tag/digest (then the sha1 does not matter).
+        """
+        image = self.cephadm_container_image()
+        if not image or any(c in image for c in (':', '@')):
+            return None
+        tag = sha1
+        if flavor in ('crimson-debug', 'crimson-release'):
+            tag += f'-{flavor}'
+        return f'{image}:{tag}'
+
+    def container_missing(self, sha1, flavor='default'):
+        """
+        True if the registry says the cephadm container for this sha1 does
+        not exist. False if it exists, is not applicable, or the registry
+        could not be queried (we do not hold up scheduling on a guess).
+        """
+        ref = self.cephadm_container_ref(sha1, flavor)
+        if ref is None:
+            return False
+        image, tag = ref.rsplit(':', 1)
+        return util.container_image_exists(image, tag) is False
+
+    def warn_missing_container(self, sha1, flavor='default', newest=False):
+        ref = self.cephadm_container_ref(sha1, flavor)
+        msg = (f"ceph sha1 {sha1} has packages but no container at {ref}. "
+               f"Pending release build, or failed container build of a "
+               f"passed package build?")
+        if newest:
+            msg += f" Moving on to the next sha1 of {self.base_config.branch}"
+        else:
+            msg += " cephadm jobs will fail to pull it"
+        log.warning(msg)
+
     def make_run_name(self):
         """
         Generate a run name. A run name looks like:
@@ -580,6 +636,7 @@ class Run(object):
     def collect_jobs(self, arch, configs, newest=False, limit=0):
         jobs_to_schedule = []
         jobs_missing_packages = []
+        containers_warned = set()
         for description, fragment_paths, parsed_yaml in configs:
             if limit > 0 and len(jobs_to_schedule) >= limit:
                 log.info(
@@ -653,6 +710,19 @@ class Run(object):
                     # optimization: one missing package causes backtrack in newest mode;
                     # no point in continuing the search
                     if newest:
+                        return jobs_missing_packages, []
+                elif self.uses_cephadm(parsed_yaml.get('tasks')) and \
+                        self.container_missing(sha1, flavor):
+                    # Packages exist but the ceph-ci container does not, e.g.
+                    # a release build (CI_CONTAINER=false). Warn once per
+                    # sha1/flavor; in newest mode treat it like missing
+                    # packages so we back off to the next sha1.
+                    if (sha1, flavor) not in containers_warned:
+                        containers_warned.add((sha1, flavor))
+                        self.warn_missing_container(sha1, flavor, newest)
+                    if newest:
+                        jobs_missing_packages.append(job)
+                        job['container_missing'] = True
                         return jobs_missing_packages, []
 
             jobs_to_schedule.append(job)

--- a/teuthology/suite/run.py
+++ b/teuthology/suite/run.py
@@ -17,7 +17,9 @@ from teuthology.config import config, JobConfig
 from teuthology.exceptions import (
     BranchMismatchError, BranchNotFoundError, CommitNotFoundError,
 )
-from teuthology.misc import deep_merge, get_results_url, update_key
+from teuthology.misc import (
+    deep_merge, get_results_url, merge_configs, update_key,
+)
 from teuthology.orchestra.opsys import OS
 from teuthology.repo_utils import build_git_url
 
@@ -29,6 +31,15 @@ from teuthology.util.time import parse_offset, parse_timestamp, TIMESTAMP_FMT
 
 log = logging.getLogger(__name__)
 
+# Some builds (currently only security builds) are published exclusively to
+# the lab-internal Pulp and Quay instances rather than shaman/chacra and
+# quay.io. A run that does not opt in to both of these (via a job yaml passed
+# to teuthology-suite) cannot find those sha1s, and --newest will backtrack
+# past them.
+INTERNAL_PACKAGE_SOURCE = 'pulp'
+INTERNAL_CONTAINER_REGISTRY = 'quay-int.front.sepia.ceph.com'
+INTERNAL_CONTAINER_IMAGE = f'{INTERNAL_CONTAINER_REGISTRY}/ceph-ci/ceph'
+
 
 class Run(object):
     WAIT_MAX_JOB_TIME = 30 * 60
@@ -36,6 +47,7 @@ class Run(object):
     __slots__ = (
         'args', 'name', 'base_config', 'suite_repo_path', 'base_yaml_paths',
         'base_args', 'kernel_dict', 'config_input', 'timestamp', 'user', 'os',
+        'extra_config',
     )
 
     def __init__(self, args):
@@ -59,6 +71,102 @@ class Run(object):
         # (absolute paths are unchanged by this)
         self.base_yaml_paths = [os.path.join(self.suite_repo_path, b) for b in
                                 self.args.base_yaml_paths]
+        # The extra job yamls are normally only handed to teuthology-schedule,
+        # but scheduling needs to know about job-level settings such as
+        # package_source in order to look for packages in the right place.
+        self.extra_config = merge_configs(self.base_yaml_paths) or dict()
+        self.apply_extra_config()
+
+    def apply_extra_config(self):
+        """
+        Honor job-level settings from the extra <config_yaml> files that
+        affect scheduling itself.
+
+        Mirrors teuthology.run: a job-level ``package_source`` overrides the
+        site-wide one, so that the package checks done while scheduling
+        (--newest backtracking, verify_ceph_hash) look in the same place the
+        jobs will.
+        """
+        package_source = self.extra_config.get('package_source')
+        if not package_source or package_source == config.package_source:
+            return
+        if package_source == 'pulp':
+            pulp_cfg = dict(config.pulp or dict())
+            pulp_cfg.update(self.extra_config.get('pulp') or dict())
+            if not (pulp_cfg.get('username') and pulp_cfg.get('password')):
+                log.warning(
+                    "Job yaml selects package_source: pulp but no Pulp "
+                    "credentials are configured on this host; scheduling "
+                    "will check for packages using package_source: %s "
+                    "instead", config.package_source)
+                return
+        log.info("Using package_source '%s' from job yaml to check for "
+                 "packages while scheduling", package_source)
+        config.package_source = package_source
+
+    def cephadm_container_image(self):
+        """
+        The container image the cephadm task will use, as far as scheduling
+        can tell: job-level overrides, then job-level defaults, then the
+        site-wide defaults. Returns None if none of them set one.
+        """
+        def image_from(section):
+            section = section or dict()
+            cephadm = section.get('cephadm') or dict()
+            containers = cephadm.get('containers') or dict()
+            return containers.get('image')
+
+        for section in (
+            self.extra_config.get('overrides'),
+            self.extra_config.get('defaults'),
+            config.get('defaults'),
+        ):
+            image = image_from(section)
+            if image:
+                return image
+        return None
+
+    def missing_internal_sources(self):
+        """
+        Return descriptions of the settings this run lacks in order to find
+        builds published only to the lab-internal Pulp/Quay (see INTERNAL_*),
+        or an empty list if the run selects all of them.
+        """
+        missing = []
+        package_source = (
+            self.extra_config.get('package_source') or config.package_source
+        )
+        if package_source != INTERNAL_PACKAGE_SOURCE:
+            missing.append(f'package_source: {INTERNAL_PACKAGE_SOURCE}')
+        image = self.cephadm_container_image() or ''
+        if image.split('/')[0] != INTERNAL_CONTAINER_REGISTRY:
+            missing.append(
+                f'defaults.cephadm.containers.image: {INTERNAL_CONTAINER_IMAGE}'
+            )
+        return missing
+
+    def warn_pulp_only_sha1(self, sha1):
+        """
+        Called when --newest skips a sha1 whose packages exist only in the
+        lab-internal Pulp (e.g. a security build), so the user knows why it
+        was skipped and, if the run does not select Pulp/Quay, how to opt in.
+        """
+        missing = self.missing_internal_sources()
+        if missing:
+            log.warning(
+                "--newest: ceph sha1 %s was only built to the lab-internal "
+                "Pulp/Quay (e.g. a security build), and this run does not "
+                "select %s. To test that sha1, add that to a job yaml passed "
+                "to teuthology-suite. Moving on to the next sha1.",
+                sha1, ' and '.join(missing),
+            )
+        else:
+            log.warning(
+                "--newest: ceph sha1 %s was only built to the lab-internal "
+                "Pulp/Quay and could not be verified there from this host. "
+                "Moving on to the next sha1.",
+                sha1,
+            )
 
     def make_run_name(self):
         """
@@ -530,6 +638,18 @@ class Run(object):
                     jobs_missing_packages.append(job)
                     log.error(f"Packages for os_type '{os_type}', flavor {flavor} and "
                          f"ceph hash '{sha1}' not found")
+                    if util.hash_only_in_pulp(sha1, flavor, os_type,
+                                              os_version, self.args.machine_type):
+                        job['pulp_only'] = True
+                        log.error(
+                            f"ceph hash '{sha1}' was only built to the "
+                            f"lab-internal Pulp (e.g. a security build); it "
+                            f"cannot be installed with package_source: "
+                            f"{config.package_source}. Select package_source: "
+                            f"{INTERNAL_PACKAGE_SOURCE} and "
+                            f"defaults.cephadm.containers.image: "
+                            f"{INTERNAL_CONTAINER_IMAGE} in a job yaml to "
+                            f"test it")
                     # optimization: one missing package causes backtrack in newest mode;
                     # no point in continuing the search
                     if newest:
@@ -680,6 +800,8 @@ Note: If you still want to go ahead, use --job-threshold 0'''
             jobs_missing_packages, jobs_to_schedule = \
                 self.collect_jobs(arch, configs, self.args.newest, job_limit)
             if jobs_missing_packages and self.args.newest:
+                if any(j.get('pulp_only') for j in jobs_missing_packages):
+                    self.warn_pulp_only_sha1(self.base_config.sha1)
                 if not sha1s:
                     sha1s = util.find_git_parents(
                         self.ceph_repo_name,

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -2,6 +2,7 @@ import copy
 import functools
 import logging
 import os
+import re
 import requests
 import smtplib
 import socket
@@ -286,6 +287,89 @@ def hash_only_in_pulp(hash, flavor='default', distro='rhel',
         return bool(getattr(bp, 'pulp_only', False))
     except (VersionNotFoundError, requests.RequestException):
         return False
+
+
+_MANIFEST_ACCEPT = ', '.join([
+    'application/vnd.docker.distribution.manifest.v2+json',
+    'application/vnd.docker.distribution.manifest.list.v2+json',
+    'application/vnd.oci.image.manifest.v1+json',
+    'application/vnd.oci.image.index.v1+json',
+])
+
+
+def _split_container_image(image):
+    """
+    Split 'registry/repo' into (registry, repo). Images without a registry
+    component (no '.' or ':' in the first path element) are assumed to be
+    on Docker Hub, e.g. 'ceph/ceph' -> ('registry-1.docker.io', 'ceph/ceph').
+    """
+    first, sep, rest = image.partition('/')
+    if sep and ('.' in first or ':' in first or first == 'localhost'):
+        return first, rest
+    repo = image if '/' in image else f'library/{image}'
+    return 'registry-1.docker.io', repo
+
+
+def _registry_bearer_token(www_authenticate, repo):
+    """
+    Given a 'Bearer realm="...",service="...",scope="..."' challenge, fetch
+    an anonymous pull token. Returns None if that does not work out.
+    """
+    if not www_authenticate or not www_authenticate.startswith('Bearer '):
+        return None
+    params = dict(
+        re.findall(r'(\w+)="([^"]*)"', www_authenticate[len('Bearer '):])
+    )
+    realm = params.get('realm')
+    if not realm:
+        return None
+    query = dict()
+    if params.get('service'):
+        query['service'] = params['service']
+    query['scope'] = params.get('scope') or f'repository:{repo}:pull'
+    try:
+        resp = requests.get(realm, params=query, timeout=30)
+        resp.raise_for_status()
+        body = resp.json()
+        return body.get('token') or body.get('access_token')
+    except (requests.RequestException, ValueError):
+        return None
+
+
+@functools.lru_cache()
+def container_image_exists(image, tag):
+    """
+    Ask the registry (OCI distribution / Docker registry v2 API) whether
+    image:tag exists.
+
+    :returns: True if it does, False if the registry says it does not (404),
+              None if that could not be determined (auth we can't satisfy,
+              unexpected status, network error) - callers should not treat
+              None as missing.
+    """
+    registry, repo = _split_container_image(image)
+    url = f'https://{registry}/v2/{repo}/manifests/{tag}'
+    headers = {'Accept': _MANIFEST_ACCEPT}
+    try:
+        resp = requests.head(url, headers=headers, timeout=30)
+        if resp.status_code == 401:
+            token = _registry_bearer_token(
+                resp.headers.get('WWW-Authenticate'), repo)
+            if token:
+                headers['Authorization'] = f'Bearer {token}'
+                resp = requests.head(url, headers=headers, timeout=30)
+    except requests.RequestException as exc:
+        log.warning("Could not query %s for %s:%s: %s",
+                    registry, repo, tag, exc)
+        return None
+    if resp.status_code == 200:
+        return True
+    if resp.status_code == 404:
+        return False
+    log.warning("Unexpected HTTP %s querying %s for %s:%s; cannot tell "
+                "whether the container exists", resp.status_code, registry,
+                repo, tag)
+    return None
 
 
 def get_arch(machine_type):

--- a/teuthology/suite/util.py
+++ b/teuthology/suite/util.py
@@ -224,17 +224,18 @@ def get_branch_info(project, branch, project_owner='ceph'):
 
 
 @functools.lru_cache()
-def package_version_for_hash(hash, flavor='default', distro='rhel',
-                             distro_version='8.0', machine_type='smithi'):
+def _builder_project_for_hash(hash, flavor='default', distro='rhel',
+                              distro_version='8.0', machine_type='smithi'):
     """
-    Does what it says on the tin. Uses gitbuilder repos.
-
-    :returns: a string.
+    Build (and cache) the builder project object used to look up packages
+    for a given ceph hash. The object caches its own search results, so
+    sharing it between package_version_for_hash() and
+    hash_only_in_pulp() avoids repeated queries.
     """
     (arch, release, _os) = get_distro_defaults(distro, machine_type)
     if distro in (None, 'None'):
         distro = _os.name
-    bp = get_builder_project()(
+    return get_builder_project()(
         'ceph',
         dict(
             flavor=flavor,
@@ -245,7 +246,19 @@ def package_version_for_hash(hash, flavor='default', distro='rhel',
         ),
     )
 
-    if (bp.distro == CONTAINER_DISTRO and bp.flavor == CONTAINER_FLAVOR and 
+
+@functools.lru_cache()
+def package_version_for_hash(hash, flavor='default', distro='rhel',
+                             distro_version='8.0', machine_type='smithi'):
+    """
+    Does what it says on the tin. Uses gitbuilder repos.
+
+    :returns: a string.
+    """
+    bp = _builder_project_for_hash(hash, flavor, distro, distro_version,
+                                   machine_type)
+
+    if (bp.distro == CONTAINER_DISTRO and bp.flavor == CONTAINER_FLAVOR and
             not bp.build_complete):
         log.info("Container build incomplete")
         return None
@@ -254,6 +267,25 @@ def package_version_for_hash(hash, flavor='default', distro='rhel',
         return bp.version
     except VersionNotFoundError:
         return None
+
+
+def hash_only_in_pulp(hash, flavor='default', distro='rhel',
+                      distro_version='8.0', machine_type='smithi'):
+    """
+    True if the configured package source (shaman) knows about this ceph hash
+    only from repos hosted on Pulp - e.g. a security build - which it cannot
+    install from. Always False for other package sources.
+
+    NOTE: depends on the cve-pipeline registering its Pulp-hosted builds in
+    shaman; see ShamanProject.pulp_only. If it stops doing so this simply
+    returns False and the sha1 is treated as not built at all.
+    """
+    bp = _builder_project_for_hash(hash, flavor, distro, distro_version,
+                                   machine_type)
+    try:
+        return bool(getattr(bp, 'pulp_only', False))
+    except (VersionNotFoundError, requests.RequestException):
+        return False
 
 
 def get_arch(machine_type):


### PR DESCRIPTION
## Problem

Security builds from the cve-pipeline are pushed to the lab-internal Pulp but still registered in shaman, with `url`/`chacra_url` pointing at Pulp. Shaman lists them first (newest), so for a sha1 that has both a cve build and a regular chacra build, `ShamanProject` picked the Pulp-hosted entry and 404'd fetching `<chacra_url>/repo` from the Pulp API:

```
teuthology-suite -s smoke -m smithi -c tentacle --newest 20 ...
...
INFO:teuthology.task.install.rpm:Pulling from https://pulp.front.sepia.ceph.com/pulp/content/repos/ceph/wip-yuriw-cve-dryrun_tentacle/66f67bca.../rocky/10/flavors/default/
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://pulp.front.sepia.ceph.com/pulp/api/v3/repositories/rpm/rpm/019fedb6-4793-72bd-895b-d0aa8effb7ad/repo
```

Because `teuthology-suite`'s schedule-time package check uses the same `ShamanProject`, `--newest` happily scheduled that sha1 too.

## Changes

**`packaging: ignore Pulp-hosted shaman results`**
- `ShamanProject` filters out search results whose `url`/`chacra_url` are Pulp-hosted and uses the first usable (chacra) one. For the sha1 above, `repo_url` now resolves to `https://3.chacra.ceph.com/repos/ceph/tentacle/66f67bca.../rocky/10/flavors/default/repo` (verified against live shaman).
- With `package_source: shaman`, a sha1 that *only* has a Pulp build is treated as not found; new `pulp_only` property tells the two cases apart.
- `package_source: pulp` is unaffected: `PulpProject` never consults shaman, it searches the Pulp API directly.

**`suite: warn and back off when --newest hits a Pulp-only sha1`**
- `--newest`: a Pulp-only sha1 is skipped with a warning saying so and, if the run doesn't select `package_source: pulp` and `defaults.cephadm.containers.image: quay-int.front.sepia.ceph.com/ceph-ci/ceph`, how to opt in. Non-newest runs get the same hint in the error before failing on missing packages.
- `teuthology-suite` now reads the extra `<config_yaml>` files it's given (previously only forwarded to `teuthology-schedule`) so it can tell what the run selects.
- A job-level `package_source` is honored for the schedule-time checks (mirroring `teuthology.run`), so passing `pulp.yaml` makes `--newest` verify against Pulp instead of shaman. Falls back to the site `package_source` with a warning if no Pulp credentials are configured on the scheduling host.
- Docs / `--newest` help text updated.

**`suite: back off with --newest when a sha1 has packages but no container`**
- Release builds (`ceph-release-pipeline` → `ceph-dev-pipeline` with `CI_CONTAINER=false`) have packages and a `completed` shaman build record, but no ceph-ci container — e.g. tentacle `7f793731…` right now: shaman says ready, `quay.ceph.io/ceph-ci/ceph:7f793731…` is 404. Nothing in shaman records this, so `--newest` would pick it and cephadm jobs would fail to pull.
- For jobs whose tasks use `cephadm`, ask the registry of the configured cephadm image (`defaults`/`overrides.cephadm.containers.image`) whether `<image>:<sha1>` exists (registry v2 manifest HEAD; anonymous bearer token fetched when challenged). If not:
  > `ceph sha1 <sha1> has packages but no container at <image>:<sha1>. Pending release build, or failed container build of a passed package build? Moving on to the next sha1 of <ref>`
  
  and with `--newest` the sha1 is treated like missing packages so we back off. Without `--newest` it's only a warning. If the registry can't be queried, scheduling proceeds as before. Non-cephadm jobs never trigger the lookup, so non-container suites can still test release sha1s.
- Verified live: `quay.ceph.io/ceph-ci/ceph:7f793731…` → missing, `:66f67bca…` → exists; Docker Hub token flow works (`alpine:latest`).

## Reviewer notes

- The Pulp-only detection relies on the cve-pipeline continuing to register its builds in shaman with Pulp URLs in `chacra_url`/`url`. If that ever stops, Pulp-only sha1s just look "not found" (no false positives, but the explanatory warning goes away). Noted in `ShamanProject.pulp_only` and `util.hash_only_in_pulp`.
- The quay-int hostname / pulp source name are module constants in `teuthology/suite/run.py` (`INTERNAL_*`); happy to make them site-config knobs if preferred.

## Testing

`tests/test_packaging.py`, `tests/suite`, `tests/scripts/test_suite.py`, `tests/task/test_install.py`: 321 passed. New tests cover the exact two-entry shaman response from the failing job, the Pulp-only case, config-based detection of pulp/quay-int selection, an end-to-end `--newest` run that skips a Pulp-only sha1 with one warning, the registry helper (200/404/401+token/error), and an end-to-end `--newest` run that skips a container-less sha1.



