### PR TITLE
teuthology-lock: add --list-images

### DIFF
--- a/scripts/lock.py
+++ b/scripts/lock.py
@@ -31,6 +31,7 @@ def parse_args(argv):
             teuthology-lock --brief
             teuthology-lock --brief --owner user@host
             teuthology-lock --update --status down --desc testing plana01
+            teuthology-lock --list-images --machine-type trial
         '''),
         formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
@@ -91,6 +92,13 @@ def parse_args(argv):
         default=False,
         help='summarize locked-machine counts by owner',
     )
+    group.add_argument(
+        '--list-images',
+        action='store_true',
+        default=False,
+        help='list available image names for --machine-type',
+    )
+
     parser.add_argument(
         '-a', '--all',
         action='store_true',

--- a/tests/provision/test_fog.py
+++ b/tests/provision/test_fog.py
@@ -221,7 +221,8 @@ class TestFOG(object):
         with raises(RuntimeError):
             obj.get_image_data()
 
-    def test_suggest_image_names(self):
+    @mark.parametrize('mtype', [None, 'mira',])
+    def test_image_names(self, mtype):
         data = {'images': [
             {'name': 'mira_rhel_9.1'},
             {'name': 'mira_rhel_9.2'},
@@ -231,7 +232,7 @@ class TestFOG(object):
         self.mocks['m_Remote_machine_type'].return_value = 'mira'
         # Not sure what this klass() is for here:
         obj = self.klass('name.fqdn', 'mira', '1.0')
-        result = obj.suggest_image_names()
+        result = obj.image_names(mtype)
         assert len(self.mocks['m_requests_Session_send'].call_args_list) == 1
         req = self.mocks['m_requests_Session_send'].call_args_list[0][0][0]
         assert req.url == test_config['fog']['endpoint'] + '/image/search/mira'

--- a/teuthology/lock/cli.py
+++ b/teuthology/lock/cli.py
@@ -58,7 +58,7 @@ def main(ctx):
         else:
             # This condition might never be hit, but it's not clear.
             assert ctx.num_to_lock or ctx.list or ctx.list_targets or \
-                ctx.summary or ctx.brief, \
+                ctx.summary or ctx.brief or ctx.list_images, \
                 'machines must be specified for that operation'
     if ctx.all:
         assert ctx.list or ctx.list_targets or ctx.brief, \
@@ -251,6 +251,11 @@ def main(ctx):
         if ctx.desc is not None or ctx.status is not None:
             for machine in machines_to_update:
                 ops.update_lock(machine, ctx.desc, ctx.status)
+
+    elif ctx.list_images:
+        assert ctx.machine_type is not None, \
+            'you must specify a machine type for list_images'
+        ops.list_images(ctx.machine_type)
 
     return ret
 

--- a/teuthology/lock/ops.py
+++ b/teuthology/lock/ops.py
@@ -301,6 +301,17 @@ def update_lock(name, description=None, status=None, ssh_pub_key=None):
     return True
 
 
+def list_images(machine_type):
+    provobj = provision.get_provisioner_object(machine_type)
+    listfunc = getattr(provobj, 'image_names', None)
+    provname = type(provobj).__name__
+    if not listfunc:
+        print(f'Image listing not implemented for provider {provname}')
+        return
+    print(f'Images available on {provname} for {machine_type}:\n')
+    print('\n'.join(listfunc(machine_type)))
+
+
 def update_inventory(node_dict):
     """
     Like update_lock(), but takes a dict and doesn't try to do anything smart
@@ -332,6 +343,7 @@ def update_inventory(node_dict):
                 )
             if response.ok:
                 return
+
 
 def do_update_keys(machines, all_=False, _raise=True):
     reference = query.list_locks(keyed_by_name=True)

--- a/teuthology/provision/__init__.py
+++ b/teuthology/provision/__init__.py
@@ -24,10 +24,7 @@ def get_reimage_types():
     return pelagos.get_types() + fog.get_types() + maas.get_types()
 
 
-def reimage(ctx, machine_name, machine_type):
-    os_type = get_distro(ctx)
-    os_version = get_distro_version(ctx)
-
+def get_provisioner_object(machine_type, machine_name='', os_type='', os_version=''):
     pelagos_types = pelagos.get_types()
     fog_types = fog.get_types()
     maas_types = maas.get_types()
@@ -53,6 +50,14 @@ def reimage(ctx, machine_name, machine_type):
     else:
         raise Exception("The machine_type '%s' is not known to any "
                         "of configured provisioners" % machine_type)
+    return obj
+
+
+def reimage(ctx, machine_name, machine_type):
+    os_type = get_distro(ctx)
+    os_version = get_distro_version(ctx)
+
+    obj = get_provisioner_object(machine_type, machine_name, os_type, os_version)
     status = "fail"
     try:
         result = obj.create()

--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -175,7 +175,7 @@ class FOG(object):
             return image
         raise RuntimeError(
             "Fog has no %s image. Available %s images: %s" %
-            (name, self.remote.machine_type, self.suggest_image_names()))
+            (name, self.remote.machine_type, self.image_names(self.remote.machine_type)))
 
     def _latest_minor_image(self, base_name):
         """
@@ -205,13 +205,14 @@ class FOG(object):
             )
         return best
 
-    def suggest_image_names(self):
+    def image_names(self, machine_type=None):
         """
-        Suggest available image names for this machine type.
+        Return available image names for this machine type.
 
         :returns: A list of image names.
         """
-        resp = self.do_request('/image/search/%s' % self.remote.machine_type)
+        mt = machine_type or self.remote.machine_type
+        resp = self.do_request('/image/search/%s' % mt)
         obj = resp.json()
         images = obj['images']
         return [image['name'] for image in images]


### PR DESCRIPTION
currently only implemented for Fog, but: allow querying reimage server for images known for a machine type.