### PR TITLE
lock: add --no-reimage to lock machines as-is

### DIFF
--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -26,6 +26,7 @@ def parse_args(argv):
             teuthology-lock --summary
             teuthology-lock --lock-many 1 --machine-type vps
             teuthology-lock --lock -t target.yaml
+            teuthology-lock --lock --no-reimage smithi001
             teuthology-lock --list-targets plana01
             teuthology-lock --brief
             teuthology-lock --brief --owner user@host
@@ -107,6 +108,13 @@ def parse_args(argv):
         default=False,
         help="don't exit after the first error, continue locking or " +
         "unlocking other machines",
+    )
+    parser.add_argument(
+        '--no-reimage',
+        action='store_true',
+        default=False,
+        help="when locking reimageable machines, don't reimage them; only " +
+        "supported by --lock and --lock-many",
     )
     parser.add_argument(
         '--desc',

--- a/teuthology/lock/cli.py
+++ b/teuthology/lock/cli.py
@@ -70,6 +70,9 @@ def main(ctx):
     if ctx.num_to_lock:
         assert ctx.machine_type, \
             'must specify machine type to lock'
+    if ctx.no_reimage:
+        assert ctx.lock or ctx.num_to_lock, \
+            '--no-reimage is only supported by --lock and --lock-many'
 
     if ctx.brief or ctx.list or ctx.list_targets:
         assert ctx.desc is None, '--desc does nothing with --list/--brief'
@@ -172,7 +175,7 @@ def main(ctx):
                 if not ctx.f:
                     return ret
             elif not query.is_vm(machine, machine_status):
-                if machine_type in reimage_types:
+                if not ctx.no_reimage and machine_type in reimage_types:
                     # Reimage in parallel just below here
                     reimage_machines.append(machine)
                 # Update keys last
@@ -210,7 +213,8 @@ def main(ctx):
                 machines_to_update.append(machine)
     elif ctx.num_to_lock:
         result = ops.lock_many(ctx, ctx.num_to_lock, ctx.machine_type, user,
-                           ctx.desc, ctx.os_type, ctx.os_version, ctx.arch)
+                           ctx.desc, ctx.os_type, ctx.os_version, ctx.arch,
+                           reimage=not ctx.no_reimage)
         if not result:
             ret = 1
         else:

--- a/teuthology/lock/ops.py
+++ b/teuthology/lock/ops.py
@@ -102,11 +102,14 @@ def lock_many(ctx, num, machine_type, user=None, description=None,
             machine_type=machine_type,
             description=description,
         )
-        # Only query for os_type/os_version if non-vps and non-libcloud, since
-        # in that case we just create them.
+        # Only query for os_type/os_version if the machines are not going to
+        # be created or reimaged, since in that case we just install what was
+        # asked for.
         vm_types = downburst_types + teuthology.provision.cloud.get_types()
         reimage_types = teuthology.provision.get_reimage_types()
-        if machine_type not in (vm_types + reimage_types):
+        will_provision = machine_type in vm_types or \
+            (reimage and machine_type in reimage_types)
+        if not will_provision:
             if os_type:
                 data['os_type'] = os_type
             if os_version:


### PR DESCRIPTION
## What

Adds a `--no-reimage` flag to `teuthology-lock`, which locks bare-metal machines without reimaging them. Accepted with `--lock` and `--lock-many`; any other operation asserts.

## Why

`--lock` and `--lock-many` always reimage bare-metal nodes whose `machine_type` is in the configured reimage types. That is the right default for handing a node to a job, but it gets in the way when the point of locking is the node's *current* state: reproducing a failure on the image a job left behind, grabbing a node whose install is mid-debug, or reserving hardware without waiting on a reinstall.

## How

**`scripts/lock.py`** — new `--no-reimage` flag plus an example in the epilog.

**`teuthology/lock/cli.py`** — three edits:

- Assert the flag is only used with `--lock` / `--lock-many`.
- In the `--lock` loop, a bare-metal node joins `reimage_machines` only `if machine_type in reimage_types and not ctx.no_reimage`. With the flag set that list stays empty, so the parallel reimage never spawns and the surrounding `update_nodes(..., True)` / `update_nodes(...)` calls become no-ops — the node's OS and paddles inventory are left alone.
- `--lock-many` passes `reimage=not ctx.no_reimage` to `ops.lock_many()`, which already had that parameter.

**`teuthology/lock/ops.py`** — `lock_many()` previously dropped the `os_type` / `os_version` query filters for reimage types, on the assumption that reimaging would install whatever was requested. That assumption does not hold when `reimage=False`, so the filters are now gated on whether the node will actually be provisioned. This makes `--lock-many --no-reimage --os-type ubuntu` select a node *already running* Ubuntu instead of silently ignoring the filter.

## Notes for reviewers

**Covers all three provisioners.** The gate is on `machine_type in reimage_types`, and `get_reimage_types()` is the union of Pelagos, FOG, and MaaS types. `teuthology.provision.reimage()` is the single dispatch point for all three, so none of them is contacted when the flag is set.

**VMs are deliberately unaffected.** downburst/cloud types go through `create_if_vm` on a separate branch, which still runs. Skipping it would hand back a node that does not exist. If reviewers would rather the flag hard-error when pointed at a VM type instead of quietly creating the VM, that is a small follow-up.

**No doc changes.** `docs/commands/teuthology-lock.rst` is a `program-output:: teuthology-lock --help` directive, so the CLI reference picks up the new flag on the next Sphinx build — which is why the help string names the `--lock` / `--lock-many` constraint. The prose section in `docs/detailed_test_config.rst` never mentions that locking reimages at all; leaving that as-is was a deliberate call, not an oversight.

## Testing

The venv in my checkout does not have teuthology's dependencies installed (`gevent`, `yaml` missing), so I could not run the real suite. Instead I exercised `cli.main()` directly with the teuthology modules stubbed and `lock_one` / `reimage` / `lock_many` mocked:

| invocation | result |
| --- | --- |
| `--lock smithi001` | 1 lock, 1 reimage call |
| `--lock --no-reimage smithi001` | 1 lock, **0** reimage calls |
| `--lock-many 1 -m smithi` | `lock_many(..., reimage=True)` |
| `--lock-many 1 -m smithi --no-reimage` | `lock_many(..., reimage=False)` |
| `--unlock --no-reimage` | rejected by the assert |

pyflakes is clean on all three changed files. The existing `tests/scripts/test_lock.py` only checks that `--help` works, which the new argument does not disturb.