### PR TITLE
opsys: let a job ask for a major-only Rocky version

### DIFF
--- a/tests/orchestra/test_opsys.py
+++ b/tests/orchestra/test_opsys.py
@@ -406,3 +406,20 @@ class TestOS(object):
     def test_eq_not_equal(self):
         os = OS(name='ubuntu', codename='trusty', version='16.04')
         assert OS(name='ubuntu', codename='trusty', version='14.04') != os
+
+    def test_eq_major_only_matches_any_minor(self):
+        major = OS(name='ubuntu', version='24')
+        assert major == OS(name='ubuntu', version='24.04')
+        assert major == OS(name='ubuntu', version='24.10')
+        assert major != OS(name='ubuntu', version='22.10')
+        assert OS(name='rocky', version='10') == OS(name='rocky', version='10.2')
+        assert OS(name='rocky', version='10') != OS(name='alma', version='10.2')
+
+    def test_eq_dotted_versions_never_cross_match(self):
+        assert OS(name='ubuntu', version='24.10') != OS(name='ubuntu', version='24.04')
+        assert OS(name='rocky', version='10.1') != OS(name='rocky', version='10.2')
+
+    def test_version_codename_rocky_major_aliases(self):
+        for version in ('8', '9', '10'):
+            assert OS.version_codename('rocky', version) == (version, 'rocky')
+        assert OS.version_codename('rocky', '10.1') == ('10.1', 'rocky')

--- a/tests/provision/test_fog.py
+++ b/tests/provision/test_fog.py
@@ -178,6 +178,49 @@ class TestFOG(object):
         assert req.body == '{"name": "type1_windows_xp"}'
         assert result == img_objs[0]
 
