### PR TITLE
provision/fog: recover from a stale known_hosts entry after reimage

### DIFF
--- a/tests/orchestra/test_connection.py
+++ b/tests/orchestra/test_connection.py
@@ -1,4 +1,7 @@
+import paramiko
+
 from mock import patch, Mock
+from pytest import raises
 
 from teuthology import config
 from teuthology.orchestra import connection
@@ -87,6 +90,19 @@ class TestConnection(object):
         )
         m_transport.set_keepalive.assert_called_once_with(False)
         assert got is m_ssh_instance
+
+    def test_connect_bad_host_key_not_retried(self):
+        self.clear_config()
+        m_ssh_instance = self.m_ssh.return_value = Mock()
+        m_ssh_instance.connect.side_effect = paramiko.BadHostKeyException(
+            'orchestra.test.newdream.net.invalid', Mock(), Mock())
+        with raises(paramiko.BadHostKeyException):
+            connection.connect(
+                'jdoe@orchestra.test.newdream.net.invalid',
+                _SSHClient=self.m_ssh,
+            )
+        # a mismatched host key is not transient; no point retrying
+        m_ssh_instance.connect.assert_called_once()
 
     def test_connect_override_hostkeys(self):
         self.clear_config()

--- a/tests/provision/test_fog.py
+++ b/tests/provision/test_fog.py
@@ -1,7 +1,8 @@
 import datetime
 
 from copy import deepcopy
-from mock import patch, DEFAULT, PropertyMock
+from mock import patch, DEFAULT, Mock, PropertyMock
+from paramiko.ssh_exception import BadHostKeyException
 from pytest import raises, mark
 
 from teuthology.config import config
@@ -363,6 +364,21 @@ class TestFOG(object):
             return
         obj._wait_for_ready()
         assert len(self.mocks['m_Remote_connect'].call_args_list) == tries + 1
+
+    def test_wait_for_ready_stale_host_key(self):
+        # A freshly-imaged node has a new host key.  If ~/.ssh/known_hosts
+        # still holds the old one, the stale entry must be dropped and the
+        # connection retried instead of failing until the timeout.
+        self.mocks['m_Remote_hostname'].return_value = 'name.fqdn'
+        obj = self.klass('name.fqdn', 'type', '1.0')
+        self.mocks['m_Remote_connect'].side_effect = [
+            BadHostKeyException('name.fqdn', Mock(), Mock()),
+            True,
+        ]
+        with patch('teuthology.provision.fog.misc.ssh_keygen_remove') as m_rm:
+            obj._wait_for_ready()
+        m_rm.assert_called_once_with('name.fqdn')
+        assert len(self.mocks['m_Remote_connect'].call_args_list) == 2
 
     @mark.parametrize(
         'sentinel_present',

--- a/teuthology/misc.py
+++ b/teuthology/misc.py
@@ -1101,6 +1101,23 @@ def ssh_keyscan_wait(hostname):
             log.info("try ssh_keyscan again for " + str(hostname))
         return success
 
+
+def ssh_keygen_remove(hostname):
+    """
+    Remove any entries for a host from the user's ~/.ssh/known_hosts
+    (``ssh-keygen -R``).
+
+    :param hostname: The hostname
+    :returns: True if the command succeeded
+    """
+    args = ['ssh-keygen', '-R', hostname]
+    p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if p.returncode != 0:
+        log.warning("%s failed: %s", ' '.join(args),
+                    p.stdout.decode().strip())
+    return p.returncode == 0
+
+
 def stop_daemons_of_type(ctx, type_, cluster='ceph', timeout=300):
     """
     :param type_: type of daemons to be stopped.

--- a/teuthology/orchestra/connection.py
+++ b/teuthology/orchestra/connection.py
@@ -114,6 +114,13 @@ def connect(user_at_host, host_key=None, keep_alive=False, timeout=60,
                     log.error(f"{auth_err_msg}: EOFError")
                 except paramiko.AuthenticationException as e:
                     log.error(f"{auth_err_msg}: {repr(e)}")
+                except paramiko.BadHostKeyException as e:
+                    # Not transient: the server's key will not change while
+                    # we retry.  Raise so the caller can decide what to do
+                    # (e.g. the FOG provisioner, which expects a new key
+                    # after a reimage).
+                    log.error(f"{auth_err_msg}: {repr(e)}")
+                    raise
                 except paramiko.SSHException as e:
                     auth_err_msg = f"{auth_err_msg}: {repr(e)}"
                     if not key_filename:

--- a/teuthology/provision/fog.py
+++ b/teuthology/provision/fog.py
@@ -6,7 +6,10 @@ import socket
 import re
 
 from paramiko import SSHException
-from paramiko.ssh_exception import NoValidConnectionsError
+from paramiko.ssh_exception import (
+    BadHostKeyException,
+    NoValidConnectionsError,
+)
 
 import teuthology.orchestra
 
@@ -348,6 +351,14 @@ class FOG(object):
                 try:
                     self.remote.connect()
                     break
+                except BadHostKeyException as e:
+                    # The node was just reimaged, so its host key is new by
+                    # definition.  A stale entry in ~/.ssh/known_hosts would
+                    # otherwise keep us failing here until the timeout.
+                    self.log.warning(
+                        f"{e}; removing stale known_hosts entry for {self.name}"
+                    )
+                    misc.ssh_keygen_remove(self.name)
                 except (
                     socket.error,
                     SSHException,


### PR DESCRIPTION
A freshly-imaged node has new ssh host keys. If the node's old key is still in `~/.ssh/known_hosts` (left behind by an earlier ansible/ssh session run as the same user), paramiko raises `BadHostKeyException` on every connect after the reimage. Today that is handled badly:

- `connection.connect()` retries it like a transient error until `safe_while` gives up (~145 s),
- `FOG._wait_for_ready()` catches the resulting `MaxWhileTries` and loops, power-cycling the node at 50% of `fog_wait_for_ssh_timeout`,
- `teuthology-lock --lock --os-type/--os-version` sits there for hours.

Seen in Sepia on 2026-09-05: `teuthology-lock` runs as `jenkins-build` on soko04 hung ~2 h on trial002/trial065 (and would have on trial150) because that account's known_hosts had entries for 17 trial nodes recorded by earlier `sepia-fog-images` runs. The code comment in `_wait_for_ready` even predicted this case.

Changes:
- `connection.connect()`: `BadHostKeyException` is not retried; it is logged and raised so the caller can decide.
- `FOG._wait_for_ready()`: on `BadHostKeyException`, remove the stale entry with `ssh-keygen -R` (new `misc.ssh_keygen_remove()`) and try again. The node was just reimaged, so a key change is expected.
- Unit tests for both.

Companion change in ceph-build (`sepia-fog-images`, ceph/ceph-build#2705): the job's `phase_prepare` now sets `UserKnownHostsFile /dev/null` for `*.front.sepia.ceph.com` so the agent account stops recording testnode keys in the first place.
