### PR TITLE
packaging: tolerate multiple Pulp distributions per label search

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -978,6 +978,41 @@ class TestPulpProject(TestBuilderProject):
         with pytest.raises(VersionNotFoundError):
             gp.version
 
+    def test_result_multiple_uses_newest(self, caplog):
+        # The same sha1 built under two branch names produces two
+        # distributions with matching labels; the newest one wins.
+        resp = Mock()
+        resp.ok = True
+        resp.json.return_value = {
+            'results': [
+                {
+                    'name': 'dist-older',
+                    'base_url': 'a/b/older/d',
+                    'pulp_created': '2026-08-14T08:04:53.409169Z',
+                    'pulp_labels': {'sha1': 'the_sha1', 'version': '0.90.0'},
+                },
+                {
+                    'name': 'dist-newer',
+                    'base_url': 'a/b/newer/d',
+                    'pulp_created': '2026-08-14T13:40:53.710313Z',
+                    'pulp_labels': {'sha1': 'the_sha1', 'version': '0.90.0'},
+                },
+            ],
+        }
+        self.m_get.return_value = resp
+        gp = self.klass('ceph', dict(os_type='ubuntu', os_version='24.04'))
+        assert gp._result['name'] == 'dist-newer'
+        assert 'Multiple results found' in caplog.text
+
+    def test_result_none_found(self):
+        resp = Mock()
+        resp.ok = True
+        resp.json.return_value = {'results': []}
+        self.m_get.return_value = resp
+        gp = self.klass('ceph', dict(os_type='ubuntu', os_version='24.04'))
+        with pytest.raises(VersionNotFoundError, match='No results found'):
+            gp._result
+
     def test_get_package_sha1_fetched_found(self):
         resp = Mock()
         resp.ok = True

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -1169,15 +1169,28 @@ class PulpProject(GitbuilderProject):
         """Get the results from the pulp api"""
         if getattr(self, '_result_obj', None) is None:
             # Get the results from the pulp api.
-            self._result_obj = self._search().get('results', [])
+            results = self._search().get('results', [])
 
-            # Check if there is exactly one result.
-            if not len(self._result_obj):
+            if not len(results):
                 log.error(f'No results found for {self._search_query}')
                 raise VersionNotFoundError(f'No results found for {self._search_query}')
-            elif len(self._result_obj) > 1:
-                log.error(f'Multiple results found for {self._search_query}')
-                raise VersionNotFoundError(f'Multiple results found for {self._search_query}')
+            elif len(results) > 1:
+                # A label search can legitimately match several
+                # distributions: the same sha1 may be built under more than
+                # one branch name, and rebuilding a branch at a new sha1
+                # leaves the older builds' distributions in place. Use the
+                # most recently created one.
+                results = sorted(
+                    results,
+                    key=lambda r: r.get('pulp_created', ''),
+                    reverse=True,
+                )
+                log.warning(
+                    'Multiple results found for %s; using newest: %s',
+                    self._search_query,
+                    results[0].get('name'),
+                )
+            self._result_obj = results
 
         return self._result_obj[0]
 

--- a/teuthology/packaging.py
+++ b/teuthology/packaging.py
@@ -1166,20 +1166,27 @@ class PulpProject(GitbuilderProject):
 
     @property
     def _result(self):
-        """Get the results from the pulp api"""
+        """
+        The Pulp distribution record for the build we are searching for.
+
+        A label search can legitimately match several distributions: the
+        same sha1 may be built under more than one branch name, and
+        rebuilding a branch at a new sha1 leaves the older builds'
+        distributions in place. When that happens, the most recently
+        created distribution is used.
+
+        :returns: a single distribution record (dict) as returned by the
+                  Pulp distributions API - the most recently created one
+                  if the label search matched more than one.
+        :raises: VersionNotFoundError if the search matched nothing.
+        """
         if getattr(self, '_result_obj', None) is None:
-            # Get the results from the pulp api.
             results = self._search().get('results', [])
 
             if not len(results):
                 log.error(f'No results found for {self._search_query}')
                 raise VersionNotFoundError(f'No results found for {self._search_query}')
             elif len(results) > 1:
-                # A label search can legitimately match several
-                # distributions: the same sha1 may be built under more than
-                # one branch name, and rebuilding a branch at a new sha1
-                # leaves the older builds' distributions in place. Use the
-                # most recently created one.
                 results = sorted(
                     results,
                     key=lambda r: r.get('pulp_created', ''),


### PR DESCRIPTION
## What

`PulpProject._result` raised `VersionNotFoundError` whenever a Pulp label search returned more than one distribution, failing jobs at install time:

```
teuthology.exceptions.VersionNotFoundError: Failed to fetch package version from Multiple results found for https://pulp.front.sepia.ceph.com/pulp/api/v3/distributions/deb/apt?pulp_label_select=project=ceph,flavors=default,distro=ubuntu,distro_version=24.04,arch=x86_64,sha1=4a522c91f889c2e5b1bad38855d034bc5d571949
```

(e.g. [this rgw job](https://qa-proxy.ceph.com/teuthology/nithyab-2026-08-20_04:28:32-rgw-wip-nbalacha-test-aug14-distro-default-smithi/495976/teuthology.log))

This PR sorts the matches by `pulp_created` and uses the newest one, logging a warning instead of raising.

## Why

Multiple matches are legitimate, not an error:

- The same sha1 can be built under more than one branch name. In the failing job above, commit `4a522c91` was built under both `wip-nbalacha-test-aug12` and `wip-nbalacha-test-aug14`, producing two distributions with identical labels and identical package content.
- Rebuilding a branch at a new sha1 leaves the older builds' distributions in place, since distribution names embed the sha1 so ceph-build's `pulp_upload.sh` cannot replace them.

This matches the long-standing `ShamanProject` behavior, which takes the newest search result and tolerates multiple builds of the same sha1 (see b0359bd1). Newest-wins is correct in both cases: for a sha1 search the contents are identical, and for a branch search it means "latest build of this branch."

## Notes for reviewers

- Shaman relies on the server returning results newest-first; the Pulp distributions endpoint has no guaranteed ordering, so this sorts client-side on `pulp_created`.
- Added `test_result_multiple_uses_newest` and `test_result_none_found`; all 185 tests in `tests/test_packaging.py` pass.