+    @mark.parametrize(
+        'images,expected_name,expected_resolved',
+        [
+            # exact major-named image wins when it exists
+            ([dict(id=1, name='type1_rocky_10', size='1:2:')],
+             'type1_rocky_10', None),
+            # otherwise the latest captured minor is used and remembered
+            ([dict(id=2, name='type1_rocky_10.1', size='1:2:'),
+              dict(id=3, name='type1_rocky_10.2', size='1:2:')],
+             'type1_rocky_10.2', '10.2'),
+            # an image without a size is a template, not a candidate
+            ([dict(id=2, name='type1_rocky_10.1', size='1:2:'),
+              dict(id=3, name='type1_rocky_10.2', size='')],
+             'type1_rocky_10.1', '10.1'),
+        ],
+    )
+    def test_get_image_data_major_only(
+            self, images, expected_name, expected_resolved):
+        exact = [i for i in images if i['name'] == 'type1_rocky_10']
+
+        def fake_json():
+            # first call: exact-name lookup; second: the search
+            call = len(self.mocks['m_requests_Session_send'].call_args_list)
+            if call <= 1:
+                return dict(count=len(exact), images=exact)
+            return dict(count=len(images), images=images)
+
+        self.mocks['m_requests_Session_send']\
+            .return_value.json.side_effect = fake_json
+        self.mocks['m_Remote_machine_type'].return_value = 'type1'
+        obj = self.klass('name.fqdn', 'rocky', '10')
+        result = obj.get_image_data()
+        assert result['name'] == expected_name
+        assert obj.resolved_os_version == expected_resolved
+
+    def test_get_image_data_major_only_none_captured(self):
+        self.mocks['m_requests_Session_send']\
+            .return_value.json.return_value = dict(count=0, images=[])
+        self.mocks['m_Remote_machine_type'].return_value = 'type1'
+        obj = self.klass('name.fqdn', 'rocky', '10')
+        with raises(RuntimeError):
+            obj.get_image_data()
+
     def test_suggest_image_names(self):
         data = {'images': [
             {'name': 'mira_rhel_9.1'},

--- a/teuthology/orchestra/opsys.py
+++ b/teuthology/orchestra/opsys.py
@@ -49,6 +49,10 @@ DISTRO_CODENAME_MAP = {
         "9.8": "rocky",
         "10.1": "rocky",
         "10.2": "rocky",
+        # aliases for latest minor releases
+        "8": "rocky",
+        "9": "rocky",
+        "10": "rocky",
     },
     "centos": {
         "10": "stream",
@@ -277,7 +281,18 @@ class OS(object):
                     codename=repr(self.codename))
 
     def __eq__(self, other):
+        """
+        Equal when the names match and the versions match.  A major-only
+        version matches any minor of that major ("24" == "24.04"); two
+        dotted versions must match exactly ("24.10" != "24.04").  centos's
+        ".stream" suffix is ignored.  See commit message for the why.
+        """
         if self.name.lower() != other.name.lower():
             return False
         normalize = lambda s: s.lower().removesuffix(".stream")
-        return normalize(self.version) == normalize(other.version)
+        mine, theirs = normalize(self.version), normalize(other.version)
+        if mine == theirs:
+            return True
+        if '.' not in mine or '.' not in theirs:
+            return mine.split('.')[0] == theirs.split('.')[0]
+        return False

--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -66,6 +66,8 @@ class FOG(object):
         self.shortname = self.remote.shortname
         self.os_type = os_type
         self.os_version = os_version
+        # set when a major-only os_version gets resolved to a point release
+        self.resolved_os_version = None
         self.log = log.getChild(self.shortname)
 
     def create(self):
@@ -163,14 +165,45 @@ class FOG(object):
         name = f"{self.remote.machine_type}_{os_type}_{os_version}"
         if image := do_get(name):
             return image
-        elif os_type == 'centos' and not os_version.endswith('.stream'):
+        if os_type == 'centos' and not os_version.endswith('.stream'):
             image = do_get(f"{name}.stream")
+        elif '.' not in os_version:
+            # A major-only version means the latest minor the lab has an
+            # image for; the deploy is verified against that exact minor
+            image = self._latest_minor_image(name)
         if image:
             return image
-        else:
-            raise RuntimeError(
-                "Fog has no %s image. Available %s images: %s" %
-                (name, self.remote.machine_type, self.suggest_image_names()))
+        raise RuntimeError(
+            "Fog has no %s image. Available %s images: %s" %
+            (name, self.remote.machine_type, self.suggest_image_names()))
+
+    def _latest_minor_image(self, base_name):
+        """
+        The latest captured point-release image for a major-only version,
+        e.g. trial_rocky_10 -> trial_rocky_10.2 over trial_rocky_10.1.
+        Only images FOG has a size for (i.e. a completed capture) count.
+
+        :returns: The image dict, or None
+        """
+        resp = self.do_request(f'/image/search/{base_name}')
+        best = best_key = None
+        for image in resp.json().get('images') or []:
+            img_name = image.get('name') or ''
+            if not img_name.startswith(base_name + '.') or not image.get('size'):
+                continue
+            try:
+                key = tuple(int(p) for p in img_name[len(base_name) + 1:].split('.'))
+            except ValueError:
+                continue
+            if best_key is None or key > best_key:
+                best, best_key = image, key
+        if best:
+            self.resolved_os_version = best['name'].rsplit('_', 1)[-1]
+            self.log.info(
+                "Resolved %s %s to image %s",
+                self.os_type, self.os_version, best['name'],
+            )
+        return best
 
     def suggest_image_names(self):
         """
@@ -375,7 +408,10 @@ class FOG(object):
         )
 
     def _verify_installed_os(self):
-        wanted_os = OS(name=self.os_type, version=self.os_version)
+        wanted_os = OS(
+            name=self.os_type,
+            version=self.resolved_os_version or self.os_version,
+        )
         if self.remote.os != wanted_os:
             raise RuntimeError(
                 f"Expected {self.remote.shortname}'s OS to be {wanted_os} but "


### PR DESCRIPTION
Rocky only maintains its newest point release and ceph's rocky/10 builds are compiled on it (they now need `c-ares >= 1.28`, which only 10.2 ships — see ceph/ceph-cm-ansible#873), so the lab is moving to treating Rocky 10 like CentOS Stream: the FOG image is named by major (`trial_rocky_10`), the capture job keeps it on the current minor, and jobs request `os_version: "10"` instead of `"10.1"`.

Two things stood in the way of `os_version: "10"`:

- `packaging.py` calls `OS.version_codename()` for every job with an `os_version`, and `DISTRO_CODENAME_MAP['rocky']` only had point releases, so `"10"` raised `KeyError: '10 not a rocky version or codename'` at `check_packages`. Add the major, the way centos has `"9"` and `"10"`.
- FOG's `_verify_installed_os()` compares `OS('rocky', '10')` with the node's `/etc/os-release` (`VERSION_ID="10.1"`), and `OS.__eq__` compared versions exactly (only stripping `.stream`), so every deploy would be rejected with `Expected … rocky 10 but found rocky 10.1`. Treat a major-only version as matching any point release of that major; two full versions still have to match exactly.

Nothing else keys on the minor: the FOG image name is built from `os_version` verbatim, reimage-type nodes aren't filtered by OS when locking (`lock/ops.py`), and the shaman/pulp queries already use the major (`rocky/10/x86_64`).

Tests added for the equality rule and the codename lookup; `tests/orchestra/test_opsys.py` + `tests/test_packaging.py` pass.

Companion changes: ceph/ceph-cm-ansible#873 (repos back at `/rocky/10/`), a `trial_rocky_10` FOG image, and `os_version: "10"` in ceph's `qa/distros/all/rocky_10.yaml`.
